### PR TITLE
Fixes New Hampshire Supreme Court

### DIFF
--- a/opinions/united_states/state/nh.py
+++ b/opinions/united_states/state/nh.py
@@ -6,6 +6,7 @@
 #History:
 # - 2014-06-27: Created
 # - 2014-10-17: Updated by mlr to fix regex error.
+# - 2015-06-04: Updated by bwc so regex catches comma, period, or whitespaces as separator
 
 import re
 import time
@@ -20,7 +21,7 @@ class Site(OpinionSite):
         self.url = 'http://www.courts.state.nh.us/supreme/opinions/{current_year}/index.htm'.format(
             current_year=date.today().year)
         self.court_id = self.__module__
-        self.case_name_regex = re.compile('(\d{4}-\d+(?!.*\d{4}-\d+)),? (.*)')
+        self.case_name_regex = re.compile('(\d{4}-\d+(?!.*\d{4}-\d+))(,|\.|\s?) (.*)')
 
     def _get_case_names(self):
         path = "id('content')/div//ul//li//a[position()=1]/text()"
@@ -29,7 +30,7 @@ class Site(OpinionSite):
             # Uses a negative look ahead to make sure to get the last
             # occurrence of a docket number.
             match_case_name = self.case_name_regex.search(text)
-            case_names.extend([match_case_name.group(2)])
+            case_names.extend([match_case_name.group(3)])
         return case_names
 
     def _get_download_urls(self):
@@ -62,6 +63,6 @@ class Site(OpinionSite):
         path = "id('content')/div//ul//li//a[position()=1]/text()"
         docket_numbers = []
         for text in self.html.xpath(path):
-            match_docket_nr = re.search('(.*\d{4}-\d+),? (.*)', text)
+            match_docket_nr = re.search('(.*\d{4}-\d+)(,|\.|\s?) (.*)', text)
             docket_numbers.append(match_docket_nr.group(1))
         return docket_numbers

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -530,7 +530,7 @@ class ScraperSpotTest(unittest.TestCase):
         regex = nh.Site().case_name_regex
         for test, result in string_pairs:
             try:
-                case_name = regex.search(test).group(2).strip()
+                case_name = regex.search(test).group(3).strip()
                 self.assertEqual(
                     case_name,
                     result,


### PR DESCRIPTION
regex was only looking for comma as separator and they decided to use a period for one line. New regex can handle a comma, period, or any number of whitespaces. tests.py was also updated to reflect this. sample_caller succeeds.