### PR TITLE
Fixes Florida 3rd District Court of Appeal scraper

### DIFF
--- a/opinions/united_states/state/fladistctapp_3.py
+++ b/opinions/united_states/state/fladistctapp_3.py
@@ -65,7 +65,7 @@ class Site(OpinionSite):
         return case_names
 
     def _return_case_names(self, html_tree):
-        path = "{base}/td[2]//text()".format(base=self.base_path)
+        path = "{base}/td[2]//text()[1]".format(base=self.base_path)
         return [titlecase(s.lower()) for s in html_tree.xpath(path)]
 
     def _get_download_urls(self):


### PR DESCRIPTION
An attempt to fix scraping of case names on this page

http://www.3dca.flcourts.org/Opinions/Opinions2015-07-22.shtml

where the case name is followed by some comment like this:

    <td> <p> case name <br> comment </p> </td>
