### PR TITLE
Fixing broken scotus scrapers

### DIFF
--- a/lib/string_utils.py
+++ b/lib/string_utils.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import re
 import geonamescache
+from dateutil import parser
 
 # For use in titlecase
 BIG = ('3D|AFL|AKA|A/K/A|BMG|CBS|CDC|CDT|CEO|CIO|CNMI|D/B/A|DOJ|DVA|EFF|FCC|'
@@ -430,6 +431,10 @@ def trunc(s, length, ellipsis=None):
         if ellipsis:
             s = u'%s%s' % (s, ellipsis)
         return s
+
+def convert_date_string(date_string):
+    """Convert date string into standard date object"""
+    return parser.parse(date_string).date()
 
 
 class CaseNameTweaker(object):

--- a/opinions/united_states/federal_appellate/scotus_chambers.py
+++ b/opinions/united_states/federal_appellate/scotus_chambers.py
@@ -1,12 +1,14 @@
-from datetime import date
-import time
-
-from lxml import html
-
 import scotus_slip
 
 
 class Site(scotus_slip.Site):
+    CELLS = {
+        'date': 1,
+        'docket': 2,
+        'name': 3,
+        'revision': 4,
+    }
+
     # Note that scotus_relating inherits from this class.
     def __init__(self, *args, **kwargs):
         super(Site, self).__init__(*args, **kwargs)
@@ -14,26 +16,6 @@ class Site(scotus_slip.Site):
         self.back_scrape_url = 'http://www.supremecourt.gov/opinions/in-chambers/{}'
         self.back_scrape_iterable = range(5, 16)
         self.court_id = self.__module__
-
-    def _get_case_dates(self):
-        path = '//div[@id = "mainbody"]//table//tr/td[1]/text()'
-        case_dates = []
-        for date_string in self.html.xpath(path):
-            try:
-                case_date = date.fromtimestamp(time.mktime(time.strptime(date_string, '%m/%d/%y')))
-            except ValueError:
-                case_date = date.fromtimestamp(time.mktime(time.strptime(date_string, '%m-%d-%y')))
-            case_dates.append(case_date)
-        return case_dates
-
-    def _get_docket_numbers(self):
-        docket_numbers = []
-        for e in self.html.xpath('//div[@id = "mainbody"]//table//tr/td[2]'):
-            s = html.tostring(e, method='text', encoding='unicode').strip()
-            if s:
-                docket_numbers.append(s)
-
-        return docket_numbers
 
     def _get_precedential_statuses(self):
         return ['In-chambers'] * len(self.case_names)

--- a/opinions/united_states/federal_appellate/scotus_relating.py
+++ b/opinions/united_states/federal_appellate/scotus_relating.py
@@ -10,6 +10,3 @@ class Site(scotus_chambers.Site):
 
     def _get_precedential_statuses(self):
         return ['Relating-to'] * len(self.case_names)
-
-    def _get_summaries(self):
-        return None

--- a/opinions/united_states/federal_appellate/scotus_slip.py
+++ b/opinions/united_states/federal_appellate/scotus_slip.py
@@ -1,12 +1,18 @@
-import time
-from datetime import date
-
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.string_utils import titlecase
 from juriscraper.AbstractSite import logger
+from juriscraper.lib.string_utils import convert_date_string
 
 
 class Site(OpinionSite):
+    CELLS = {
+        'date': 2,
+        'docket': 3,
+        'name': 4,
+        'revision': 5,
+    }
+    BASE_TABLE_ROW_PATH = '//div[@id = "mainbody"]//table//tr'
+
     def __init__(self, *args, **kwargs):
         super(Site, self).__init__(*args, **kwargs)
         self.url = 'http://www.supremecourt.gov/opinions/slipopinions.aspx'
@@ -15,34 +21,37 @@ class Site(OpinionSite):
         self.back_scrape_iterable = range(6, 16)
 
     def _get_case_names(self):
-        return [titlecase(text) for text in
-                self.html.xpath('//div[@id = "mainbody"]//table//tr/td/a/text()')]
+        cell_sub_path = 'td[%d]/a/text()' % self.CELLS['name']
+        case_names_path = '%s/%s' % (self.BASE_TABLE_ROW_PATH, cell_sub_path)
+        case_names = [titlecase(case_name) for case_name in self.html.xpath(case_names_path)]
+
+        # Append case name for revised opinion records
+        for row in self._get_table_rows():
+            if self._row_has_revision(row):
+                case_names.append(titlecase(row.xpath(cell_sub_path)[0]))
+
+        return case_names
 
     def _get_download_urls(self):
-        path = '//div[@id = "mainbody"]//table//tr/td/a[text()]/@href'
-        return [e for e in self.html.xpath(path)]
+        return self._get_opinion_urls() + self._get_revision_urls()
 
     def _get_case_dates(self):
-        path = '//div[@id = "mainbody"]//table//tr/td[2]/text()'
-        case_dates = []
-        for date_string in self.html.xpath(path):
-            try:
-                case_date = date.fromtimestamp(time.mktime(time.strptime(date_string, '%m/%d/%y')))
-            except ValueError:
-                case_date = date.fromtimestamp(time.mktime(time.strptime(date_string, '%m-%d-%y')))
-            case_dates.append(case_date)
-        return case_dates
+        return self._get_opinion_dates() + self._get_revision_dates()
 
     def _get_docket_numbers(self):
-        path = '//div[@id = "mainbody"]//table//tr/td[3]/text()'
-        return [docket_number for docket_number in self.html.xpath(path)]
+        cell_sub_path = 'td[%d]/text()' % self.CELLS['docket']
+        dockets_path = '%s/%s' % (self.BASE_TABLE_ROW_PATH, cell_sub_path)
+        docket_numbers = [docket_number for docket_number in self.html.xpath(dockets_path)]
+
+        # Append docket number for revised opinion records
+        for row in self._get_table_rows():
+            if self._row_has_revision(row):
+                docket_numbers.append(row.xpath(cell_sub_path)[0])
+
+        return docket_numbers
 
     def _get_precedential_statuses(self):
         return ['Published'] * len(self.case_names)
-
-    def _get_summaries(self):
-        path = '//div[@id = "mainbody"]//table//tr//td/a/text()'
-        return [summary for summary in self.html.xpath(path)]
 
     def _download_backwards(self, d):
         logger.info("Running backscraper for year: 20{}".format(d))
@@ -52,3 +61,29 @@ class Site(OpinionSite):
             # Setting status is important because it prevents the download
             # function from being run a second time by the parse method.
             self.status = 200
+
+    def _get_opinion_dates(self):
+        return self._get_dates_from_path('%s/td[%d]/text()' % (self.BASE_TABLE_ROW_PATH, self.CELLS['date']))
+
+    def _get_revision_dates(self):
+        return self._get_dates_from_path('%s/td[%d]/a/text()' % (self.BASE_TABLE_ROW_PATH, self.CELLS['revision']))
+
+    def _get_dates_from_path(self, path):
+        return [convert_date_string(date_string) for date_string in self.html.xpath(path)]
+
+    def _get_opinion_urls(self):
+        return self._get_url_from_cell_index(self.CELLS['name'])
+
+    def _get_revision_urls(self):
+        return self._get_url_from_cell_index(self.CELLS['revision'])
+
+    def _get_url_from_cell_index(self, cell):
+        path = '%s/td[%d]/a/@href' % (self.BASE_TABLE_ROW_PATH, cell)
+        return [url for url in self.html.xpath(path)]
+
+    def _row_has_revision(self, row):
+        revision = row.xpath('td[%d]/a' % self.CELLS['revision'])
+        return True if revision else False
+
+    def _get_table_rows(self):
+        return [row for row in self.html.xpath(self.BASE_TABLE_ROW_PATH) if len(row.xpath('td')) > 0]

--- a/tests/examples/opinions/united_states/scotus_chambers_example.html
+++ b/tests/examples/opinions/united_states/scotus_chambers_example.html
@@ -1,923 +1,417 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
-        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+
+<!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head><title>
-    2013 Term In-Chambers Opinions
-</title>
-    <meta http-equiv="content-type" content="txt/html; charset=utf-8"/>
-    <meta http-equiv="X-UA-Compatible" content="IE=EmulateIE9"/>
-    <meta name="viewport" content="width=device-width, initial-scale=0.7"/>
-    <meta name="author" content="Supreme Court of the United States"/>
-    <meta name="description"
-          content="supremecourt.gov is the official web site for the Supreme Court of the United States."/>
-    <meta http-equiv="content-language" content="en"/>
-    <link rel='stylesheet' href='/styles/jquery.ui.base.css'/>
-    <link rel='stylesheet' href='/styles/jquery.ui.theme.css'/>
-    <script src="/script/jquery.js"></script>
-    <script src="/script/ui/jquery.ui.core.js"></script>
-    <script src="/script/ui/jquery.ui.widget.js"></script>
-    <script src="/script/ui/jquery.ui.accordion.js"></script>
-
-    <script type='text/javascript'>
-        $(document).ready(function () {
-            $('#middleCol2 #leftcolumn #leftmenu2').accordion({
-                collapsible: true,
-                autoHeight: false, active: 2
-            });
-        });
-    </script>
+<head><meta http-equiv="X-UA-Compatible" content="IE=edge" /><meta http-equiv="content-type" content="txt/html; charset=utf-8" /><meta name="viewport" content="width=device-width, initial-scale=0.7" />
+        <script type="text/javascript" src="/engine1/jquery-1.11.0.js"></script>
+	    <script type="text/javascript" src="/js/bootstrap.js"></script>
+	    <link rel="Stylesheet" type="text/css" href="/css/bootstrap.min.css" />
+	    <link rel="Stylesheet" type="text/css" href="/css/bootstrap-theme.min.css" />
+	    <link rel="Stylesheet" type="text/css" href="/styles/supremecourt_style2.css" title="default" />
+	    <link rel="stylesheet" type="text/css" href="/styles/newBootStrap.css" />
 
 
-    <meta name="title" content="2005 Term In-Chambers Opinions"/>
-    <meta name="created" content='9/30/2010 10:36:01 AM'/>
-    <meta name="revised" content='6/1/2012 7:22:30 AM'/>
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+
+        <!--[if lt IE 9]>
+          <script src="/js/html5shiv.js"></script>
+          <script src="/js/respond.min.js"></script>
+        <![endif]-->
+
+        <!--[if lt IE 8]>
+          <link rel="stylesheet" type="text/css" href="css/bootstrap-ie7.css">
+        <![endif]-->
+
+
+
+    <meta name="title" content="2005 Term In-Chambers Opinions" />
+    <meta name="created" content='12/31/1600 7:00:00 PM' />
+    <meta name="revised" content='12/31/1600 7:00:00 PM' />
     <meta name="keywords" content="Supreme Court of the United States, Supreme Court, Supreme Court of US, Supremecourt,
-    United State Supreme Court, US Supreme Court, U.S. Supreme Court, Court, Opinions, In-Chambers Opinions, 2005 Term"/>
-
-    <link rel="Alternate" type="application/atom+xml" title="Supreme Court of United States Slip Opinions"
-          href="../rss/slipopinion_rss.aspx"/>
-    <link rel="Alternate" type="application/atom+xml" title="Supreme Court of United States Argument Audio"
-          href="../rss/argument_audio_rss.aspx"/>
-    <link rel="Alternate" type="application/atom+xml" title="Supreme Court of United States Argument Transcripts"
-          href="../rss/argument_transcripts_rss.aspx"/>
-    <link rel="Alternate" type="application/atom+xml" title="Supreme Court of United States Hermes Transfer List"
-          href="../rss/hermes_transfer.xml"/>
-    <link rel="Stylesheet" type="text/css" href="../styles/supremecourt_style.css" title="default"/>
-    <!--[if lte IE 9]>
-    <script language="javascript" src="/script/html5.js"></script>
-    <link rel="Stylesheet" type="text/css" href="/styles/ie.css"/>
-    <link rel="Stylesheet" type="text/css" href="/styles/mainmenu.css"/>
-    <![endif]-->
-    <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon"/>
-    <link rel="icon" href="../favicon.ico" type="image/x-icon"/>
-    <script language="javascript" type="text/javascript">
-        function PrintThisPage() {
-            var sOption = "toolbar=yes,location=no,directories=yes,menubar=yes,scrollbars=yes,width=800,height=600,left=100,top=25";
-            var sWinHTML = document.getElementById('maincontentbox').innerHTML;
-
-            var winprint = window.open("", "", sOption);
-            winprint.document.open();
-            winprint.document.write('<html><link type=text/css rel=Stylesheet href=/styles/supremecourt_style_pr.css><body>');
-            winprint.document.write('<div style=\'margin: 10px;\'>');
-            winprint.document.write('<table border=0 cellpadding=5 cellspacing=5 width=100%><tr><td align=left><img src=/images/supremecourt_seal_pr.gif /></td></tr></table>');
-            winprint.document.write(sWinHTML)
-            winprint.document.write('</div></body></html>');
-            winprint.document.close();
-            winprint.focus();
+    United State Supreme Court, US Supreme Court, U.S. Supreme Court, Court, Opinions, In-Chambers Opinions, 2005 Term" />
+    <style type="text/css">
+        .well-lg {
+            background-image: none;
         }
-    </script>
-</head>
+    </style>
+
+<title>
+	2015 Term In-Chambers Opinions
+</title></head>
 <body>
-<form name="aspnetForm" method="post" action="in-chambers.aspx" onsubmit="javascript:return WebForm_OnSubmit();"
-      onkeypress="javascript:return WebForm_FireDefaultButton(event, 'ctl00_ctl00_cmdSearch')" id="aspnetForm">
-<div>
-    <input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value=""/>
-    <input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value=""/>
-    <input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE"
-           value="3NcR8YxZNkD9aM7zo2VDeJgvv+8zvA2aOlOhDC2QgkQ9yXn9omwXZJ/CVYrcskrzBT+kGH5aUPmKSuYTPPTq4qLi9IwmdVfWL4QLuTs4AyfZDgZBvQhrk499OkzG+NYCRjRntPi6niInZZG2AdWVlHLUOX5r1kXKfSD6y/11VwwyumoDIjZPHK28EhkzYMsobcfN534fb9N4jb0sbyFk2ciP6xsci5DrClQooUxjemZ3wvWcTAqAY45VvfEa9bfZ+JafN2gpJaHYAKkE+7HJf+Cv/Sx82NcipsH+EqjpXdmwO71aNMwK0MCx3iESqEdXzx6IXxxo6YMdS9mrXASFVkSf5PjegCzhhdpWa46qFj8aYx4gYwky6I/r3KUW9tAM5oXTGhmxR+rv7Lup9WFWr+oDsSbihspvKbdT0RCGLSykYrLGxhMT6WsQNDkBTJSBYI9kgG87Bnvwqu3duoYBUhlQxbrVvFh6ke0R3CrHDRgOlRKuLalwWYulGHT9kZnFXJbl7fAbAPFHapa2WKKHVVz0vUXxq78z5mE/uilTYgL6596wrWYHUaAL81xoB4SgULAFo6hpx/9g1Mcv4R+Eihna8SFrZLbuWfzhBMChNvMnhRCob+Bgr0MG/+JGokf25+WNzcLpf7up5rR+Q3ZZhmQ3filzwNwj+AcYlMcWLAxt7JaLo7zrtPrZM0fgL4unP7VSnBi2g417tRNwvmrCz/kBg8zS5IiiINqomp5LrsgK6XII9NawWQWFEAM2na/Pws5L0lF+yh7YHPWqyDp8fW+KyLawArerEGZkisOefRoJry18EESu3fTl4OZojDhbdW03S3BXl0zoAVY7n4YRCxwNwuIEWv4n+Ako1yzg1NTqDCyWu4ccBnzWlt4YjbJTAaAGOuwfThGIWtNDLx8yHjR2adzw99T9OKTFTqEeGz3A0ceui59FbSPnPmZIglZ1vy7RFFDlxLb4RxKjsVgtQpVr2nbSZVwbn++zOFf9Cr1DQUiTrgdWwW5NNzhk7p7IoYEdtn8GWwBbBrKRuljHnA6Lq7TGwLMI9Nt2jEcpY8KUuAYTxOpJgwfuTqknaPHJFUFVwdiTc4t0cqpoQ1BJdG65j7m+yMGA1oF965At5kZ71UEizCrMh52kaFAIGZnXzD18BTcjdHjHY3MKBbIRZkB6ZJ4="/>
+<form method="post" action="./15" onsubmit="javascript:return WebForm_OnSubmit();" id="aspnetForm" class="form-horizontal">
+<div class="aspNetHidden">
+<input type="hidden" name="ctl00_ctl00_RadScriptManager1_TSM" id="ctl00_ctl00_RadScriptManager1_TSM" value="" />
+<input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
+<input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKLTUyNTYxMDM4OGQYAQUeX19Db250cm9sc1JlcXVpcmVQb3N0QmFja0tleV9fFgMFEmN0bDAwJGN0bDAwJHJkb1NDRAUVY3RsMDAkY3RsMDAkcmRvRG9ja2V0BRVjdGwwMCRjdGwwMCRyZG9Eb2NrZXROszeS6AEx7si7/ZvEZNBkTHFRLQ2TQRJT/hyOLPyDuQ==" />
 </div>
 
 <script type="text/javascript">
-    //<![CDATA[
-    var theForm = document.forms['aspnetForm'];
-    if (!theForm) {
-        theForm = document.aspnetForm;
+//<![CDATA[
+var theForm = document.forms['aspnetForm'];
+if (!theForm) {
+    theForm = document.aspnetForm;
+}
+function __doPostBack(eventTarget, eventArgument) {
+    if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
+        theForm.__EVENTTARGET.value = eventTarget;
+        theForm.__EVENTARGUMENT.value = eventArgument;
+        theForm.submit();
     }
-    function __doPostBack(eventTarget, eventArgument) {
-        if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
-            theForm.__EVENTTARGET.value = eventTarget;
-            theForm.__EVENTARGUMENT.value = eventArgument;
-            theForm.submit();
-        }
-    }
-    //]]>
+}
+//]]>
 </script>
 
 
-<script src="/WebResource.axd?d=rCyPEAmf29aK8BeFRIEhbXldpW7f-asSrfmAnr28XnQjOTQwUjmGvIHJCJJm4v7IJZkG4ax3TsVfNP3Zfj1Xy2r1tfA1&amp;t=635284882248476408"
-        type="text/javascript"></script>
+<script src="/WebResource.axd?d=ZseFxRmodsjlJy9k0UdiXxfb7wQAfWNAtk-hWKsIVwqttbSJWpLjYBJmam7CfEZLJLf7sKFty6JfANmeDb1yOD4h9KMbXr56yCcCUvQ6KBI1&amp;t=635802997220000000" type="text/javascript"></script>
 
 
-<script src="/ScriptResource.axd?d=mj2dFicu5g65fMBa8AJDXUtDMHYVnxq3amfRp6jYM8JyIGCswNaJPhOpobKdZRwSb9w7Y6a5sGP3yHxprm7YZjRk2JYFIyum_b3d30kwDOUfuytrvwakamehBT7QZ7FzfNq0x3QqLKaSE5zf8WotF5nDR5k1&amp;t=14aef61"
-        type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=xEdKPjj3pDPKNfnZguzNH_04EyP2FCYqDDKgnfLCAkZYTziAJbfWr3_Ej_IPRYypdiIfvpQhHQ7F9p86HJHd0nIW6CD_DzYTHX16ei5_joydAqS-txNMDaM-ury3ac_U_sdiD-sca4X1I5iwJpVUuzGBlaw-21Zg2xePQC0qTsgR3YT30&amp;t=ffffffffef159b14"
-        type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=-1iQ2WcP2s9NWfKKUi9b6m1_4OYBd4w31KIprGEVFv_RHcxIF1RUeZK2lKoVvvOGMv5MiSynUBzh_MhoFIGA6bGC74mX1V8R3e7DXITahbg0Ghdvaf393nk5CzWUokUychNb-HiEAJOfHvIaJ4Zb5GYa5VCIcEKhzD9x5_MCB6r6_zMP0&amp;t=ffffffffef159b14"
-        type="text/javascript"></script>
-<script src="/WebResource.axd?d=bx8Y0YOs1kS7XLiLwKdln58vZzO1KZjuzg66fdi-49BbSUjUbJEunNAKfaT6TMdZgTLs2yhcRZwXP9vQSRETylSd6D81&amp;t=635284882248476408"
-        type="text/javascript"></script>
+<script src="/ScriptResource.axd?d=GlhBca8eluQuJwqE2XKg6d4gdr42Z3rGGJuxOr40y55kuSdjyPrun1QMAZ5MBmhwt68k5oPj2gaBSJdhSejVKL5D85WFVoA7HVMCCmhmdUjqXt0MtN5RCVVbtYH_2Lx6qcznaTHfEYkMVrwhzdpRKDZQAt7pOLumM2hobVElu9g1&amp;t=62fc1f78" type="text/javascript"></script>
+<script src="/ScriptResource.axd?d=_BWakfwwT2jhiTrQjTSYbO3M095QPfg77rLRHl9L_B4HueCpSl8U5nj8FVs3ia15GiSxQlmNNCEwqYB0FRnrFYnL_u2XqwJZZNFUYhhG38ndESmRRmv8cdx08yEeGwStqJT4E36-FqPmtjH0zkJQ1Q3nxB4kKb4D8LiQLUqknzY1&amp;t=5f9d5645" type="text/javascript"></script>
+<script src="/ScriptResource.axd?d=WH-Abrkv_pMIZUCxOmJ4Iv0soXt_Zwippp1KntwLPhKFk07tEKkubgqJZYngPss18zBcZgMWhpaYNP4MFaQg-mY0BEaYyFuDqd9OmcQzdjdYkUfEA841SJZ1owkEzNjI8blk-djzH4OgYYtbaC6je4BOF8zzF0RdtAgiw0YKHhoQDsx9YLSK20gDsTuQ3BR60&amp;t=5f9d5645" type="text/javascript"></script>
 <script type="text/javascript">
-    //<![CDATA[
-    function WebForm_OnSubmit() {
-        if (typeof(ValidatorOnSubmit) == "function" && ValidatorOnSubmit() == false) return false;
-        return true;
-    }
-    //]]>
+//<![CDATA[
+function WebForm_OnSubmit() {
+if (typeof(ValidatorOnSubmit) == "function" && ValidatorOnSubmit() == false) return false;
+return true;
+}
+//]]>
 </script>
 
-<div>
+<div class="aspNetHidden">
 
-    <input type="hidden" name="__VIEWSTATEENCRYPTED" id="__VIEWSTATEENCRYPTED" value=""/>
-    <input type="hidden" name="__PREVIOUSPAGE" id="__PREVIOUSPAGE"
-           value="Um2MsBLO0Qp6OubKok2E7HRobUMjMxLZAfQi4mfjnjOsOVTdtOL1SXUeX8RqaJJC9WvEkRMjjdFtEplN33UD7CFMVOq5gRky3o8-itGmhw11MTPe0"/>
-    <input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION"
-           value="r3zgb4DGogo0rredea83dAfkcOAbgRrdv04XsFtn1W8f/hdOsy39NYGEpQfg1Q6JIycSHOvVgaH9eRvQMB5jEIlbd95jRcP9KZyEgNk6BxGWUqAvOWzRP3EIUP9VkP5tVP2Qd8/uSBAexx0Xz4cC2BJEX13+doiEtpo9iIF3kkXTdYnE"/>
+	<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="28AB6F64" />
+	<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEdAAip780WT1dtYL3NvhalCSUedcLA2cVr55mmAI/xV+qwRAMiFNqFT7E2zKelBoXU3xbDDU+RV/jOi+vSugvNJrSXAeQgnDYEcS/A3pq4nSD4D0Ddcr9W1vG3+GTAwlOJUM51PENixjB8uIhh9HSYVMY81TqJGMO3GEtAB5QnaLsNtA0ucWYe0eRk9OdsBRyBo/8YEhGkPvNEJlD7lR+8pchr" />
 </div>
+    <div class="noindex">
+	    <script type="text/javascript">
+//<![CDATA[
+Sys.WebForms.PageRequestManager._initialize('ctl00$ctl00$RadScriptManager1', 'aspnetForm', [], [], [], 90, 'ctl00$ctl00');
+//]]>
+</script>
+
+    </div>
+	<div class="container well well-lg">
+            <div class="noindex">
+			    <div class="row bannerStyle">
+				    <div class="col-md-6 col-xs-12">
+                         <a id="ctl00_ctl00_hypSealLink" href="../../"><img id="ctl00_ctl00_imgSeal" class="SCUSSeal" src="../../images/banner_h120.jpg" alt="Supreme Court of the United States" /></a>
+				    </div>
+				    <div class="col-md-6 col-xs-12" style="font-size: 9pt;">
+					    <div class="Div1">
+                            <a id="ctl00_ctl00_wucBannerMenu_Hyperlink42" href="../../visiting/visiting.aspx">Visiting the Court</a> &nbsp;|&nbsp;
+        <a id="ctl00_ctl00_wucBannerMenu_Hyperlink53" href="../../visiting/touringthebuilding.aspx">Touring the Building</a> &nbsp;|&nbsp;
+        <a id="ctl00_ctl00_wucBannerMenu_Hyperlink1" href="../../visiting/exhibition.aspx">Exhibitions</a>
+					    </div>
+					    <div class="pull-right search">
+						    <div id="ctl00_ctl00_pnlSearch">
+
+                                <table>
+							        <tr>
+                                        <td>
+                                            <span id="ctl00_ctl00_lblSearchOn" style="font-weight:bold;">Search: </span>&nbsp;
+                                            <span title="Radio button - Search All Documents"><input id="ctl00_ctl00_rdoSCD" type="radio" name="ctl00$ctl00$USSC" value="rdoSCD" checked="checked" /><label for="ctl00_ctl00_rdoSCD">All Documents</label></span>
+                                            <span title="Radio Button - Search Docket"><input id="ctl00_ctl00_rdoDocket" type="radio" name="ctl00$ctl00$USSC" value="rdoDocket" /><label for="ctl00_ctl00_rdoDocket">Docket</label></span>
+					    <a id="ctl00_ctl00_SearchCenter" href="../../search_center.aspx" style="font-size:small; float:right">Advanced Search</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+							            <td>
+                                            <span id="ctl00_ctl00_lblForDocuments" style="font-weight:bold;">Enter Search Text:</span>
+                                            <input name="ctl00$ctl00$txtSearch" type="text" id="ctl00_ctl00_txtSearch" /><input name="ctl00$ctl00$txbhidden" type="text" id="ctl00_ctl00_txbhidden" style="visibility: hidden; display: none;" />&nbsp;
+                                            <input type="submit" name="ctl00$ctl00$cmdSearch" value="Search" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdSearch&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_cmdSearch" title="Perform quick search" /> &nbsp;
+                                            <input type="submit" name="ctl00$ctl00$cmdHelp" value="Help" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdHelp&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_cmdHelp" title="Search help tips" /><br />
+
+                                                <span id="ctl00_ctl00_RegularExpressionValidator2" style="display:inline-block;height:20px;visibility:hidden;">Search term too short </span>
+
+
+                                            <span id="ctl00_ctl00_SearchVal" style="display:inline-block;height:20px;visibility:hidden;">Invalid text in search term. Try again</span>
+                                        </td>
+                                    </tr>
+                                </table>
+
+</div>
+					    </div>
+				    </div>
+			    </div>
+			    <div class="row" style="margin-bottom: 5px; margin-top: 5px;">
+				    <div class="col-lg-10 col-md-10">
+					    <div id="sitemappath">
+					        <span id="ctl00_ctl00_SiteMapPath1" style="color:#ED0303;font-size:1em;"><a href="#ctl00_ctl00_SiteMapPath1_SkipLink"><img alt="Skip Navigation Links" src="/WebResource.axd?d=WLY2oepp1eKPePERXTuqUau_buIJz5S7ntqiGL3pUm39ydKxNwryN9m5LqCjmtlpSPkXXzclABxfMGVVXMTu6J6S8rDd4o05EnrXXVm10l81&amp;t=635802997220000000" width="0" height="0" style="border-width:0px;" /></a><span style="color:Red;"><span><a title='Supreme Court Home' href='/' style='color:#507CD1;font-weight:bold;'>Home</a></span><span style='color:#507CD1;font-weight:bold;'> | </span><span><a title='Opinions' href='/opinions/opinions.aspx' style='color:#284E98;font-weight:bold;'>Opinions</a></span><span style='color:#507CD1;font-weight:bold;'> | </span><span style='color:Red;font-weight:bold;'>2015 Term In-Chambers Opinions</span></span><a id="ctl00_ctl00_SiteMapPath1_SkipLink"></a></span>
+				        </div>
+				    </div>
+                    <div class="col-lg-2 col-md-2 text-right">
+
+                    </div>
+			    </div>
+			    <div class="navbar navbar-inverse" role="navigation">
+				    <div class="container-fluid">
+						    <!-- menu starts here -->
+
+<div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+    </button>
+</div>
+<div class="navbar-collapse collapse">
+    <ul class="nav navbar-nav">
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_HyperLink5" class="dropdown-toggle" href="../opinions.aspx">Opinions</a>
+                <ul class="dropdown-menu">
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink30" href="../slipopinion/15">Latest Slip Opinions</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink31" href="../relatingtoorders/15">Opinions Relating to Orders</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink32" href="15">In-Chambers Opinions</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink1" href="../opinions.aspx">Slip opinions - Earlier Terms</a></li>
+                    <!-- li><a id="ctl00_ctl00_wucNewMenu1_HyperLink34" href="../counsellist.aspx">Counsel Listings</a></li -->
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink35" href="../boundvolumes.aspx">Bound Volumes</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink36" href="../../media/media.aspx">Media Files Related to Opinions</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink37" href="../Cited_URL_List.aspx">Internet Sources Cited in Opinions</a></li>
+                    <li>&nbsp;</li>
+                </ul>
+        </li>
+        <li class="dropdown"><a id="ctl00_ctl00_wucNewMenu1_hl" class="dropdown-toggle" href="../../oral_arguments/oral_arguments.aspx">Oral Arguments</a>
+                <ul class="dropdown-menu">
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink23" href="../../oral_arguments/2016TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2016)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink15" href="../../oral_arguments/2015TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2015)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink9" href="../../oral_arguments/2014termcourtcalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2014)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink8" href="../../oral_arguments/2013TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2013)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink10" href="../../oral_arguments/argument_calendars.aspx">Argument Calendars</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink11" href="../../oral_arguments/hearinglist.aspx">Hearing Lists</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink12" href="../../visiting/visitorsguidetooralargument.aspx">Visitor's Guide to Oral Argument</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink13" href="../../oral_arguments/argument_transcript.aspx">Argument Transcripts</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink14" href="../../oral_arguments/argument_audio.aspx">Argument Audio</a></li>
+                    <li>&nbsp;</li>
+                </ul>
+        </li>
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_HyperLink41" class="dropdown-toggle" href="../../case_documents.aspx">Case Documents</a>
+                <ul class="dropdown-menu">
+                    <li><a id="ctl00_ctl00_wucNewMenu1_hldocket" href="../../docket/docket.aspx">Docket Search</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink18" href="../../redirect.aspx?newURL=www.americanbar.org/publications/preview_home/alphabetical.html">On-Line MERITS BRIEFS</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink17" href="../../oral_arguments/briefsource.aspx">Where to Find Briefs</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_hypOrdersOfCourt" href="../../orders/ordersofthecourt/15">Orders of the Court - 2015 Term</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink43" href="../../orders/orders.aspx#Orders">Orders - Earlier Term</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink67" href="../../orders/orders.aspx#OrdersByCircuit">Orders by Circuit</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink68" href="../../orders/orders.aspx#GrantedNotedCases">Granted/Noted Cases List</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink39" href="../../orders/journal.aspx">Journal</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink7" href="../../SpecMastRpt/SpecMastRpt.aspx">Special Master Reports</a></li>
+                    <li>&nbsp;</li>
+                </ul>
+        </li>
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_HyperLink69" class="dropdown-toggle" href="../../rules_guidance.aspx">Rules & Guidance</a>
+            <ul class="dropdown-menu">
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink3" href="../../ctrules/ctrules.aspx">Court Rules</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink4" href="../../casehand/casehand.aspx">Guides for Counsel</a>
+                    <ul class="dropdown-menu sub-menu">
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink26" href="../../casehand/guidetofilingpaidcases2014.pdf" target="_blank">Guide to Filing Paid Cases (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink6" href="../../casehand/courtspecchart02162010.aspx">Paid Cases Brief Chart</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink27" href="../../casehand/guideforifpcases2014.pdf" target="_blank">Guide to Filing <i>In Forma Pauperis</i> Cases (PDF) </a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink28" href="../../casehand/guideforcounsel.pdf" target="_blank">Guide for Counsel in Cases to be Argued (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink29" href="../../oral_arguments/2010ElectronicMeritsBriefsSubmissionGuidelines.pdf" target="_blank">Electronic Merits Briefs Submission Guidelines (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink16" href="../../deliveryofdocuments.aspx">Delivery of Documents to the Clerk's Office</a></li>
+                    </ul>
+                </li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink2" href="../../bar/baradmissions.aspx">Supreme Court Bar</a>
+                    <ul class="dropdown-menu sub-menu">
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink20" href="../../bar/barinstructions.pdf" target="_blank">Bar Admissions Instructions (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink19" href="../../bar/barapplication.pdf" target="_blank">Bar Admissions Forms (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink21" href="../../bar/smallGroups_ArguDays_instr.pdf" target="_blank">Small Group Admissions - Argument Days (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink22" href="../../bar/largeGroups_NonArgument_Instr.pdf" target="_blank">Large Group Admissions - Nonargument Days (PDF)</a></li>
+                    </ul>
+                </li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HypCaseDistribution" href="../../casedistribution/casedistributionschedule.aspx">Case Distribution Schedule</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink40" href="../../casehand/waiver.pdf" target="_blank">Waiver Form (PDF)</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink70" href="../../orders/courtorders/ALLOTMENTORDER9-28-10.pdf" target="_blank">Circuit Assignments of Justices</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink71" href="../../about/Circuit%20Map.pdf" target="_blank">&nbsp;&nbsp;&nbsp;&nbsp; - Circuit Map</a></li>
+                <li>&nbsp;</li>
+            </ul>
+        </li>
+
+            <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_hypCourtInfo" class="dropdown-toggle" href="../../publicinfo/publicinfo.aspx">News Media</a>
+            <ul class="dropdown-menu">
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink57" href="../../publicinfo/press/pressreleases.aspx">Press Releases</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink58" href="../../publicinfo/media/mediaadvisories.aspx">Media Advisories</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink61" href="../../publicinfo/press/presscredentials.aspx">Press Credentials</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink62" href="../../publicinfo/reportersguide.pdf" target="_blank">A Reporter's Guide to Applications (PDF)</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink59" href="../../publicinfo/speeches/speeches.aspx">Speeches</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink60" href="../../publicinfo/year-end/year-endreports.aspx">Chief Justice's Year-End Reports on the Federal Judiciary</a></li>
+                <li>&nbsp;</li>
+            </ul>
+        </li>
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_hypAboutCourt" class="dropdown-toggle" href="../../about/about.aspx">About the Court</a>
+            <ul class="dropdown-menu">
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink46" href="../../about/briefoverview.aspx">Brief Overview</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink47" href="../../about/biographies.aspx">Biographies of Current Justices</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink48" href="../../about/members.aspx">Justices 1789 to Present</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink49" href="../../about/courtbuilding.aspx">The Supreme Court Building</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink45" href="../../redirect.aspx?federal=y&amp;newURL=www.archives.gov/historical-docs/document.html?doc=3&amp;title.raw=Constitution%252">Constitution</a></li>
+                <li>&nbsp;</li>
+            </ul>
+        </li>
+    </ul>
+</div>
+						    <!-- menu ends here -->
+				    </div>
+			    </div>
+            </div>
+			<div class="row">
+				<div class="col-lg-12 col-md-12 col-sm-12" id="mainbody">
+
+
+<div class="col-sm-12 sectiontitle">
+    <div id="sectionbanner5">
+        <div id="pagetitle">
+            <h3><span id="ctl00_ctl00_MainEditable_mainContent_lblTitle" style="font-weight:bold;">2015 Term In-Chambers Opinions</span></h3>
+        </div>
+    </div>
+</div>
+<br />
+
+<p>An in-chambers opinion is written by an individual Justice, usually the Justice for the Circuit from which
+the case arises, to dispose of an application by a party to the case for interim relief, e.g., for a stay of
+the judgment of the court below, for vacation of a stay, or for a temporary injunction.  Any in-chambers
+opinions written during <span id="ctl00_ctl00_MainEditable_mainContent_lblTerms">October Term 2015 (October 5, 2015, through October 2, 2016)</span>, will be posted here on
+the day of their issuance.  They will remain posted until the opinions for the entire Term are published in
+    the bound volumes of the United States Reports. For further information, see <a id="ctl00_ctl00_MainEditable_mainContent_lbnDefA" href="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$MainEditable$mainContent$lbnDefA&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, true))">Column Header Definitions</a>.</p>
+
+<p><b>Caution:</b> These electronic opinions may contain computer-generated errors or other deviations from
+the official paper versions of the opinions.  Moreover, the original version of an in-chambers opinion is
+replaced by a paginated version of the opinion in the preliminary print, and, subsequently, by the final version
+of the case in a U. S. Reports bound volume.  In case
+of discrepancies between the print and electronic versions of an in-chambers opinion, the print version
+controls.
+However, where the electronic version has been designated “revised,” the electronic version controls
+to the extent that it differs from the print version with regard to the noted revision. In case of discrepancies
+between the initial print version or electronic version of an in-chambers opinion and any later official version
+of the opinion—<i>i.e.</i>, the preliminary print or bound volume version—the later version controls.
+
+</p>
+
+
+
+
 <center>
-<div id="wrapper">
-<script type="text/javascript">
-    //<![CDATA[
-    Sys.WebForms.PageRequestManager._initialize('ctl00$ctl00$ScriptManager1', document.getElementById('aspnetForm'));
-    Sys.WebForms.PageRequestManager.getInstance()._updateControls(['tctl00$ctl00$upSearchBox'], [], [], 90);
-    //]]>
-</script>
 
-<!-- hidden banner for print -->
-<div id="hidden">
-    <input type="image" name="ctl00$ctl00$ibtHiddenSeal" id="ctl00_ctl00_ibtHiddenSeal"
-           title="Supreme Court of the United States" src="../images/supremecourt_seal_pr.gif"
-           onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$ibtHiddenSeal&quot;, &quot;&quot;, true, &quot;&quot;, &quot;../default.aspx&quot;, false, false))"
-           style="border-width:0px;"/>
-</div>
-<!-- banner -->
-<div id="banner">
-    <div id="supremecourt_seal"><a name="top"></a><a href='/default.aspx'><img id="ctl00_ctl00_ibtseal"
-                                                                               title="Supreme Court of the United States"
-                                                                               src="../images/banner_seal2.gif"
-                                                                               style="border-width:0px;"/></a></div>
-    <div id="banner_right">
-        <div id="ctl00_ctl00_pnlspacer" style="height:27px;">
+        <table class="table table-bordered" style="text-align: left;" border="1" cellspacing="0" cellpadding="2">
+            <tr>
+            <th style="text-align: center;" width="60" scope="col">Date</th>
+            <th style="text-align: center;" width="80" scope="col">Docket</th>
+            <th style="text-align: center;" width="360" scope="col">Name</th>
+<th style="text-align: center;" width="60" scope="col">Revised</th>
+
+            <th style="text-align: center;" width="20" scope="col">J.</th>
+            <th style="text-align: center;" width="40" scope="col">Pt.</th>
+            </tr>
+
+        </table>
 
 
-            <img id="ctl00_ctl00_imgclear" src="../images/clearpixel.gif" alt="spacer"
-                 style="height:25px;border-width:0px;"/>
-
-        </div>
-        <div id="searchbox">
-            <div id="ctl00_ctl00_pnlSearch" style="height:65px;margin-left: 0px">
-
-                <span id="ctl00_ctl00_lblSearchOn" style="font-weight:bold;">Search: </span>
-                <span title="Radio button - Search All Documents"><input id="ctl00_ctl00_rdoSCD" type="radio"
-                                                                         name="ctl00$ctl00$USSC" value="rdoSCD"
-                                                                         checked="checked"/><label
-                        for="ctl00_ctl00_rdoSCD">All Documents</label></span>
-                <span title="Radio Button - Search Docket Files"><input id="ctl00_ctl00_rdoDocket" type="radio"
-                                                                        name="ctl00$ctl00$USSC"
-                                                                        value="rdoDocket"/><label
-                        for="ctl00_ctl00_rdoDocket">Docket Files</label></span>
-                <br/>
-                <span id="ctl00_ctl00_lblForDocuments" style="font-weight:bold;">For Search Term:</span>
-                &nbsp;
-                <input name="ctl00$ctl00$txtSearch" type="text" id="ctl00_ctl00_txtSearch"
-                       style="font-size:8pt;width:180px;margin-left: 0px"/>
-                <input name="ctl00$ctl00$txbhidden" type="text" id="ctl00_ctl00_txbhidden"
-                       style="visibility: hidden; display: none;"/>
-                <br/>
-                <span id="ctl00_ctl00_SearchVal" style="display:inline-block;color:Red;height:20px;visibility:hidden;">Invalid text in search term. Try again</span>
-                <input type="submit" name="ctl00$ctl00$cmdSearch" value="Search"
-                       onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdSearch&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))"
-                       id="ctl00_ctl00_cmdSearch" title="Perform quick search" style="font-size:8pt;height:21px;"/>
-                &nbsp;
-                <input type="submit" name="ctl00$ctl00$cmdHelp" value="Help"
-                       onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdHelp&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))"
-                       id="ctl00_ctl00_cmdHelp" title="Search help tips" style="font-size:8pt;height:21px;"/>
-
-            </div>
-        </div>
-    </div>
-</div>
-
-<!-- banner bottom -->
-<div id="bannerbottom">
-    <div id="sitemappath">
-        <span id="ctl00_ctl00_SiteMapPath1" style="color:#ED0303;font-size:1em;"><a
-                href="#ctl00_ctl00_SiteMapPath1_SkipLink"><img alt="Skip Navigation Links" height="0" width="0"
-                                                               src="/WebResource.axd?d=TxgnMbr7ckctIVqnqON2aZ4VG0sU5yvRunk8f2razbiWdo3avLGzWworzeUYVPVzUGUkqJ0lYE7uX2NxF8vdr-pc2Mk1&amp;t=635284882248476408"
-                                                               style="border-width:0px;"/></a><span><a
-                title="Supreme Court Home" href="/default.aspx"
-                style="color:#507CD1;font-weight:bold;">Home</a></span><span
-                style="color:#507CD1;font-weight:bold;"> | </span><span><a title="Opinions"
-                                                                           href="/opinions/opinions.aspx"
-                                                                           style="color:#284E98;font-weight:bold;">Opinions</a></span><span
-                style="color:#507CD1;font-weight:bold;"> | </span><span style="color:Red;font-weight:bold;"></span><span
-                style="color:Red;">2013 Term In-Chambers Opinions</span><a
-                id="ctl00_ctl00_SiteMapPath1_SkipLink"></a></span>
-    </div>
-    <div id="bannerbottomright">
-        <div id="date">
-            <a href="javascript:PrintThisPage();"><img id="ctl00_ctl00_imgPrinter" title="Printer-Friendly"
-                                                       src="../images/printer1.gif"
-                                                       style="border-style:None;border-width:0px;"/>
-                Printer-Friendly Version</a>
-        </div>
-    </div>
-</div>
-<!-- search update pannel -->
-<div id="searchboxpannel">
-    <div id="ctl00_ctl00_upSearchBox">
-
-        <div id="searchwrap">
-            <div id="searchbox2" style="width: 100%">
-                <input type="submit" name="ctl00$ctl00$btnsearch" value="Show Search"
-                       onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$btnsearch&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))"
-                       id="ctl00_ctl00_btnsearch"/>
-            </div>
-            <div id="searchbox3" style="display:block; float: right;">
-
-            </div>
-        </div>
-
-    </div>
-</div>
-<div class="bnr-clear"></div>
-
-<!-- mid-section -->
-<div id="main">
-
-<div id="columntop"><img id="ctl00_ctl00_mainbody_imagetopcolumn2" alt="" src="../images/clearpixel.gif"
-                         style="height:7px;border-width:0px;"/></div>
-<div id="middleCol2">
-<div id="leftcolumn" class="noindex" style="z-index: 2;">
-<div id="leftmenu1" class="textbox">
-
-    <div class="menu1title">
-        <img id="ctl00_ctl00_mainbody_wucMenu1_imgTbDoc" src="../images/tb_documents.gif" alt="Supreme Court Document"
-             style="border-width:0px;"/>
-    </div>
-    <div style="display: block; z-index: 100;">
-        <div class="MainMenu">
-            <ul class="AspNet-Menu">
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_hlTdocket" class="MenuTier1" href="../docket/docket.aspx">Docket</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_hldocket" href="../docket/docket.aspx">Docket
-                            Search</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HypCaseDistribution"
-                               href="../casedistribution/casedistributionschedule.aspx">Case Distribution Schedule</a>
-                        </li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink7" href="../SpecMastRpt/SpecMastRpt.aspx">Special
-                            Master Reports</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_hl" class="MenuTier1"
-                       href="../oral_arguments/oral_arguments.aspx">Oral Arguments</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink9"
-                               href="../oral_arguments/2013termcourtcalendar.pdf" target="_blank">Supreme Court Calendar
-                            (PDF) (October Term 2013)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink10"
-                               href="../oral_arguments/argument_calendars.aspx">Argument Calendars</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink11" href="../oral_arguments/hearinglist.aspx">Hearing
-                            Lists</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink12"
-                               href="../visiting/visitorsguidetooralargument.aspx">Visitor's Guide to Oral Argument</a>
-                        </li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink13"
-                               href="../oral_arguments/argument_transcripts.aspx">Argument Transcripts</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink14"
-                               href="../oral_arguments/argument_audio.aspx">Argument Audio</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink15"
-                               href="../oral_arguments/oral_arguments.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink1" class="MenuTier1"
-                       href="../meritsbriefs/meritsbriefs.aspx">Merits Briefs</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink16" href="../deliveryofdocuments.aspx">Delivery
-                            of Documents to the Clerk's Office</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink17" href="../oral_arguments/briefsource.aspx">Where
-                            to Find Briefs</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink18"
-                               href="../redirect.aspx?newURL=www.americanbar.org/publications/preview_home/alphabetical.html">On-Line
-                            MERITS BRIEFS</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink2" class="MenuTier1" href="../bar/baradmissions.aspx">Bar
-                        Admissions</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink19" href="../bar/barapplication.pdf">Bar
-                            Admissions Forms (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink20" href="../bar/barinstructions.pdf">Bar
-                            Admissions Instructions (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink21"
-                               href="../bar/smallGroups_ArguDays_instr.pdf" target="_blank">Argument Day Group
-                            Admissions (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink22"
-                               href="../bar/largeGroups_NonArgument_Instr.pdf" target="_blank">Large Group Admissions
-                            (PDF)</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink3" class="MenuTier1" href="../ctrules/ctrules.aspx">Court
-                        Rules</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink23" href="../ctrules/2013RulesoftheCourt.pdf"
-                               target="_blank">Rules of the Supreme Court (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink24" href="../ctrules/041913zr.pdf"
-                               target="_blank">Order Adopting Revised Rules (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink25" href="../ctrules/ctrules.aspx">More..</a>
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink4" class="MenuTier1" href="../casehand/casehand.aspx">Case
-                        Handling Guides</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink26"
-                               href="../casehand/guidetofilingpaidcases2013.pdf" target="_blank">Guide to Filing Paid
-                            Cases (2013) (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink27"
-                               href="../casehand/guideforifpcases2013.pdf" target="_blank">Guide to IFP Cases (PDF)</a>
-                        </li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink28"
-                               href="../oral_arguments/guideforcounsel.pdf" target="_blank">Guide for Counsel (PDF)</a>
-                        </li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink29"
-                               href="../casehand/casehand.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink5" class="MenuTier1" href="opinions.aspx">Opinions</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink30" href="slipopinions.aspx">Latest Slip
-                            Opinions</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink31" href="relatingtoorders.aspx">Opinions
-                            Relating to Orders</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink32" href="in-chambers.aspx">In-Chambers
-                            Opinions</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink33" href="sliplists.aspx">Sliplists</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink34" href="counsellist.aspx">Counsel
-                            Listings</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink35" href="boundvolumes.aspx">Bound Volumes</a>
-                        </li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink36" href="../media/media.aspx">Video
-                            Resources</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink37" href="opinions.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink6" class="MenuTier1" href="../orders/orders.aspx">Orders
-                        and Journals</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink38" href="../orders/ordersofthecourt.aspx">Orders
-                            of the Court</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink39" href="../orders/journal.aspx">Journal</a>
-                        </li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink40" href="../orders/orders.aspx">More..</a>
-                        </li>
-                    </ul>
-                </li>
-            </ul>
-        </div>
-    </div>
-    &nbsp;<br/>
-
-
-    <div class="menu1title">
-        <img id="ctl00_ctl00_mainbody_wucMenu2_imgTbInfo" src="../images/tb_information.gif"
-             alt="Supreme Court Information" style="border-width:0px;"/>
-    </div>
-    <div style="display: block; z-index: 100;">
-        <div class="MainMenu">
-            <ul class="AspNet-Menu">
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink40" class="MenuTier1" href="../about/about.aspx">About
-                        the Supreme Court</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink45"
-                               href="../redirect.aspx?federal=y&amp;newURL=www.archives.gov/historical-docs/document.html?doc=3&amp;title.raw=Constitution%252">Constitution</a>
-                        </li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink46" href="../about/briefoverview.aspx">Brief
-                            Overview</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink47" href="../about/biographies.aspx">Biographies
-                            of Current Justices</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink48" href="../about/members.aspx">Members of
-                            the Supreme Court</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink49" href="../about/courtbuilding.aspx">The
-                            Supreme Court Building</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink50" href="../about/about.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink41" class="MenuTier1"
-                       href="../visiting/visiting.aspx">Visiting the Court</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink51" href="../visiting/visitorservices.aspx">Plan
-                            Your Visit</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_HyperLink1" href="../visiting/schoolgroups.aspx">School
-                            Groups</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink52"
-                               href="../visiting/touringthebuilding.aspx">Touring the Building</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink3" href="../visiting/exhibition.aspx">Exhibitions</a>
-                        </li>
-
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink54" href="../visiting/map.pdf"
-                               target="_blank">Map (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink55"
-                               href="../visiting/foreigntranslations.aspx">Foreign Translations</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink56" href="../faq_visiting.aspx">FAQ on
-                            Visiting</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink4" href="../visiting/visiting.aspx">More..</a>
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink42" class="MenuTier1"
-                       href="../publicinfo/publicinfo.aspx">Public Information</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink57"
-                               href="../publicinfo/press/pressreleases.aspx">Press Releases</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink58"
-                               href="../publicinfo/media/mediaadvisories.aspx">Media Advisories</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink59"
-                               href="../publicinfo/speeches/speeches.aspx">Speeches</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink60"
-                               href="../publicinfo/year-end/year-endreports.aspx">Chief Justice's Year-End Reports on
-                            the Federal Judiciary</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink61"
-                               href="../publicinfo/modernization/home.aspx">Supreme Court Building Modernization
-                            Project</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink62" href="../publicinfo/reportersguide.pdf"
-                               target="_blank">A Reporter's Guide to Applications (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink63"
-                               href="../publicinfo/buildingregulations.aspx">Building Regulations</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink64" href="../publicinfo/phonenumbers.aspx">Helpful
-                            Telephone Numbers</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink65" href="../publicinfo/comments.aspx">Where
-                            to Send Comments</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink66" href="../problemwithoutofdateinfo.aspx">Problem
-                            with out of date information?</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink67" href="../publicinfo/publicinfo.aspx">More..</a>
-                        </li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink43" class="MenuTier1"
-                       href="../jobs/jobs.aspx">Jobs</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink68" href="../jobs/career/career.aspx">Career
-                            Opportunities</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink69" href="../fellows/default.aspx">Supreme
-                            Court Fellows Program</a></li>
-
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink71" href="../jobs/jip/jip.aspx">Judicial
-                            Internship Program</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink72" href="../jobs/docent/docent.aspx">Docent
-                            Program</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink73"
-                               href="../jobs/curatorial_internship/InternshipInfoSheet.aspx">Curatorial Internship
-                            Program</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink44" class="MenuTier1"
-                       href="../links/links.aspx">Links</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink74"
-                               href="../redirect.aspx?federal=y&amp;newURL=www.uscourts.gov/">Administrative Office of
-                            the United States Courts</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink75"
-                               href="../redirect.aspx?federal=y&amp;newURL=www.fjc.gov">Federal Judicial Center</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink76"
-                               href="../redirect.aspx?federal=y&amp;newURL=www.ussc.gov">United States Sentencing
-                            Commission</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink77"
-                               href="../redirect.aspx?newURL=www.icivics.org">iCivics Web site (Educational & Student
-                            Friendly)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink78" href="../fellows/default.aspx">Supreme
-                            Court Fellows Program</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink79" href="../links/links.aspx">More..</a></li>
-                    </ul>
-                </li>
-            </ul>
-        </div>
-    </div>
-    &nbsp;<br/>
-
-</div>
-<div id="leftmenu2" class="textbox">
-    <h3 id="menu1H3Title"><a href="#">Supreme Court Documents</a></h3>
-
-    <div>
-
-        <div class="menu1title">
-            <img id="ctl00_ctl00_mainbody_wucMenu3_imgTbDoc" src="../images/tb_documents.gif"
-                 alt="Supreme Court Document" style="border-width:0px;"/>
-        </div>
-        <div style="display: block; z-index: 100;">
-            <div class="MainMenu">
-                <ul class="AspNet-Menu">
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_hlTdocket" class="MenuTier1" href="../docket/docket.aspx">Docket</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_hldocket" href="../docket/docket.aspx">Docket
-                                Search</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HypCaseDistribution"
-                                   href="../casedistribution/casedistributionschedule.aspx">Case Distribution
-                                Schedule</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink7" href="../SpecMastRpt/SpecMastRpt.aspx">Special
-                                Master Reports</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_hl" class="MenuTier1"
-                           href="../oral_arguments/oral_arguments.aspx">Oral Arguments</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink9"
-                                   href="../oral_arguments/2013termcourtcalendar.pdf" target="_blank">Supreme Court
-                                Calendar (PDF) (October Term 2013)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink10"
-                                   href="../oral_arguments/argument_calendars.aspx">Argument Calendars</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink11"
-                                   href="../oral_arguments/hearinglist.aspx">Hearing Lists</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink12"
-                                   href="../visiting/visitorsguidetooralargument.aspx">Visitor's Guide to Oral
-                                Argument</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink13"
-                                   href="../oral_arguments/argument_transcripts.aspx">Argument Transcripts</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink14"
-                                   href="../oral_arguments/argument_audio.aspx">Argument Audio</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink15"
-                                   href="../oral_arguments/oral_arguments.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink1" class="MenuTier1"
-                           href="../meritsbriefs/meritsbriefs.aspx">Merits Briefs</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink16" href="../deliveryofdocuments.aspx">Delivery
-                                of Documents to the Clerk's Office</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink17"
-                                   href="../oral_arguments/briefsource.aspx">Where to Find Briefs</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink18"
-                                   href="../redirect.aspx?newURL=www.americanbar.org/publications/preview_home/alphabetical.html">On-Line
-                                MERITS BRIEFS</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink2" class="MenuTier1"
-                           href="../bar/baradmissions.aspx">Bar Admissions</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink19" href="../bar/barapplication.pdf">Bar
-                                Admissions Forms (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink20" href="../bar/barinstructions.pdf">Bar
-                                Admissions Instructions (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink21"
-                                   href="../bar/smallGroups_ArguDays_instr.pdf" target="_blank">Argument Day Group
-                                Admissions (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink22"
-                                   href="../bar/largeGroups_NonArgument_Instr.pdf" target="_blank">Large Group
-                                Admissions (PDF)</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink3" class="MenuTier1"
-                           href="../ctrules/ctrules.aspx">Court Rules</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink23"
-                                   href="../ctrules/2013RulesoftheCourt.pdf" target="_blank">Rules of the Supreme Court
-                                (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink24" href="../ctrules/041913zr.pdf"
-                                   target="_blank">Order Adopting Revised Rules (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink25"
-                                   href="../ctrules/ctrules.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink4" class="MenuTier1"
-                           href="../casehand/casehand.aspx">Case Handling Guides</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink26"
-                                   href="../casehand/guidetofilingpaidcases2013.pdf" target="_blank">Guide to Filing
-                                Paid Cases (2013) (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink27"
-                                   href="../casehand/guideforifpcases2013.pdf" target="_blank">Guide to IFP Cases
-                                (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink28"
-                                   href="../oral_arguments/guideforcounsel.pdf" target="_blank">Guide for Counsel
-                                (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink29" href="../casehand/casehand.aspx">More..</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink5" class="MenuTier1"
-                           href="opinions.aspx">Opinions</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink30" href="slipopinions.aspx">Latest Slip
-                                Opinions</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink31" href="relatingtoorders.aspx">Opinions
-                                Relating to Orders</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink32" href="in-chambers.aspx">In-Chambers
-                                Opinions</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink33" href="sliplists.aspx">Sliplists</a>
-                            </li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink34" href="counsellist.aspx">Counsel
-                                Listings</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink35" href="boundvolumes.aspx">Bound
-                                Volumes</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink36" href="../media/media.aspx">Video
-                                Resources</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink37" href="opinions.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink6" class="MenuTier1" href="../orders/orders.aspx">Orders
-                            and Journals</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink38"
-                                   href="../orders/ordersofthecourt.aspx">Orders of the Court</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink39"
-                                   href="../orders/journal.aspx">Journal</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink40"
-                                   href="../orders/orders.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                </ul>
-            </div>
-        </div>
-        &nbsp;<br/>
-    </div>
-    <h3 id="menu2H3Title"><a href="#">Supreme Court Information</a></h3>
-
-    <div>
-
-        <div class="menu1title">
-            <img id="ctl00_ctl00_mainbody_wucMenu4_imgTbInfo" src="../images/tb_information.gif"
-                 alt="Supreme Court Information" style="border-width:0px;"/>
-        </div>
-        <div style="display: block; z-index: 100;">
-            <div class="MainMenu">
-                <ul class="AspNet-Menu">
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink40" class="MenuTier1" href="../about/about.aspx">About
-                            the Supreme Court</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink45"
-                                   href="../redirect.aspx?federal=y&amp;newURL=www.archives.gov/historical-docs/document.html?doc=3&amp;title.raw=Constitution%252">Constitution</a>
-                            </li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink46" href="../about/briefoverview.aspx">Brief
-                                Overview</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink47" href="../about/biographies.aspx">Biographies
-                                of Current Justices</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink48" href="../about/members.aspx">Members
-                                of the Supreme Court</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink49" href="../about/courtbuilding.aspx">The
-                                Supreme Court Building</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink50" href="../about/about.aspx">More..</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink41" class="MenuTier1"
-                           href="../visiting/visiting.aspx">Visiting the Court</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink51"
-                                   href="../visiting/visitorservices.aspx">Plan Your Visit</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_HyperLink1" href="../visiting/schoolgroups.aspx">School
-                                Groups</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink52"
-                                   href="../visiting/touringthebuilding.aspx">Touring the Building</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink3" href="../visiting/exhibition.aspx">Exhibitions</a>
-                            </li>
-
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink54" href="../visiting/map.pdf"
-                                   target="_blank">Map (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink55"
-                                   href="../visiting/foreigntranslations.aspx">Foreign Translations</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink56" href="../faq_visiting.aspx">FAQ on
-                                Visiting</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink4"
-                                   href="../visiting/visiting.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink42" class="MenuTier1"
-                           href="../publicinfo/publicinfo.aspx">Public Information</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink57"
-                                   href="../publicinfo/press/pressreleases.aspx">Press Releases</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink58"
-                                   href="../publicinfo/media/mediaadvisories.aspx">Media Advisories</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink59"
-                                   href="../publicinfo/speeches/speeches.aspx">Speeches</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink60"
-                                   href="../publicinfo/year-end/year-endreports.aspx">Chief Justice's Year-End Reports
-                                on the Federal Judiciary</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink61"
-                                   href="../publicinfo/modernization/home.aspx">Supreme Court Building Modernization
-                                Project</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink62"
-                                   href="../publicinfo/reportersguide.pdf" target="_blank">A Reporter's Guide to
-                                Applications (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink63"
-                                   href="../publicinfo/buildingregulations.aspx">Building Regulations</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink64"
-                                   href="../publicinfo/phonenumbers.aspx">Helpful Telephone Numbers</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink65" href="../publicinfo/comments.aspx">Where
-                                to Send Comments</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink66"
-                                   href="../problemwithoutofdateinfo.aspx">Problem with out of date information?</a>
-                            </li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink67" href="../publicinfo/publicinfo.aspx">More..</a>
-                            </li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink43" class="MenuTier1" href="../jobs/jobs.aspx">Jobs</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink68" href="../jobs/career/career.aspx">Career
-                                Opportunities</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink69" href="../fellows/default.aspx">Supreme
-                                Court Fellows Program</a></li>
-
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink71" href="../jobs/jip/jip.aspx">Judicial
-                                Internship Program</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink72" href="../jobs/docent/docent.aspx">Docent
-                                Program</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink73"
-                                   href="../jobs/curatorial_internship/InternshipInfoSheet.aspx">Curatorial Internship
-                                Program</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink44" class="MenuTier1" href="../links/links.aspx">Links</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink74"
-                                   href="../redirect.aspx?federal=y&amp;newURL=www.uscourts.gov/">Administrative Office
-                                of the United States Courts</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink75"
-                                   href="../redirect.aspx?federal=y&amp;newURL=www.fjc.gov">Federal Judicial Center</a>
-                            </li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink76"
-                                   href="../redirect.aspx?federal=y&amp;newURL=www.ussc.gov">United States Sentencing
-                                Commission</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink77"
-                                   href="../redirect.aspx?newURL=www.icivics.org">iCivics Web site (Educational &
-                                Student Friendly)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink78" href="../fellows/default.aspx">Supreme
-                                Court Fellows Program</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink79" href="../links/links.aspx">More..</a>
-                            </li>
-                        </ul>
-                    </li>
-                </ul>
-            </div>
-        </div>
-        &nbsp;<br/>
-    </div>
-</div>
-</div>
-<div id="maincolumn" style="z-index: 1;">
-    <div class="textbox4">
-        <div id="maincontentbox">
-
-
-            <div id="sectionbanner5">
-                <div id="pagetitle">
-                    <h3><span id="ctl00_ctl00_mainbody_mainContent_lblTitle" style="font-weight:bold;">2013 Term In-Chambers Opinions</span>
-                    </h3>
-                </div>
-            </div>
-            <br/>
-
-            <p>An in-chambers opinion is written by an individual Justice, usually the Justice for the Circuit from
-                which
-                the case arises, to dispose of an application by a party to the case for interim relief, e.g., for a
-                stay of
-                the judgment of the court below, for vacation of a stay, or for a temporary injunction. Any in-chambers
-                opinions written during <span id="ctl00_ctl00_mainbody_mainContent_lblTerms">October Term 2013 (October 07, 2013, through October 05, 2014)</span>,
-                will be posted here on
-                the day of their issuance. They will remain posted until the opinions for the entire Term are published
-                in the bound volumes of the United States Reports. For further information, see <a
-                        id="ctl00_ctl00_mainbody_mainContent_lbnDefA"
-                        href="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$mainbody$mainContent$lbnDefA&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, true))">Column
-                    Header Definitions</a>.</p>
-
-            <p><b>Caution:</b> These electronic opinions may contain computer-generated errors or other deviations from
-                the official paper versions of the opinions. Moreover, the original version of an in-chambers opinion is
-                replaced within a few months by a paginated version of the opinion in the preliminary print, and-one
-                year
-                after the issuance of that print-by the final version of the case in a U. S. Reports bound volume. In
-                case
-                of discrepancies between the print and electronic versions of an in-chambers opinion, the print version
-                controls. In case of discrepancies between the in-chambers opinion and any later official version of the
-                opinion, the later version controls.</p>
-
-
-            <center>
-
-                <table class="datatables" style="text-align: left;" border="1" cellspacing="0" cellpadding="2">
-                    <tr>
-                        <th style="text-align: center;" width="60" scope="col">Date</th>
-                        <th style="text-align: center;" width="80" scope="col">Docket</th>
-                        <th style="text-align: center;" width="400" scope="col">Name</th>
-                        <th style="text-align: center;" width="20" scope="col">J.</th>
-                        <th style="text-align: center;" width="40" scope="col">Pt.</th>
-                    </tr>
-
-                    <tr>
-                        <td style="text-align: center;">4/18/14</td>
-                        <td style="text-align: center;">13A1003 <br> (13-854)</td>
-                        <td><a href='13pdf/13a1003_5h26.pdf' target='_blank'>Teva Pharmaceuticals USA, Inc. v. Sandoz,
-                            Inc.</a></td>
-                        <td style="text-align: center;">R</td>
-                        <td style="text-align: center;">572/1</td>
-                    </tr>
-
-                </table>
-
-
-            </center>
-
-            <br/>
-
-        </div>
-    </div>
-</div>
-</div>
-<div id="columnbottom"><img id="ctl00_ctl00_mainbody_imagebottomcolumn2" alt="" src="../images/clearpixel.gif"
-                            style="height:7px;border-width:0px;"/></div>
-
-</div>
-
-<!-- footer -->
-<div id="footer" class="noindex">
-    <hr style="width: 95%; text-align: left; margin-left: 5px;"/>
-    <div id="versiontext" style="text-align: center;"><span id="ctl00_ctl00_lbltoday">May 09, 2014</span>
-        | <span id="ctl00_ctl00_lblversion">Version 2012.0</span></div>
-    <div id="footertext">
-        <a id="ctl00_ctl00_hypHome" href="../">Home</a> |
-        <a id="ctl00_ctl00_hypHelp" href="../help.aspx">Help</a>
-        |
-        <a id="ctl00_ctl00_hpsitemap" href="../sitemap.aspx">Site Map</a>
-        |
-        <a id="ctl00_ctl00_HypContactUs" href="../contact/contactus.aspx">Contact Us</a>
-        |
-        <a id="ctl00_ctl00_HypAboutUs" href="../about/about_us.aspx">About Us</a>
-        |
-        <a id="ctl00_ctl00_HypFAQ" href="../faq.aspx">FAQ</a>
-        |
-        <a id="ctl00_ctl00_HypWebPolicy" href="../policies/web_policies_and_notices.aspx">Website Policies and
-            Notices</a>
-        |
-        <a id="ctl00_ctl00_HypPrivacy" href="../policies/privacy_notice.aspx">Privacy Policy</a>
-        |
-        <a id="ctl00_ctl00_hypUSA" href="../redirect.aspx?federal=y&amp;newURL=www.usa.gov">USA.GOV</a><br/>
-                   <span style="display:block; margin-top: 5px; font-size: 12pt;font-weight:bold; color: #ffffff;">
-                    Supreme Court of the United States</span>
-
-        <p>&nbsp;</p>
-
-    </div>
-</div>
-</div>
 </center>
 
+<br />
+
+
+				</div>
+			</div>
+		</div>
+	<div class="container well">
+        <div class="noindex">
+		    <div class="container">
+			    <div class="row">
+				    <div class="col-lg-12 col-md-12 col-sm-12">
+
+					    <div id="versiontext" class="text-center"  style="display:block; width: auto;"><span id="ctl00_ctl00_lbltoday">February 12, 2016</span>
+						    |  Version 2014.1</div>
+					    <div class="text-center"  id="footertext">
+					       <a id="ctl00_ctl00_hypHome" href="../../">Home</a>
+                            |
+					       <a id="ctl00_ctl00_hypHelp" href="../../help.aspx">Help</a>
+						    |
+					       <a id="ctl00_ctl00_hpsitemap" href="../../sitemap.aspx">Site Map</a>
+						    |
+					       <a id="ctl00_ctl00_HypContactUs" href="../../contact/contactus.aspx">Contact Us</a>
+						    |
+					       <a id="ctl00_ctl00_HypAboutUs" href="../../about/about_us.aspx">About Us</a>
+						    |
+					       <a id="ctl00_ctl00_HypFAQ" href="../../faq.aspx">FAQ</a>
+						    |
+                           <a id="ctl00_ctl00_HypJobs" href="../../jobs/jobs.aspx">Jobs</a>
+                            |
+                           <a id="ctl00_ctl00_HypLinks" href="../../links/links.aspx">Links</a>
+                            |
+                           <a id="ctl00_ctl00_Hyperlink63" href="../../publicinfo/buildingregulations.aspx">Building Regulations</a><br />
+
+					       <a id="ctl00_ctl00_HypWebPolicy" href="../../policies/web_policies_and_notices.aspx">Website Policies and Notices</a>
+						    |
+					       <a id="ctl00_ctl00_HypPrivacy" href="../../policies/privacy_notice.aspx">Privacy Policy</a>
+                            |
+					       <a id="ctl00_ctl00_hypUSA" href="../../redirect.aspx?federal=y&amp;newURL=www.usa.gov">USA.GOV</a><br />
+
+					       <span style="display:block; margin-top: 5px; font-size: 14pt;font-weight:bold; color: #000;">Supreme Court of the United States</span>
+					    </div>
+
+				    </div>
+			    </div>
+		    </div>
+        </div>
+	</div>
+
+
 <script type="text/javascript">
-    //<![CDATA[
-    var Page_Validators = new Array(document.getElementById("ctl00_ctl00_SearchVal"));
-    //]]>
+//<![CDATA[
+var Page_Validators =  new Array(document.getElementById("ctl00_ctl00_RegularExpressionValidator2"), document.getElementById("ctl00_ctl00_SearchVal"));
+//]]>
 </script>
 
 <script type="text/javascript">
-    //<![CDATA[
-    var ctl00_ctl00_SearchVal = document.all ? document.all["ctl00_ctl00_SearchVal"] : document.getElementById("ctl00_ctl00_SearchVal");
-    ctl00_ctl00_SearchVal.controltovalidate = "ctl00_ctl00_txtSearch";
-    ctl00_ctl00_SearchVal.errormessage = "Invalid text in search term. Try again";
-    ctl00_ctl00_SearchVal.evaluationfunction = "RegularExpressionValidatorEvaluateIsValid";
-    ctl00_ctl00_SearchVal.validationexpression = "[\\w\\s-/?!\"\'&~@<>/*.(),]*";
-    //]]>
+//<![CDATA[
+var ctl00_ctl00_RegularExpressionValidator2 = document.all ? document.all["ctl00_ctl00_RegularExpressionValidator2"] : document.getElementById("ctl00_ctl00_RegularExpressionValidator2");
+ctl00_ctl00_RegularExpressionValidator2.controltovalidate = "ctl00_ctl00_txtSearch";
+ctl00_ctl00_RegularExpressionValidator2.errormessage = "Search term too short ";
+ctl00_ctl00_RegularExpressionValidator2.evaluationfunction = "RegularExpressionValidatorEvaluateIsValid";
+ctl00_ctl00_RegularExpressionValidator2.validationexpression = "^[\\s\\S]{3,}$";
+var ctl00_ctl00_SearchVal = document.all ? document.all["ctl00_ctl00_SearchVal"] : document.getElementById("ctl00_ctl00_SearchVal");
+ctl00_ctl00_SearchVal.controltovalidate = "ctl00_ctl00_txtSearch";
+ctl00_ctl00_SearchVal.errormessage = "Invalid text in search term. Try again";
+ctl00_ctl00_SearchVal.evaluationfunction = "RegularExpressionValidatorEvaluateIsValid";
+ctl00_ctl00_SearchVal.validationexpression = "[\\w\\s-/\"\'() /*@.]*";
+//]]>
 </script>
 
 
 <script type="text/javascript">
-    //<![CDATA[
+//<![CDATA[
 
-    var Page_ValidationActive = false;
-    if (typeof(ValidatorOnLoad) == "function") {
-        ValidatorOnLoad();
-    }
+var Page_ValidationActive = false;
+if (typeof(ValidatorOnLoad) == "function") {
+    ValidatorOnLoad();
+}
 
-    function ValidatorOnSubmit() {
-        if (Page_ValidationActive) {
-            return ValidatorCommonOnSubmit();
-        }
-        else {
-            return true;
-        }
+function ValidatorOnSubmit() {
+    if (Page_ValidationActive) {
+        return ValidatorCommonOnSubmit();
     }
-    WebForm_AutoFocus('cmdSearch');
-    Sys.Application.initialize();
+    else {
+        return true;
+    }
+}
 
-    document.getElementById('ctl00_ctl00_SearchVal').dispose = function () {
-        Array.remove(Page_Validators, document.getElementById('ctl00_ctl00_SearchVal'));
-    }
-    //]]>
+document.getElementById('ctl00_ctl00_RegularExpressionValidator2').dispose = function() {
+    Array.remove(Page_Validators, document.getElementById('ctl00_ctl00_RegularExpressionValidator2'));
+}
+
+document.getElementById('ctl00_ctl00_SearchVal').dispose = function() {
+    Array.remove(Page_Validators, document.getElementById('ctl00_ctl00_SearchVal'));
+}
+//]]>
 </script>
 </form>
 </body>

--- a/tests/examples/opinions/united_states/scotus_relating_example.html
+++ b/tests/examples/opinions/united_states/scotus_relating_example.html
@@ -1,714 +1,395 @@
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+
+<!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head><title>
-    2012 Term Opinions Relating to Orders
-</title><meta http-equiv="content-type" content="txt/html; charset=utf-8" /><meta http-equiv="X-UA-Compatible" content="IE=edge" /><meta name="viewport" content="width=device-width, initial-scale=0.7" /><meta name="author" content="Supreme Court of the United States" /><meta name="description" content="supremecourt.gov is the official web site for the Supreme Court of the United States." /><meta http-equiv="content-language" content="en" />
-    <link rel='stylesheet' href='/styles/jquery.ui.base.css' />
-    <link rel='stylesheet' href='/styles/jquery.ui.theme.css' />
-    <script src="/script/jquery.js"></script>
-    <script src="/script/ui/jquery.ui.core.js"></script>
-    <script src="/script/ui/jquery.ui.widget.js"></script>
-    <script src="/script/ui/jquery.ui.accordion.js"></script>
-
-    <script type='text/javascript' >
-        $(document).ready(function() {
-            $('#middleCol2 #leftcolumn #leftmenu2').accordion({
-                collapsible: true,
-                autoHeight: false, active: 2
-            });
-        });
-    </script>
+<head><meta http-equiv="X-UA-Compatible" content="IE=edge" /><meta http-equiv="content-type" content="txt/html; charset=utf-8" /><meta name="viewport" content="width=device-width, initial-scale=0.7" />
+        <script type="text/javascript" src="/engine1/jquery-1.11.0.js"></script>
+	    <script type="text/javascript" src="/js/bootstrap.js"></script>
+	    <link rel="Stylesheet" type="text/css" href="/css/bootstrap.min.css" />
+	    <link rel="Stylesheet" type="text/css" href="/css/bootstrap-theme.min.css" />
+	    <link rel="Stylesheet" type="text/css" href="/styles/supremecourt_style2.css" title="default" />
+	    <link rel="stylesheet" type="text/css" href="/styles/newBootStrap.css" />
 
 
-    <meta name="title" content="2008 Term Opinions Relating to Orders" />
-    <meta name="created" content='9/30/2010 10:36:01 AM' />
-    <meta name="revised" content='10/24/2012 12:48:27 PM' />
-    <meta name="keywords" content="Supreme Court of the United States, Supreme Court, Supreme Court of US, Supremecourt,
-    United State Supreme Court, US Supreme Court, U.S. Supreme Court, Court, Opinions, Orders, Opinions relating to orders" />
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
 
-    <link rel="Alternate" type="application/atom+xml" title="Supreme Court of United States Slip Opinions" href="../rss/slipopinion_rss.aspx" /><link rel="Alternate" type="application/atom+xml" title="Supreme Court of United States Argument Audio" href="../rss/argument_audio_rss.aspx" /><link rel="Alternate" type="application/atom+xml" title="Supreme Court of United States Argument Transcripts" href="../rss/argument_transcripts_rss.aspx" /><link rel="Alternate" type="application/atom+xml" title="Supreme Court of United States Hermes Transfer List" href="../rss/hermes_transfer.xml" /><link rel="Stylesheet" type="text/css" href="../styles/supremecourt_style.css" title="default" />
-    <!--[if lte IE 9]>
-    <script language="javascript" src="/script/html5.js"></script>
-    <link rel="Stylesheet" type="text/css" href="/styles/ie.css" />
-    <link rel="Stylesheet" type="text/css" href="/styles/mainmenu.css" />
-    <![endif]-->
-    <link rel="shortcut icon" href="../favicon.ico" type="image/x-icon" /><link rel="icon" href="../favicon.ico" type="image/x-icon" />
-    <script language="javascript" type="text/javascript">
-        function PrintThisPage() {
-            var sOption = "toolbar=yes,location=no,directories=yes,menubar=yes,scrollbars=yes,width=800,height=600,left=100,top=25";
-            var sWinHTML = document.getElementById('maincontentbox').innerHTML;
+        <!--[if lt IE 9]>
+          <script src="/js/html5shiv.js"></script>
+          <script src="/js/respond.min.js"></script>
+        <![endif]-->
 
-            var winprint = window.open("", "", sOption);
-            winprint.document.open();
-            winprint.document.write('<html><link type=text/css rel=Stylesheet href=/styles/supremecourt_style_pr.css><body>');
-            winprint.document.write('<div style=\'margin: 10px;\'>');
-            winprint.document.write('<table border=0 cellpadding=5 cellspacing=5 width=100%><tr><td align=left><img src=/images/supremecourt_seal_pr.gif /></td></tr></table>');
-            winprint.document.write(sWinHTML)
-            winprint.document.write('</div></body></html>');
-            winprint.document.close();
-            winprint.focus();
+        <!--[if lt IE 8]>
+          <link rel="stylesheet" type="text/css" href="css/bootstrap-ie7.css">
+        <![endif]-->
+
+
+
+<meta name="title" content="2008 Term Opinions Relating to Orders" />
+	<meta name="created" content='12/31/1600 7:00:00 PM' />
+	<meta name="revised" content='12/31/1600 7:00:00 PM' />
+	<meta name="keywords" content="Supreme Court of the United States, Supreme Court, Supreme Court of US, Supremecourt,
+	United State Supreme Court, US Supreme Court, U.S. Supreme Court, Court, Opinions, Orders, Opinions relating to orders" />
+    <style type="text/css">
+        .well-lg {
+            background-image: none;
         }
-    </script>
-</head>
+    </style>
+
+<title>
+	2015 Term Opinions Relating to Orders
+</title></head>
 <body>
-<form name="aspnetForm" method="post" action="relatingtoorders.aspx" onsubmit="javascript:return WebForm_OnSubmit();" onkeypress="javascript:return WebForm_FireDefaultButton(event, 'ctl00_ctl00_cmdSearch')" id="aspnetForm">
-<div>
-    <input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
-    <input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
-    <input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="F36FarWBlfGIkLt2z0+/bcMYdGWMgRq3hb/TsvIwBwrmjTFz6tQVZTSMT7u4nxCgG/mwqtpqEm3rBa/LtZpuoy+udSmpJEkfDUjKT1bujWSiMcOP7WjxUoBq5fmnEzQYo4JvNh9Iyew7wdwcjrGUBsWezklOuyJGXZMGtLyfzybgs6UlacKWU49vOskRKcIT2JFa7G/OlrIyi+lS2b7WL8B/t47ZLxTWnkLxt/F9rAGze0bNEcPTC7d63/pwDvcdW4erksa7xAxE8526PH+zxTP455S80kY6cuKyYvZhRvcUW5+NR60CkHk8X0ZC55elm7L2vL+IdodI8Di3EFL7l2xncVYS+d0ZlBg+Z7cqVx+0rXjBG7AlxY/v9ek62tG10TvStJBEcZn1mXrEBcsqxUq3rNos7moesswmybwtKgObc+XuE1k/GCzuBzpl6QbZn6x5NtU2lLWOKw3U+HY2c6PKE0c2jM8pCYUGsEaTyUJ60roasqKCwnRUu8U/QuJ+x5ujuOIRAh2WAp2oChQDVaKGodl9OA1314LemIar3Rr9EIVa0LeRFIBl+BLjNksktZY4xzxI/Km0d2uBkiVi2wiznsVJJ9lyFFKT0lA2t65IuoIenM8NseYDqLlcM6ipnc4Zr8H/4ie25EZhzH4pCCQhygxPP4PdyXL8cvFGKDXUyPuMUmlUz4cQhM5PA8cSFZ39KIDo06iLUBzaCR0cBuVzPW1eGoIXZ6Lzqfu3ETRjGH3fQSkwVufMiO9PDgOBeGAnyKABgS1nmY5SxuhSmJht4zGYbRL0SuQPjUQNrnTB3CkgDYPi7RUOwOiulGcZ7w7TquKpr0QOdmInESguGMc5z0Z0Wku/5oA/7iLtU18Pl7nzaPtfcP6kOHvWt/UnRLObAaKh0ZMAQkYTbwsuvE4n4dVbx8s3/oXQEi0JimrUkEebmumnj7GuRJ+a+zeDBpvuNnOMEERUyXpPhn3JcyxFjCF/IPICdfAGg9zjjZaaUKduSro6+zPSud7xL8YsP9Tn6cH3bLCoMsn1stnMidGIIb/EfNGY4LBvb6IQYpRhH4cF2pqXbygqPTVLLoURLzeQSVxRdl3Imt7LUFTMY1/1Ct4X7QlPZWiFBmzu/PN4/U6gD78sOLpZGoZWAnYH1A8cYHMuP3I4JjTtZpg0k9RmrCMyVRGEFVxbtisT+HtjVnmWkV8U/FdLFqnA/NJMYm9vpCeXPSr0P8RXfd8bUmRAHRzD30eWDjymawia9JBojIInQno8J+Ti9K9LOHT0ws+d5WNFGm/JeAOr3x8PJrpLbtzf+hDvEwdG3+Ipmz/DezA5Ma179FwlUyWiGuK4Kbh+m2758uJWAwVw3I7+cA+/xD9NJRs9EnF68XP+zmHmqflrcXbuWjsCGYs9U+62tzyhtYRfSRDhW7eq/hHGo+cJwB0QyiURd471cZx9Lv1ou11EUCWz3ew3FU+w4ExAZX/Z4Yi6msKML3k665NYOzU6A/z556yVJnuFFxlGPX3O9aaAHX2w25N3doCuAryB58hE4KUAIr3thhgtR3+DRsQvNPTEtaOgGK+Nmqccz52+LWjhYfXXW+slb+gWJAMwk/mIoWTZFCldfbGgFHVi41YK7t/r96H3bUxTN4GlLdDcPZ2+6xSe3tf6gLKU3yk3b9jUdU6SMC+Fb25sYXiHxCPq5X/f8n031uIHrABEMg1JN7RnW/Rrkqr6d4vpdHSQKHtKkCawE8WLhpcBcO4ia5eyX/DsalM48zX/PQIc4LUCrgEW3i4bAUjd0S7pgufF1vsJCNeqbKwVBwvWPNu5OeQbIFznVg2VAPolkD4AAQewnQmJYa0E/tNWKNSxzDKrJ30TewPSv9g09oiC9H+pYhqV34XHdSInDJTFkXS0kHNiULs1AJ1VtAX/p8wkTRa1bFYRZwSXyZvm4g95tTCfERsKrg9z6qWN3eW5j/JVSeb8KwUP70KgpX3pBAQEqxgoaaQE/IqENwfv0z8IJYihPzFBtcHADrHGZAxPFu9o+Zd2d7G3glpdT5uYa9ReoBgtMmdTwFufOa5yhyptPXOc+yptMK+CFk2Moq6T6XyVkBoLcxzjSSUhgwQIYt8wCGs/1+su2sAKf4yv5zqOM53Oe+SYh7cfJiJXQU23ckIajnZBySR0FuNWudLfAAY/CAIw5yfYDstLF1gOReO01JCh+f56EhZ9+eF2WRwo6Bi9JG7iS0qz0Xqu9OA90+nzsW76tAvLk/dhuFtYLUxHxpltvtSFWCEL4vaZyn2YtV/y+v2YE6eMsxah4a4n9/dztsbcwLCvDQ==" />
+<form method="post" action="./15" id="aspnetForm" class="form-horizontal">
+<input type="hidden" name="ctl00_ctl00_RadScriptManager1_TSM" id="ctl00_ctl00_RadScriptManager1_TSM" value="" />
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKLTUyNTYxMDM4OGQYAQUeX19Db250cm9sc1JlcXVpcmVQb3N0QmFja0tleV9fFgMFEmN0bDAwJGN0bDAwJHJkb1NDRAUVY3RsMDAkY3RsMDAkcmRvRG9ja2V0BRVjdGwwMCRjdGwwMCRyZG9Eb2NrZXQ4F2GhrmcfLit/5YryKy+I6t/8FIY+5diW60gX4BQXWA==" />
+
+
+<script src="/ScriptResource.axd?d=_BWakfwwT2jhiTrQjTSYbO3M095QPfg77rLRHl9L_B4HueCpSl8U5nj8FVs3ia15GiSxQlmNNCEwqYB0FRnrFYnL_u2XqwJZZNFUYhhG38ndESmRRmv8cdx08yEeGwStqJT4E36-FqPmtjH0zkJQ1Q3nxB4kKb4D8LiQLUqknzY1&amp;t=5f9d5645" type="text/javascript"></script>
+<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="06DA2503" />
+<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEdAAgnL0yB1uLCgBCCcspuszmOdcLA2cVr55mmAI/xV+qwRAMiFNqFT7E2zKelBoXU3xbDDU+RV/jOi+vSugvNJrSXAeQgnDYEcS/A3pq4nSD4D0Ddcr9W1vG3+GTAwlOJUM51PENixjB8uIhh9HSYVMY8+wKGv+b7jvKFRjdrgci1SRrnOWWMCiBx5Nak4R+oYApAj0VONWB3SX1tw3XV4JoH" />
+    <div class="noindex">
+
+    </div>
+	<div class="container well well-lg">
+            <div class="noindex">
+			    <div class="row bannerStyle">
+				    <div class="col-md-6 col-xs-12">
+                         <a id="ctl00_ctl00_hypSealLink" href="../../"><img id="ctl00_ctl00_imgSeal" class="SCUSSeal" src="../../images/banner_h120.jpg" alt="Supreme Court of the United States" /></a>
+				    </div>
+				    <div class="col-md-6 col-xs-12" style="font-size: 9pt;">
+					    <div class="Div1">
+                            <a id="ctl00_ctl00_wucBannerMenu_Hyperlink42" href="../../visiting/visiting.aspx">Visiting the Court</a> &nbsp;|&nbsp;
+        <a id="ctl00_ctl00_wucBannerMenu_Hyperlink53" href="../../visiting/touringthebuilding.aspx">Touring the Building</a> &nbsp;|&nbsp;
+        <a id="ctl00_ctl00_wucBannerMenu_Hyperlink1" href="../../visiting/exhibition.aspx">Exhibitions</a>
+					    </div>
+					    <div class="pull-right search">
+						    <div id="ctl00_ctl00_pnlSearch">
+
+                                <table>
+							        <tr>
+                                        <td>
+                                            <span id="ctl00_ctl00_lblSearchOn"><b>Search: </b></span>&nbsp;
+                                            <span title="Radio button - Search All Documents"><input id="ctl00_ctl00_rdoSCD" type="radio" name="ctl00$ctl00$USSC" value="rdoSCD" checked="checked" /><label for="ctl00_ctl00_rdoSCD">All Documents</label></span>
+                                            <span title="Radio Button - Search Docket"><input id="ctl00_ctl00_rdoDocket" type="radio" name="ctl00$ctl00$USSC" value="rdoDocket" /><label for="ctl00_ctl00_rdoDocket">Docket</label></span>
+					    <a id="ctl00_ctl00_SearchCenter" href="../../search_center.aspx" style="font-size:small; float:right">Advanced Search</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+							            <td>
+                                            <span id="ctl00_ctl00_lblForDocuments"><b>Enter Search Text:</b></span>
+                                            <input name="ctl00$ctl00$txtSearch" type="text" id="ctl00_ctl00_txtSearch" /><input name="ctl00$ctl00$txbhidden" type="text" id="ctl00_ctl00_txbhidden" style="visibility: hidden; display: none;" />&nbsp;
+                                            <input type="submit" name="ctl00$ctl00$cmdSearch" value="Search" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdSearch&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_cmdSearch" title="Perform quick search" /> &nbsp;
+                                            <input type="submit" name="ctl00$ctl00$cmdHelp" value="Help" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdHelp&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_cmdHelp" title="Search help tips" /><br />
+
+                                                &nbsp;
+
+
+                                            &nbsp;
+                                        </td>
+                                    </tr>
+                                </table>
+
 </div>
+					    </div>
+				    </div>
+			    </div>
+			    <div class="row" style="margin-bottom: 5px; margin-top: 5px;">
+				    <div class="col-lg-10 col-md-10">
+					    <div id="sitemappath">
+					        <span id="ctl00_ctl00_SiteMapPath1"><font color="#ED0303"><a href="#ctl00_ctl00_SiteMapPath1_SkipLink"><img alt="Skip Navigation Links" src="/WebResource.axd?d=WLY2oepp1eKPePERXTuqUau_buIJz5S7ntqiGL3pUm39ydKxNwryN9m5LqCjmtlpSPkXXzclABxfMGVVXMTu6J6S8rDd4o05EnrXXVm10l81&amp;t=635802997220000000" width="0" height="0" border="0" /></a><span><font color="Red"><span><a title='Supreme Court Home' href='/' style='color:#507CD1;font-weight:bold;'>Home</a></span><span style='color:#507CD1;font-weight:bold;'> | </span><span><a title='Opinions' href='/opinions/opinions.aspx' style='color:#284E98;font-weight:bold;'>Opinions</a></span><span style='color:#507CD1;font-weight:bold;'> | </span><span style='color:Red;font-weight:bold;'>2015 Term Opinions Relating to Orders</span></font></span><a id="ctl00_ctl00_SiteMapPath1_SkipLink"></a></font></span>
+				        </div>
+				    </div>
+                    <div class="col-lg-2 col-md-2 text-right">
 
-<script type="text/javascript">
-    //<![CDATA[
-    var theForm = document.forms['aspnetForm'];
-    if (!theForm) {
-        theForm = document.aspnetForm;
-    }
-    function __doPostBack(eventTarget, eventArgument) {
-        if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
-            theForm.__EVENTTARGET.value = eventTarget;
-            theForm.__EVENTARGUMENT.value = eventArgument;
-            theForm.submit();
-        }
-    }
-    //]]>
-</script>
+                    </div>
+			    </div>
+			    <div class="navbar navbar-inverse" role="navigation">
+				    <div class="container-fluid">
+						    <!-- menu starts here -->
 
-
-<script src="/WebResource.axd?d=rCyPEAmf29aK8BeFRIEhbXldpW7f-asSrfmAnr28XnQjOTQwUjmGvIHJCJJm4v7IJZkG4ax3TsVfNP3Zfj1Xy2r1tfA1&amp;t=635091451369243374" type="text/javascript"></script>
-
-
-<script src="/ScriptResource.axd?d=mj2dFicu5g65fMBa8AJDXUtDMHYVnxq3amfRp6jYM8JyIGCswNaJPhOpobKdZRwSb9w7Y6a5sGP3yHxprm7YZjRk2JYFIyum_b3d30kwDOUfuytrvwakamehBT7QZ7FzfNq0x3QqLKaSE5zf8WotF5nDR5k1&amp;t=6e12bb04" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=xEdKPjj3pDPKNfnZguzNH_04EyP2FCYqDDKgnfLCAkZYTziAJbfWr3_Ej_IPRYypdiIfvpQhHQ7F9p86HJHd0nIW6CD_DzYTHX16ei5_joydAqS-txNMDaM-ury3ac_U_sdiD-sca4X1I5iwJpVUuzGBlaw-21Zg2xePQC0qTsgR3YT30&amp;t=79a50c3f" type="text/javascript"></script>
-<script src="/ScriptResource.axd?d=-1iQ2WcP2s9NWfKKUi9b6m1_4OYBd4w31KIprGEVFv_RHcxIF1RUeZK2lKoVvvOGMv5MiSynUBzh_MhoFIGA6bGC74mX1V8R3e7DXITahbg0Ghdvaf393nk5CzWUokUychNb-HiEAJOfHvIaJ4Zb5GYa5VCIcEKhzD9x5_MCB6r6_zMP0&amp;t=79a50c3f" type="text/javascript"></script>
-<script src="/WebResource.axd?d=bx8Y0YOs1kS7XLiLwKdln58vZzO1KZjuzg66fdi-49BbSUjUbJEunNAKfaT6TMdZgTLs2yhcRZwXP9vQSRETylSd6D81&amp;t=635091451369243374" type="text/javascript"></script>
-<script type="text/javascript">
-    //<![CDATA[
-    function WebForm_OnSubmit() {
-        if (typeof(ValidatorOnSubmit) == "function" && ValidatorOnSubmit() == false) return false;
-        return true;
-    }
-    //]]>
-</script>
-
-<div>
-
-    <input type="hidden" name="__VIEWSTATEENCRYPTED" id="__VIEWSTATEENCRYPTED" value="" />
-    <input type="hidden" name="__PREVIOUSPAGE" id="__PREVIOUSPAGE" value="SqOe8CWz5ilkN6RrDeBCfWsijlRDGpzxjxJxrE9L_4jBil5D1oyQdFo6asvAtzBa5huTnUz-Wkz0hm8tGz2kw5U-Du1Hw-TOVwTlLuejbZnbrqOc0" />
-    <input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="7VjNgPwhyhPJDm5zhM23FH+7WFyX5Is+D1T6ajpUxsbUP82ByclczJXxwOaunkLe/vIGYoG7FT/ov38/aMiyJAWcf+Sox22AWWdUy0/ZUWczvArjrIEbkAL6PnZIyuxF5e/EBJL65Y9/BvRjiiWJLi5E4lTP7M7HcbNUy0nWeB+oE4SV" />
+<div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+    </button>
 </div>
+<div class="navbar-collapse collapse">
+    <ul class="nav navbar-nav">
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_HyperLink5" class="dropdown-toggle" href="../opinions.aspx">Opinions</a>
+                <ul class="dropdown-menu">
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink30" href="../slipopinion/15">Latest Slip Opinions</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink31" href="15">Opinions Relating to Orders</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink32" href="../in-chambers/15">In-Chambers Opinions</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink1" href="../opinions.aspx">Slip opinions - Earlier Terms</a></li>
+                    <!-- li><a id="ctl00_ctl00_wucNewMenu1_HyperLink34" href="../counsellist.aspx">Counsel Listings</a></li -->
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink35" href="../boundvolumes.aspx">Bound Volumes</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink36" href="../../media/media.aspx">Media Files Related to Opinions</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink37" href="../Cited_URL_List.aspx">Internet Sources Cited in Opinions</a></li>
+                    <li>&nbsp;</li>
+                </ul>
+        </li>
+        <li class="dropdown"><a id="ctl00_ctl00_wucNewMenu1_hl" class="dropdown-toggle" href="../../oral_arguments/oral_arguments.aspx">Oral Arguments</a>
+                <ul class="dropdown-menu">
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink23" href="../../oral_arguments/2016TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2016)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink15" href="../../oral_arguments/2015TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2015)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink9" href="../../oral_arguments/2014termcourtcalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2014)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink8" href="../../oral_arguments/2013TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2013)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink10" href="../../oral_arguments/argument_calendars.aspx">Argument Calendars</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink11" href="../../oral_arguments/hearinglist.aspx">Hearing Lists</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink12" href="../../visiting/visitorsguidetooralargument.aspx">Visitor's Guide to Oral Argument</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink13" href="../../oral_arguments/argument_transcript.aspx">Argument Transcripts</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink14" href="../../oral_arguments/argument_audio.aspx">Argument Audio</a></li>
+                    <li>&nbsp;</li>
+                </ul>
+        </li>
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_HyperLink41" class="dropdown-toggle" href="../../case_documents.aspx">Case Documents</a>
+                <ul class="dropdown-menu">
+                    <li><a id="ctl00_ctl00_wucNewMenu1_hldocket" href="../../docket/docket.aspx">Docket Search</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink18" href="../../redirect.aspx?newURL=www.americanbar.org/publications/preview_home/alphabetical.html">On-Line MERITS BRIEFS</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink17" href="../../oral_arguments/briefsource.aspx">Where to Find Briefs</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_hypOrdersOfCourt" href="../../orders/ordersofthecourt/15">Orders of the Court - 2015 Term</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink43" href="../../orders/orders.aspx#Orders">Orders - Earlier Term</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink67" href="../../orders/orders.aspx#OrdersByCircuit">Orders by Circuit</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink68" href="../../orders/orders.aspx#GrantedNotedCases">Granted/Noted Cases List</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink39" href="../../orders/journal.aspx">Journal</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink7" href="../../SpecMastRpt/SpecMastRpt.aspx">Special Master Reports</a></li>
+                    <li>&nbsp;</li>
+                </ul>
+        </li>
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_HyperLink69" class="dropdown-toggle" href="../../rules_guidance.aspx">Rules & Guidance</a>
+            <ul class="dropdown-menu">
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink3" href="../../ctrules/ctrules.aspx">Court Rules</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink4" href="../../casehand/casehand.aspx">Guides for Counsel</a>
+                    <ul class="dropdown-menu sub-menu">
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink26" href="../../casehand/guidetofilingpaidcases2014.pdf" target="_blank">Guide to Filing Paid Cases (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink6" href="../../casehand/courtspecchart02162010.aspx">Paid Cases Brief Chart</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink27" href="../../casehand/guideforifpcases2014.pdf" target="_blank">Guide to Filing <i>In Forma Pauperis</i> Cases (PDF) </a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink28" href="../../casehand/guideforcounsel.pdf" target="_blank">Guide for Counsel in Cases to be Argued (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink29" href="../../oral_arguments/2010ElectronicMeritsBriefsSubmissionGuidelines.pdf" target="_blank">Electronic Merits Briefs Submission Guidelines (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink16" href="../../deliveryofdocuments.aspx">Delivery of Documents to the Clerk's Office</a></li>
+                    </ul>
+                </li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink2" href="../../bar/baradmissions.aspx">Supreme Court Bar</a>
+                    <ul class="dropdown-menu sub-menu">
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink20" href="../../bar/barinstructions.pdf" target="_blank">Bar Admissions Instructions (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink19" href="../../bar/barapplication.pdf" target="_blank">Bar Admissions Forms (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink21" href="../../bar/smallGroups_ArguDays_instr.pdf" target="_blank">Small Group Admissions - Argument Days (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink22" href="../../bar/largeGroups_NonArgument_Instr.pdf" target="_blank">Large Group Admissions - Nonargument Days (PDF)</a></li>
+                    </ul>
+                </li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HypCaseDistribution" href="../../casedistribution/casedistributionschedule.aspx">Case Distribution Schedule</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink40" href="../../casehand/waiver.pdf" target="_blank">Waiver Form (PDF)</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink70" href="../../orders/courtorders/ALLOTMENTORDER9-28-10.pdf" target="_blank">Circuit Assignments of Justices</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink71" href="../../about/Circuit%20Map.pdf" target="_blank">&nbsp;&nbsp;&nbsp;&nbsp; - Circuit Map</a></li>
+                <li>&nbsp;</li>
+            </ul>
+        </li>
+
+            <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_hypCourtInfo" class="dropdown-toggle" href="../../publicinfo/publicinfo.aspx">News Media</a>
+            <ul class="dropdown-menu">
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink57" href="../../publicinfo/press/pressreleases.aspx">Press Releases</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink58" href="../../publicinfo/media/mediaadvisories.aspx">Media Advisories</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink61" href="../../publicinfo/press/presscredentials.aspx">Press Credentials</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink62" href="../../publicinfo/reportersguide.pdf" target="_blank">A Reporter's Guide to Applications (PDF)</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink59" href="../../publicinfo/speeches/speeches.aspx">Speeches</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink60" href="../../publicinfo/year-end/year-endreports.aspx">Chief Justice's Year-End Reports on the Federal Judiciary</a></li>
+                <li>&nbsp;</li>
+            </ul>
+        </li>
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_hypAboutCourt" class="dropdown-toggle" href="../../about/about.aspx">About the Court</a>
+            <ul class="dropdown-menu">
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink46" href="../../about/briefoverview.aspx">Brief Overview</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink47" href="../../about/biographies.aspx">Biographies of Current Justices</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink48" href="../../about/members.aspx">Justices 1789 to Present</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink49" href="../../about/courtbuilding.aspx">The Supreme Court Building</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink45" href="../../redirect.aspx?federal=y&amp;newURL=www.archives.gov/historical-docs/document.html?doc=3&amp;title.raw=Constitution%252">Constitution</a></li>
+                <li>&nbsp;</li>
+            </ul>
+        </li>
+    </ul>
+</div>
+						    <!-- menu ends here -->
+				    </div>
+			    </div>
+            </div>
+			<div class="row">
+				<div class="col-lg-12 col-md-12 col-sm-12" id="mainbody">
+
+
+<div class="col-sm-12 sectiontitle">
+    <div id="sectionbanner5">
+	    <div id="pagetitle">
+		    <h3><span id="ctl00_ctl00_MainEditable_mainContent_lblTitle"><b>2015 Term Opinions Relating to Orders</b></span></h3>
+	    </div>
+    </div>
+</div>
+<br />
+
+<p>The opinions included here are those written by individual Justices to comment on the summary
+disposition of cases by orders. Such an opinion might, for example, dissent from the denial of
+certiorari or concur in that denial. The opinions here include those written during
+<span id="ctl00_ctl00_MainEditable_mainContent_lblTerms">October Term 2015 (October 5, 2015, through October 2, 2016)</span>. These opinions were posted here on the day of
+their issuance. They will remain posted until the opinions for the entire Term are published in
+the bound volumes of the United States Reports. For further information, see <a id="ctl00_ctl00_MainEditable_mainContent_lbnDefB" href="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$MainEditable$mainContent$lbnDefB&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, true))">Column Header Definitions</a>.</p>
+
+<p><b>Caution:</b> These electronic opinions may contain computer-generated errors or other
+deviations from the official paper versions of the opinions. Moreover, the original version of an
+opinion relating to an order is replaced by a paginated version of the opinion
+in the preliminary print, and, subsequently, by the final version of the
+case in a U.S. Reports bound volume.  In case of discrepancies between the print and electronic versions of an
+opinion relating to an order, the print version controls.
+However, where the electronic version has been designated “revised,” the electronic
+version controls to the extent that it differs from the print version with regard to the noted revision.
+In case of discrepancies between the initial print version or electronic version of an opinion relating
+to an order and any later official version of the opinion—<i>i.e.</i>, the preliminary print or bound volume
+versions—the later version controls.
+</p>
+
 <center>
-<div id="wrapper">
-<script type="text/javascript">
-    //<![CDATA[
-    Sys.WebForms.PageRequestManager._initialize('ctl00$ctl00$ScriptManager1', document.getElementById('aspnetForm'));
-    Sys.WebForms.PageRequestManager.getInstance()._updateControls(['tctl00$ctl00$upSearchBox'], [], [], 90);
-    //]]>
-</script>
 
-<!-- hidden banner for print -->
-<div id="hidden">
-    <input type="image" name="ctl00$ctl00$ibtHiddenSeal" id="ctl00_ctl00_ibtHiddenSeal" title="Supreme Court of the United States" src="../images/supremecourt_seal_pr.gif" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$ibtHiddenSeal&quot;, &quot;&quot;, true, &quot;&quot;, &quot;../default.aspx&quot;, false, false))" style="border-width:0px;" />
-</div>
-<!-- banner -->
-<div id="banner">
-    <div id="supremecourt_seal"><a name="top"></a><a href='/default.aspx'><img id="ctl00_ctl00_ibtseal" title="Supreme Court of the United States" src="../images/banner_seal2.gif" style="border-width:0px;" /></a></div>
-    <div id="banner_right">
-        <div id="ctl00_ctl00_pnlspacer" style="height:27px;">
+		<table class="table table-bordered" style="text-align: left;" cellspacing="0" cellpadding="2">
+			<tr>
+			<th style="text-align: center;" width="60" scope="col">Date</th>
+			<th style="text-align: center;" width="60" scope="col">Docket</th>
+			<th style="text-align: center;" width="360" scope="col">Name</th>
+<th style="text-align: center;" width="60" scope="col">Revised</th>
 
+			<th style="text-align: center;" width="20" scope="col">J.</th>
+			<th style="text-align: center;" width="40" scope="col">Pt.</th>
+			</tr>
 
-            <img id="ctl00_ctl00_imgclear" src="../images/clearpixel.gif" alt="spacer" style="height:25px;border-width:0px;" />
+			<tr>
+				<td style="text-align: center;">1/21/16</td>
+				<td style="text-align: center;">15-7786</td>
+				<td><a href='/opinions/15pdf/15-7786_n7io.pdf' target='_blank'>Brooks v. Alabama</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+                <td style="text-align: center;">SS</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
 
-        </div>
-        <div id="searchbox">
-            <div id="ctl00_ctl00_pnlSearch" style="height:65px;margin-left: 0px">
+			<tr>
+				<td style="text-align: center;">1/21/16</td>
+				<td style="text-align: center;">15-7786</td>
+				<td><a href='/opinions/15pdf/15-7786_n7io.pdf#page=2' target='_blank'>Brooks v. Alabama</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+                <td style="text-align: center;">B</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
 
-                <span id="ctl00_ctl00_lblSearchOn" style="font-weight:bold;">Search: </span>
-                <span title="Radio button - Search All Documents"><input id="ctl00_ctl00_rdoSCD" type="radio" name="ctl00$ctl00$USSC" value="rdoSCD" checked="checked" /><label for="ctl00_ctl00_rdoSCD">All Documents</label></span>
-                <span title="Radio Button - Search Docket Files"><input id="ctl00_ctl00_rdoDocket" type="radio" name="ctl00$ctl00$USSC" value="rdoDocket" /><label for="ctl00_ctl00_rdoDocket">Docket Files</label></span>
-                <br />
-                <span id="ctl00_ctl00_lblForDocuments" style="font-weight:bold;">For Search Term:</span>
-                &nbsp;
-                <input name="ctl00$ctl00$txtSearch" type="text" id="ctl00_ctl00_txtSearch" style="font-size:8pt;width:180px;margin-left: 0px" />
-                <input name="ctl00$ctl00$txbhidden" type="text" id="ctl00_ctl00_txbhidden" style="visibility: hidden; display: none;" />
-                <br />
-                <span id="ctl00_ctl00_SearchVal" style="display:inline-block;color:Red;height:20px;visibility:hidden;">Invalid text in search term. Try again</span>
-                <input type="submit" name="ctl00$ctl00$cmdSearch" value="Search" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdSearch&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_cmdSearch" title="Perform quick search" style="font-size:8pt;height:21px;" />
-                &nbsp;
-                <input type="submit" name="ctl00$ctl00$cmdHelp" value="Help" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdHelp&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_cmdHelp" title="Search help tips" style="font-size:8pt;height:21px;" />
+			<tr>
+				<td style="text-align: center;">12/07/15</td>
+				<td style="text-align: center;">15-133</td>
+				<td><a href='/opinions/15pdf/15-133_7l48.pdf' target='_blank'>Friedman v. Highland Park</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+                <td style="text-align: center;">T</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
 
-            </div>
-        </div>
-    </div>
-</div>
+			<tr>
+				<td style="text-align: center;">11/30/15</td>
+				<td style="text-align: center;">15-161</td>
+				<td><a href='/opinions/15pdf/15-161_h315.pdf' target='_blank'>Rapelje v. Blackston</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+                <td style="text-align: center;">AS</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
 
-<!-- banner bottom -->
-<div id="bannerbottom">
-    <div id="sitemappath">
-        <span id="ctl00_ctl00_SiteMapPath1" style="color:#ED0303;font-size:1em;"><a href="#ctl00_ctl00_SiteMapPath1_SkipLink"><img alt="Skip Navigation Links" height="0" width="0" src="/WebResource.axd?d=TxgnMbr7ckctIVqnqON2aZ4VG0sU5yvRunk8f2razbiWdo3avLGzWworzeUYVPVzUGUkqJ0lYE7uX2NxF8vdr-pc2Mk1&amp;t=635091451369243374" style="border-width:0px;" /></a><span><a title="Supreme Court Home" href="/default.aspx" style="color:#507CD1;font-weight:bold;">Home</a></span><span style="color:#507CD1;font-weight:bold;"> | </span><span><a title="Opinions" href="/opinions/opinions.aspx" style="color:#284E98;font-weight:bold;">Opinions</a></span><span style="color:#507CD1;font-weight:bold;"> | </span><span style="color:Red;font-weight:bold;"></span><span style="color:Red;">2012 Term Opinions Relating to Orders</span><a id="ctl00_ctl00_SiteMapPath1_SkipLink"></a></span>
-    </div>
-    <div id="bannerbottomright">
-        <div id="date">
-            <a href="javascript:PrintThisPage();"><img id="ctl00_ctl00_imgPrinter" title="Printer-Friendly" src="../images/printer1.gif" style="border-style:None;border-width:0px;" />
-                Printer-Friendly Version</a>
-        </div>
-    </div>
-</div>
-<!-- search update pannel -->
-<div id="searchboxpannel">
-    <div id="ctl00_ctl00_upSearchBox">
+			<tr>
+				<td style="text-align: center;">11/18/15</td>
+				<td style="text-align: center;">15-6956</td>
+				<td><a href='/opinions/15pdf/5p6959t_32q3.pdf' target='_blank'>Holiday v. Stephens</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+                <td style="text-align: center;">SS</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
 
-        <div id="searchwrap">
-            <div id="searchbox2" style="width: 100%">
-                <input type="submit" name="ctl00$ctl00$btnsearch" value="Show Search" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$btnsearch&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_btnsearch" />
-            </div>
-            <div id="searchbox3" style="display:block; float: right;">
+			<tr>
+				<td style="text-align: center;">11/16/15</td>
+				<td style="text-align: center;">14-1273</td>
+				<td><a href='/opinions/15pdf/14-1273_6j37.pdf' target='_blank'>New Hampshire Right to Life v. Department of Health and Human Services</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+                <td style="text-align: center;">T</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
 
-            </div>
-        </div>
+			<tr>
+				<td style="text-align: center;">10/29/2015</td>
+				<td style="text-align: center;">15-6551</td>
+				<td><a href='/opinions/15pdf/15-6551_c07d.pdf#page=2' target='_blank'>Correll v. Florida</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+                <td style="text-align: center;">SS</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
 
-    </div>
-</div>
-<div class="bnr-clear"></div>
+			<tr>
+				<td style="text-align: center;">10/29/2015</td>
+				<td style="text-align: center;">15-6551</td>
+				<td><a href='/opinions/15pdf/15-6551_c07d.pdf' target='_blank'>Correll v. Florida</a></td>
+				<td style='text-align: center;'><a href='/opinions/15pdf/15-6551_diff_1924.pdf' target='_blank'>10/30/15</a></td>
+                <td style="text-align: center;">B</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
 
-<!-- mid-section -->
-<div id="main">
+		</table>
 
-<div id="columntop"><img id="ctl00_ctl00_mainbody_imagetopcolumn2" alt="" src="../images/clearpixel.gif" style="height:7px;border-width:0px;" /></div>
-<div id="middleCol2">
-<div id="leftcolumn" class="noindex" style="z-index: 2;">
-<div id="leftmenu1" class="textbox">
-
-    <div class="menu1title">
-        <img id="ctl00_ctl00_mainbody_wucMenu1_imgTbDoc" src="../images/tb_documents.gif" alt="Supreme Court Document" style="border-width:0px;" />
-    </div>
-    <div style="display: block; z-index: 100;">
-        <div class="MainMenu">
-            <ul class="AspNet-Menu">
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_hlTdocket" class="MenuTier1" href="../docket/docket.aspx">Docket</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_hldocket" href="../docket/docket.aspx">Docket Search</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HypCaseDistribution" href="../casedistribution/casedistributionschedule.aspx">Case Distribution Schedule</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink7" href="../SpecMastRpt/SpecMastRpt.aspx">Special Master Reports</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_hl" class="MenuTier1" href="../oral_arguments/oral_arguments.aspx">Oral Arguments</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink8" href="../oral_arguments/2012TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2012)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink9" href="../oral_arguments/2013termcourtcalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2013)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink10" href="../oral_arguments/argument_calendars.aspx">Argument Calendars</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink11" href="../oral_arguments/hearinglist.aspx">Hearing Lists</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink12" href="../visiting/visitorsguidetooralargument.aspx">Visitor's Guide to Oral Argument</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink13" href="../oral_arguments/argument_transcripts.aspx">Argument Transcripts</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink14" href="../oral_arguments/argument_audio.aspx">Argument Audio</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink15" href="../oral_arguments/oral_arguments.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink1" class="MenuTier1" href="../meritsbriefs/meritsbriefs.aspx">Merits Briefs</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink16" href="../deliveryofdocuments.aspx">Delivery of Documents to the Clerk's Office</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink17" href="../oral_arguments/briefsource.aspx">Where to Find Briefs</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink18" href="../redirect.aspx?newURL=www.americanbar.org/publications/preview_home/alphabetical.html">On-Line MERITS BRIEFS</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink2" class="MenuTier1" href="../bar/baradmissions.aspx">Bar Admissions</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink19" href="../bar/barapplication.pdf">Bar Admissions Forms (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink20" href="../bar/barinstructions.pdf">Bar Admissions Instructions (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink21" href="../bar/smallGroups_ArguDays_instr.pdf" target="_blank">Argument Day Group Admissions (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink22" href="../bar/largeGroups_NonArgument_Instr.pdf" target="_blank">Large Group Admissions (PDF)</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink3" class="MenuTier1" href="../ctrules/ctrules.aspx">Court Rules</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink23" href="../ctrules/2013RulesoftheCourt.pdf" target="_blank">Rules of the Supreme Court (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink24" href="../ctrules/041913zr.pdf" target="_blank">Order Adopting Revised Rules (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink25" href="../ctrules/ctrules.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink4" class="MenuTier1" href="../casehand/casehand.aspx">Case Handling Guides</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink26" href="../casehand/guidetofilingpaidcases2012.pdf" target="_blank">Guide to Filing Paid Cases (2012) (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink27" href="../casehand/guideforifpcases2012.pdf" target="_blank">Guide to IFP Cases (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink28" href="../oral_arguments/guideforcounsel.pdf" target="_blank">Guide for Counsel (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink29" href="../casehand/casehand.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink5" class="MenuTier1" href="opinions.aspx">Opinions</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink30" href="slipopinions.aspx">Latest Slip Opinions</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink31" href="relatingtoorders.aspx">Opinions Relating to Orders</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink32" href="in-chambers.aspx">In-Chambers Opinions</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink33" href="sliplists.aspx">Sliplists</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink34" href="counsellist.aspx">Counsel Listings</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink35" href="boundvolumes.aspx">Bound Volumes</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink36" href="../media/media.aspx">Video Resources</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink37" href="opinions.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink6" class="MenuTier1" href="../orders/orders.aspx">Orders and Journals</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink38" href="../orders/ordersofthecourt.aspx">Orders of the Court</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink39" href="../orders/journal.aspx">Journal</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu1_HyperLink40" href="../orders/orders.aspx">More..</a></li>
-                    </ul>
-                </li>
-            </ul>
-        </div>
-    </div>
-    &nbsp;<br />
-
-
-    <div class="menu1title">
-        <img id="ctl00_ctl00_mainbody_wucMenu2_imgTbInfo" src="../images/tb_information.gif" alt="Supreme Court Information" style="border-width:0px;" />
-    </div>
-    <div style="display: block; z-index: 100;">
-        <div class="MainMenu">
-            <ul class="AspNet-Menu">
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink40" class="MenuTier1" href="../about/about.aspx">About the Supreme Court</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink45" href="../redirect.aspx?federal=y&amp;newURL=www.archives.gov/historical-docs/document.html?doc=3&amp;title.raw=Constitution%252">Constitution</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink46" href="../about/briefoverview.aspx">Brief Overview</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink47" href="../about/biographies.aspx">Biographies of Current Justices</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink48" href="../about/members.aspx">Members of the Supreme Court</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink49" href="../about/courtbuilding.aspx">The Supreme Court Building</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink50" href="../about/about.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink41" class="MenuTier1" href="../visiting/visiting.aspx">Visiting the Court</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink51" href="../visiting/visitorservices.aspx">Plan Your Visit</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_HyperLink1" href="../visiting/schoolgroups.aspx">School Groups</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink52" href="../visiting/touringthebuilding.aspx">Touring the Building</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink3" href="../visiting/exhibition.aspx">Exhibitions</a></li>
-
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink54" href="../visiting/map.pdf" target="_blank">Map (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink55" href="../visiting/foreigntranslations.aspx">Foreign Translations</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink56" href="../faq_visiting.aspx">FAQ on Visiting</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink4" href="../visiting/visiting.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink42" class="MenuTier1" href="../publicinfo/publicinfo.aspx">Public Information</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink57" href="../publicinfo/press/pressreleases.aspx">Press Releases</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink58" href="../publicinfo/media/mediaadvisories.aspx">Media Advisories</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink59" href="../publicinfo/speeches/speeches.aspx">Speeches</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink60" href="../publicinfo/year-end/year-endreports.aspx">Chief Justice's Year-End Reports on the Federal Judiciary</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink61" href="../publicinfo/modernization/home.aspx">Supreme Court Building Modernization Project</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink62" href="../publicinfo/reportersguide.pdf" target="_blank">A Reporter's Guide to Applications (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink63" href="../publicinfo/buildingregulations.aspx">Building Regulations</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink64" href="../publicinfo/phonenumbers.aspx">Helpful Telephone Numbers</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink65" href="../publicinfo/comments.aspx">Where to Send Comments</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink66" href="../problemwithoutofdateinfo.aspx">Problem with out of date information?</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink67" href="../publicinfo/publicinfo.aspx">More..</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink43" class="MenuTier1" href="../jobs/jobs.aspx">Jobs</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink68" href="../jobs/career/career.aspx">Career Opportunities</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink69" href="../fellows/default.aspx">Supreme Court Fellows Program</a></li>
-
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink71" href="../jobs/jip/jip.aspx">Judicial Internship Program</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink72" href="../jobs/docentprogram.pdf">Volunteer Docent Program (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink73" href="../jobs/curatorial_internship/InternshipInfoSheet.aspx">Curatorial Internship Program</a></li>
-                    </ul>
-                </li>
-                <li>
-                    <a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink44" class="MenuTier1" href="../links/links.aspx">Links</a>
-                    <ul class="Menu-Sub">
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink74" href="../redirect.aspx?federal=y&amp;newURL=www.uscourts.gov/">Administrative Office of the United States Courts</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink75" href="../redirect.aspx?federal=y&amp;newURL=www.fjc.gov">Federal Judicial Center</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink76" href="../redirect.aspx?federal=y&amp;newURL=www.ussc.gov">United States Sentencing Commission</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink77" href="../redirect.aspx?newURL=www.icivics.org">iCivics Web site (Educational & Student Friendly)</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink78" href="../fellows/default.aspx">Supreme Court Fellows Program</a></li>
-                        <li><a id="ctl00_ctl00_mainbody_wucMenu2_Hyperlink79" href="../links/links.aspx">More..</a></li>
-                    </ul>
-                </li>
-            </ul>
-        </div>
-    </div>
-    &nbsp;<br />
-
-</div>
-<div id="leftmenu2" class="textbox">
-    <h3 id="menu1H3Title"><a href="#">Supreme Court Documents</a></h3>
-    <div>
-
-        <div class="menu1title">
-            <img id="ctl00_ctl00_mainbody_wucMenu3_imgTbDoc" src="../images/tb_documents.gif" alt="Supreme Court Document" style="border-width:0px;" />
-        </div>
-        <div style="display: block; z-index: 100;">
-            <div class="MainMenu">
-                <ul class="AspNet-Menu">
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_hlTdocket" class="MenuTier1" href="../docket/docket.aspx">Docket</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_hldocket" href="../docket/docket.aspx">Docket Search</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HypCaseDistribution" href="../casedistribution/casedistributionschedule.aspx">Case Distribution Schedule</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink7" href="../SpecMastRpt/SpecMastRpt.aspx">Special Master Reports</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_hl" class="MenuTier1" href="../oral_arguments/oral_arguments.aspx">Oral Arguments</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink8" href="../oral_arguments/2012TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2012)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink9" href="../oral_arguments/2013termcourtcalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2013)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink10" href="../oral_arguments/argument_calendars.aspx">Argument Calendars</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink11" href="../oral_arguments/hearinglist.aspx">Hearing Lists</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink12" href="../visiting/visitorsguidetooralargument.aspx">Visitor's Guide to Oral Argument</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink13" href="../oral_arguments/argument_transcripts.aspx">Argument Transcripts</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink14" href="../oral_arguments/argument_audio.aspx">Argument Audio</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink15" href="../oral_arguments/oral_arguments.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink1" class="MenuTier1" href="../meritsbriefs/meritsbriefs.aspx">Merits Briefs</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink16" href="../deliveryofdocuments.aspx">Delivery of Documents to the Clerk's Office</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink17" href="../oral_arguments/briefsource.aspx">Where to Find Briefs</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink18" href="../redirect.aspx?newURL=www.americanbar.org/publications/preview_home/alphabetical.html">On-Line MERITS BRIEFS</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink2" class="MenuTier1" href="../bar/baradmissions.aspx">Bar Admissions</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink19" href="../bar/barapplication.pdf">Bar Admissions Forms (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink20" href="../bar/barinstructions.pdf">Bar Admissions Instructions (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink21" href="../bar/smallGroups_ArguDays_instr.pdf" target="_blank">Argument Day Group Admissions (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink22" href="../bar/largeGroups_NonArgument_Instr.pdf" target="_blank">Large Group Admissions (PDF)</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink3" class="MenuTier1" href="../ctrules/ctrules.aspx">Court Rules</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink23" href="../ctrules/2013RulesoftheCourt.pdf" target="_blank">Rules of the Supreme Court (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink24" href="../ctrules/041913zr.pdf" target="_blank">Order Adopting Revised Rules (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink25" href="../ctrules/ctrules.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink4" class="MenuTier1" href="../casehand/casehand.aspx">Case Handling Guides</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink26" href="../casehand/guidetofilingpaidcases2012.pdf" target="_blank">Guide to Filing Paid Cases (2012) (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink27" href="../casehand/guideforifpcases2012.pdf" target="_blank">Guide to IFP Cases (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink28" href="../oral_arguments/guideforcounsel.pdf" target="_blank">Guide for Counsel (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink29" href="../casehand/casehand.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink5" class="MenuTier1" href="opinions.aspx">Opinions</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink30" href="slipopinions.aspx">Latest Slip Opinions</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink31" href="relatingtoorders.aspx">Opinions Relating to Orders</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink32" href="in-chambers.aspx">In-Chambers Opinions</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink33" href="sliplists.aspx">Sliplists</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink34" href="counsellist.aspx">Counsel Listings</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink35" href="boundvolumes.aspx">Bound Volumes</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink36" href="../media/media.aspx">Video Resources</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink37" href="opinions.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink6" class="MenuTier1" href="../orders/orders.aspx">Orders and Journals</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink38" href="../orders/ordersofthecourt.aspx">Orders of the Court</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink39" href="../orders/journal.aspx">Journal</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu3_HyperLink40" href="../orders/orders.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                </ul>
-            </div>
-        </div>
-        &nbsp;<br />
-    </div>
-    <h3 id="menu2H3Title"><a href="#">Supreme Court Information</a></h3>
-    <div>
-
-        <div class="menu1title">
-            <img id="ctl00_ctl00_mainbody_wucMenu4_imgTbInfo" src="../images/tb_information.gif" alt="Supreme Court Information" style="border-width:0px;" />
-        </div>
-        <div style="display: block; z-index: 100;">
-            <div class="MainMenu">
-                <ul class="AspNet-Menu">
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink40" class="MenuTier1" href="../about/about.aspx">About the Supreme Court</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink45" href="../redirect.aspx?federal=y&amp;newURL=www.archives.gov/historical-docs/document.html?doc=3&amp;title.raw=Constitution%252">Constitution</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink46" href="../about/briefoverview.aspx">Brief Overview</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink47" href="../about/biographies.aspx">Biographies of Current Justices</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink48" href="../about/members.aspx">Members of the Supreme Court</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink49" href="../about/courtbuilding.aspx">The Supreme Court Building</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink50" href="../about/about.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink41" class="MenuTier1" href="../visiting/visiting.aspx">Visiting the Court</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink51" href="../visiting/visitorservices.aspx">Plan Your Visit</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_HyperLink1" href="../visiting/schoolgroups.aspx">School Groups</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink52" href="../visiting/touringthebuilding.aspx">Touring the Building</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink3" href="../visiting/exhibition.aspx">Exhibitions</a></li>
-
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink54" href="../visiting/map.pdf" target="_blank">Map (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink55" href="../visiting/foreigntranslations.aspx">Foreign Translations</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink56" href="../faq_visiting.aspx">FAQ on Visiting</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink4" href="../visiting/visiting.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink42" class="MenuTier1" href="../publicinfo/publicinfo.aspx">Public Information</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink57" href="../publicinfo/press/pressreleases.aspx">Press Releases</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink58" href="../publicinfo/media/mediaadvisories.aspx">Media Advisories</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink59" href="../publicinfo/speeches/speeches.aspx">Speeches</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink60" href="../publicinfo/year-end/year-endreports.aspx">Chief Justice's Year-End Reports on the Federal Judiciary</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink61" href="../publicinfo/modernization/home.aspx">Supreme Court Building Modernization Project</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink62" href="../publicinfo/reportersguide.pdf" target="_blank">A Reporter's Guide to Applications (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink63" href="../publicinfo/buildingregulations.aspx">Building Regulations</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink64" href="../publicinfo/phonenumbers.aspx">Helpful Telephone Numbers</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink65" href="../publicinfo/comments.aspx">Where to Send Comments</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink66" href="../problemwithoutofdateinfo.aspx">Problem with out of date information?</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink67" href="../publicinfo/publicinfo.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink43" class="MenuTier1" href="../jobs/jobs.aspx">Jobs</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink68" href="../jobs/career/career.aspx">Career Opportunities</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink69" href="../fellows/default.aspx">Supreme Court Fellows Program</a></li>
-
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink71" href="../jobs/jip/jip.aspx">Judicial Internship Program</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink72" href="../jobs/docentprogram.pdf">Volunteer Docent Program (PDF)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink73" href="../jobs/curatorial_internship/InternshipInfoSheet.aspx">Curatorial Internship Program</a></li>
-                        </ul>
-                    </li>
-                    <li>
-                        <a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink44" class="MenuTier1" href="../links/links.aspx">Links</a>
-                        <ul class="Menu-Sub">
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink74" href="../redirect.aspx?federal=y&amp;newURL=www.uscourts.gov/">Administrative Office of the United States Courts</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink75" href="../redirect.aspx?federal=y&amp;newURL=www.fjc.gov">Federal Judicial Center</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink76" href="../redirect.aspx?federal=y&amp;newURL=www.ussc.gov">United States Sentencing Commission</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink77" href="../redirect.aspx?newURL=www.icivics.org">iCivics Web site (Educational & Student Friendly)</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink78" href="../fellows/default.aspx">Supreme Court Fellows Program</a></li>
-                            <li><a id="ctl00_ctl00_mainbody_wucMenu4_Hyperlink79" href="../links/links.aspx">More..</a></li>
-                        </ul>
-                    </li>
-                </ul>
-            </div>
-        </div>
-        &nbsp;<br />
-    </div>
-</div>
-</div>
-<div id="maincolumn" style="z-index: 1;">
-    <div class="textbox4">
-        <div id="maincontentbox">
-
-
-            <div id="sectionbanner5">
-                <div id="pagetitle">
-                    <h3><span id="ctl00_ctl00_mainbody_mainContent_lblTitle" style="font-weight:bold;">2012 Term Opinions Relating to Orders</span></h3>
-                </div>
-            </div>
-            <br />
-
-            <p>The opinions included here are those written by individual Justices to comment on the summary
-                disposition of cases by orders. Such an opinion might, for example, dissent from the denial of
-                certiorari or concur in that denial. The opinions here include those written during
-                <span id="ctl00_ctl00_mainbody_mainContent_lblTerms">October Term 2012 (October 1, 2012, through October 6, 2013)</span>. These opinions were posted here on the day of
-                their issuance. They will remain posted until the opinions for the entire Term are published in
-                the bound volumes of the United States Reports. For further information, see <a id="ctl00_ctl00_mainbody_mainContent_lbnDefB" href="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$mainbody$mainContent$lbnDefB&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, true))">Column Header Definitions</a>.</p>
-
-            <p><b>Caution:</b> These electronic opinions may contain computer-generated errors or other
-                deviations from the official paper versions of the opinions. Moreover, the original version of an
-                opinion relating to an order is replaced within a few months by a paginated version of the opinion
-                in the preliminary print, and-one year after the issuance of that print-by the final version of the
-                case in a U.S. Reports bound volume. In case of discrepancies between the print and electronic
-                versions of an opinion relating to an order, the print version controls. In case of discrepancies
-                between an opinion relating to an order and any later official version of the opinion, the later
-                version controls.</p>
-
-            <center>
-
-                <table class="datatables" style="text-align: left;" border="1" cellspacing="0" cellpadding="2">
-                    <tr>
-                        <th style="text-align: center;" width="60" scope="col">Date</th>
-                        <th style="text-align: center;" width="60" scope="col">Docket</th>
-                        <th style="text-align: center;" width="400" scope="col">Name</th>
-                        <th style="text-align: center;" width="20" scope="col">J.</th>
-                        <th style="text-align: center;" width="40" scope="col">Pt.</th>
-                    </tr>
-
-                    <tr>
-                        <td style="text-align: center;">8/02/13</td>
-                        <td style="text-align: center;">13A57</td>
-                        <td><a href='12pdf/13a57_19m2.pdf' target='_blank'>Brown v. Plata</a></td>
-                        <td style="text-align: center;">AS</td>
-                        <td style="text-align: center;">570/2</td>
-                    </tr>
-
-                    <tr>
-                        <td style="text-align: center;">6/27/13</td>
-                        <td style="text-align: center;">12-7516</td>
-                        <td><a href='12pdf/12-7516_m648.pdf' target='_blank'>Gallow v. Cooper</a></td>
-                        <td style="text-align: center;">B</td>
-                        <td style="text-align: center;">570/2</td>
-                    </tr>
-
-                    <tr>
-                        <td style="text-align: center;">6/27/13</td>
-                        <td style="text-align: center;">12-6355</td>
-                        <td><a href='12pdf/12-6355_6k47.pdf' target='_blank'>Marrero v. United States</a></td>
-                        <td style="text-align: center;">A</td>
-                        <td style="text-align: center;">570/2</td>
-                    </tr>
-
-                    <tr>
-                        <td style="text-align: center;">6/27/13</td>
-                        <td style="text-align: center;">12-862</td>
-                        <td><a href='12pdf/12-862_8njp.pdf' target='_blank'>Lanus v. United States</a></td>
-                        <td style="text-align: center;">T</td>
-                        <td style="text-align: center;">570/2</td>
-                    </tr>
-
-                    <tr>
-                        <td style="text-align: center;">2/25/13</td>
-                        <td style="text-align: center;">12-6142</td>
-                        <td><a href='12pdf/12-6142_2co3.pdf' target='_blank'>Calhoun v. United States</a></td>
-                        <td style="text-align: center;">SS</td>
-                        <td style="text-align: center;">568/2</td>
-                    </tr>
-
-                    <tr>
-                        <td style="text-align: center;">12/03/12</td>
-                        <td style="text-align: center;">11-10974</td>
-                        <td><a href='12pdf/11-10974_d1o2.pdf' target='_blank'>Hodge v. Kentucky</a></td>
-                        <td style="text-align: center;">SS</td>
-                        <td style="text-align: center;">568/1</td>
-                    </tr>
-
-                    <tr>
-                        <td style="text-align: center;">11/26/12</td>
-                        <td style="text-align: center;">11-1515</td>
-                        <td><a href='12pdf/11-1515_e2pg.pdf' target='_blank'>Delling v. Idaho</a></td>
-                        <td style="text-align: center;">B</td>
-                        <td style="text-align: center;">568/1</td>
-                    </tr>
-
-                    <tr>
-                        <td style="text-align: center;">11/13/12</td>
-                        <td style="text-align: center;">12-6760</td>
-                        <td><a href='12pdf/12-6760scalia_c0n2.pdf' target='_blank'>Haynes v. Thaler</a></td>
-                        <td style="text-align: center;">AS</td>
-                        <td style="text-align: center;">568/1</td>
-                    </tr>
-
-                    <tr>
-                        <td style="text-align: center;">11/13/12</td>
-                        <td style="text-align: center;">12-6760</td>
-                        <td><a href='12pdf/12-6760sotomayor_7k47.pdf' target='_blank'>Haynes v. Thaler</a></td>
-                        <td style="text-align: center;">SS</td>
-                        <td style="text-align: center;">568/1</td>
-                    </tr>
-
-                </table>
-
-            </center>
-
-            <br />
-
-        </div>
-    </div>
-</div>
-</div>
-<div id="columnbottom"><img id="ctl00_ctl00_mainbody_imagebottomcolumn2" alt="" src="../images/clearpixel.gif" style="height:7px;border-width:0px;" /></div>
-
-</div>
-
-<!-- footer -->
-<div id="footer" class="noindex">
-    <hr style="width: 95%; text-align: left; margin-left: 5px;" />
-    <div id="versiontext" style="text-align: center;"><span id="ctl00_ctl00_lbltoday">August 10, 2013</span>
-        |  <span id="ctl00_ctl00_lblversion">Version 2012.0</span></div>
-    <div id="footertext">
-        <a id="ctl00_ctl00_hypHome" href="../">Home</a> |
-        <a id="ctl00_ctl00_hypHelp" href="../help.aspx">Help</a>
-        |
-        <a id="ctl00_ctl00_hpsitemap" href="../sitemap.aspx">Site Map</a>
-        |
-        <a id="ctl00_ctl00_HypContactUs" href="../contact/contactus.aspx">Contact Us</a>
-        |
-        <a id="ctl00_ctl00_HypAboutUs" href="../about/about_us.aspx">About Us</a>
-        |
-        <a id="ctl00_ctl00_HypFAQ" href="../faq.aspx">FAQ</a>
-        |
-        <a id="ctl00_ctl00_HypWebPolicy" href="../policies/web_policies_and_notices.aspx">Website Policies and Notices</a>
-        |
-        <a id="ctl00_ctl00_HypPrivacy" href="../policies/privacy_notice.aspx">Privacy Policy</a>
-        |
-        <a id="ctl00_ctl00_hypUSA" href="../redirect.aspx?federal=y&amp;newURL=www.usa.gov">USA.GOV</a><br />
-                   <span style="display:block; margin-top: 5px; font-size: 12pt;font-weight:bold; color: #ffffff;">
-                    Supreme Court of the United States</span> <p>&nbsp;</p>
-
-    </div>
-</div>
-</div>
 </center>
 
-<script type="text/javascript">
-    //<![CDATA[
-    var Page_Validators =  new Array(document.getElementById("ctl00_ctl00_SearchVal"));
-    //]]>
-</script>
-
-<script type="text/javascript">
-    //<![CDATA[
-    var ctl00_ctl00_SearchVal = document.all ? document.all["ctl00_ctl00_SearchVal"] : document.getElementById("ctl00_ctl00_SearchVal");
-    ctl00_ctl00_SearchVal.controltovalidate = "ctl00_ctl00_txtSearch";
-    ctl00_ctl00_SearchVal.errormessage = "Invalid text in search term. Try again";
-    ctl00_ctl00_SearchVal.evaluationfunction = "RegularExpressionValidatorEvaluateIsValid";
-    ctl00_ctl00_SearchVal.validationexpression = "[\\w\\s-/?!\"\'&~@<>/*.(),]*";
-    //]]>
-</script>
+<br />
 
 
-<script type="text/javascript">
-    //<![CDATA[
+				</div>
+			</div>
+		</div>
+	<div class="container well">
+        <div class="noindex">
+		    <div class="container">
+			    <div class="row">
+				    <div class="col-lg-12 col-md-12 col-sm-12">
 
-    var Page_ValidationActive = false;
-    if (typeof(ValidatorOnLoad) == "function") {
-        ValidatorOnLoad();
-    }
+					    <div id="versiontext" class="text-center"  style="display:block; width: auto;"><span id="ctl00_ctl00_lbltoday">February 14, 2016</span>
+						    |  Version 2014.1</div>
+					    <div class="text-center"  id="footertext">
+					       <a id="ctl00_ctl00_hypHome" href="../../">Home</a>
+                            |
+					       <a id="ctl00_ctl00_hypHelp" href="../../help.aspx">Help</a>
+						    |
+					       <a id="ctl00_ctl00_hpsitemap" href="../../sitemap.aspx">Site Map</a>
+						    |
+					       <a id="ctl00_ctl00_HypContactUs" href="../../contact/contactus.aspx">Contact Us</a>
+						    |
+					       <a id="ctl00_ctl00_HypAboutUs" href="../../about/about_us.aspx">About Us</a>
+						    |
+					       <a id="ctl00_ctl00_HypFAQ" href="../../faq.aspx">FAQ</a>
+						    |
+                           <a id="ctl00_ctl00_HypJobs" href="../../jobs/jobs.aspx">Jobs</a>
+                            |
+                           <a id="ctl00_ctl00_HypLinks" href="../../links/links.aspx">Links</a>
+                            |
+                           <a id="ctl00_ctl00_Hyperlink63" href="../../publicinfo/buildingregulations.aspx">Building Regulations</a><br />
 
-    function ValidatorOnSubmit() {
-        if (Page_ValidationActive) {
-            return ValidatorCommonOnSubmit();
-        }
-        else {
-            return true;
-        }
-    }
-    WebForm_AutoFocus('cmdSearch');Sys.Application.initialize();
+					       <a id="ctl00_ctl00_HypWebPolicy" href="../../policies/web_policies_and_notices.aspx">Website Policies and Notices</a>
+						    |
+					       <a id="ctl00_ctl00_HypPrivacy" href="../../policies/privacy_notice.aspx">Privacy Policy</a>
+                            |
+					       <a id="ctl00_ctl00_hypUSA" href="../../redirect.aspx?federal=y&amp;newURL=www.usa.gov">USA.GOV</a><br />
 
-    document.getElementById('ctl00_ctl00_SearchVal').dispose = function() {
-        Array.remove(Page_Validators, document.getElementById('ctl00_ctl00_SearchVal'));
-    }
-    //]]>
-</script>
-</form>
+					       <span style="display:block; margin-top: 5px; font-size: 14pt;font-weight:bold; color: #000;">Supreme Court of the United States</span>
+					    </div>
+
+				    </div>
+			    </div>
+		    </div>
+        </div>
+	</div>
+
+	</form>
 </body>
 </html>

--- a/tests/examples/opinions/united_states/scotus_slip_example.html
+++ b/tests/examples/opinions/united_states/scotus_slip_example.html
@@ -1,419 +1,596 @@
 
+
 <!DOCTYPE html>
 
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head><meta http-equiv="X-UA-Compatible" content="IE=edge" /><meta http-equiv="content-type" content="txt/html; charset=utf-8" /><meta name="viewport" content="width=device-width, initial-scale=0.7" />
-    <script type="text/javascript" src="/engine1/jquery-1.11.0.js"></script>
-    <script type="text/javascript" src="/js/bootstrap.js"></script>
-    <link rel="Stylesheet" type="text/css" href="/css/bootstrap.min.css" />
-    <link rel="Stylesheet" type="text/css" href="/css/bootstrap-theme.min.css" />
-    <link rel="Stylesheet" type="text/css" href="/styles/supremecourt_style2.css" title="default" />
-    <link rel="stylesheet" type="text/css" href="/styles/newBootStrap.css" />
+        <script type="text/javascript" src="/engine1/jquery-1.11.0.js"></script>
+	    <script type="text/javascript" src="/js/bootstrap.js"></script>
+	    <link rel="Stylesheet" type="text/css" href="/css/bootstrap.min.css" />
+	    <link rel="Stylesheet" type="text/css" href="/css/bootstrap-theme.min.css" />
+	    <link rel="Stylesheet" type="text/css" href="/styles/supremecourt_style2.css" title="default" />
+	    <link rel="stylesheet" type="text/css" href="/styles/newBootStrap.css" />
 
 
-    <!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
+<!-- HTML5 shim and Respond.js IE8 support of HTML5 elements and media queries -->
 
-    <!--[if lt IE 9]>
-    <script src="/js/html5shiv.js"></script>
-    <script src="/js/respond.min.js"></script>
-    <![endif]-->
+        <!--[if lt IE 9]>
+          <script src="/js/html5shiv.js"></script>
+          <script src="/js/respond.min.js"></script>
+        <![endif]-->
 
-    <!--[if lt IE 8]>
-    <link rel="stylesheet" type="text/css" href="css/bootstrap-ie7.css">
-    <![endif]-->
+        <!--[if lt IE 8]>
+          <link rel="stylesheet" type="text/css" href="css/bootstrap-ie7.css">
+        <![endif]-->
 
 
 
-    <meta name="title" content="2008 Term Opinions of the Court" />
-    <meta name="created" content='12/31/1600 7:00:00 PM' />
-    <meta name="revised" content='12/31/1600 7:00:00 PM' />
-    <meta name="keywords" content="Supreme Court of the United States, Supreme Court, Supreme Court of US, Supremecourt,
+	<meta name="title" content="2008 Term Opinions of the Court" />
+	<meta name="created" content='10/1/2014 3:25:13 PM' />
+	<meta name="revised" content='10/2/2015 12:49:24 PM' />
+	<meta name="keywords" content="Supreme Court of the United States, Supreme Court, Supreme Court of US, Supremecourt,
 	United State Supreme Court, US Supreme Court, U.S. Supreme Court, Court, Opinions, Slip Opinions" />
-    <style type="text/css">
-        .well-lg {
-            background-image: none;
-        }
-    </style>
+	<style type="text/css">
+		.well-lg {
+			background-image: none;
+		}
+	</style>
 
-    <title>
-        2014 Term Opinions of the Court
-    </title></head>
+<title>
+	2015 Term Opinions of the Court
+</title></head>
 <body>
-<form method="post" action="14" onsubmit="javascript:return WebForm_OnSubmit();" id="aspnetForm" class="form-horizontal">
+<form method="post" action="./slipopinions.aspx" onsubmit="javascript:return WebForm_OnSubmit();" id="aspnetForm" class="form-horizontal">
 <div class="aspNetHidden">
-    <input type="hidden" name="ctl00_ctl00_RadScriptManager1_TSM" id="ctl00_ctl00_RadScriptManager1_TSM" value="" />
-    <input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
-    <input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
-    <input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwULLTE1NzA0MTQ1MjgPZBYCZg9kFgJmD2QWAgIDD2QWBAIPD2QWAgIBD2QWBgIBDw8WAh4EVGV4dAUfMjAxNCBUZXJtIE9waW5pb25zIG9mIHRoZSBDb3VydGRkAgMPDxYCHwAFPE9jdG9iZXIgVGVybSAyMDE0IChPY3RvYmVyIDYsIDIwMTQsIHRocm91Z2ggT2N0b2JlciA0LCAyMDE1KWRkAgkPFgIeC18hSXRlbUNvdW50AgEWAgIBD2QWAmYPFQYBMQgxMC8wNi8xNAYxMy05NDbTAzxhIGhyZWY9Jy9vcGluaW9ucy8xNHBkZi8xMy05NDZfYWRiYy5wZGYnIHRhcmdldD0nX2JsYW5rJyB0aXRsZT0iIFRoZSBOaW50aCBDaXJjdWl0IGVycmVkIGluIGdyYW50aW5nIGhhYmVhcyByZWxpZWYgYmFzZWQgb24gaXRzIG93biBwcmVjZWRlbnQsIHdoZXJlIHRoaXMgQ291cnQncyBjYXNlIGxhdyBoYWQgbm90ICdjbGVhcmx5IGVzdGFibGlzaFtlZF0nIHRoYXQgYSBkZWZlbmRhbnQgYWRlcXVhdGVseSBhcHByaXNlZCBvZiB0aGUgcG9zc2liaWxpdHkgb2YgY29udmljdGlvbiBvbiBhbiBhaWRpbmctYW5kLWFiZXR0aW5nIHRoZW9yeSBjYW4gbmV2ZXJ0aGVsZXNzIGJlIGRlcHJpdmVkIG9mIGFkZXF1YXRlIG5vdGljZSBieSBhIHByb3NlY3V0b3JpYWwgZGVjaXNpb24gdG8gZm9jdXMgb24gYW5vdGhlciB0aGVvcnkgYXQgdHJpYWwsIHNlZSAyOCBVLiBTLiBDLiAyMjU0KGQpKDEpLiI+TG9wZXogdi4gU21pdGg8L2E+BTU3NC8xBTU3NC8xZAIRDw8WAh8ABRBPY3RvYmVyIDA4LCAyMDE0ZGQYAQUeX19Db250cm9sc1JlcXVpcmVQb3N0QmFja0tleV9fFgMFEmN0bDAwJGN0bDAwJHJkb1NDRAUVY3RsMDAkY3RsMDAkcmRvRG9ja2V0BRVjdGwwMCRjdGwwMCRyZG9Eb2NrZXSS861q8GCSz2JY4i+mjKEg3Be473jhzJphKqfD8qst1A==" />
+<input type="hidden" name="ctl00_ctl00_RadScriptManager1_TSM" id="ctl00_ctl00_RadScriptManager1_TSM" value="" />
+<input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
+<input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUKLTUzMjE3ODUzOGQYAQUeX19Db250cm9sc1JlcXVpcmVQb3N0QmFja0tleV9fFgMFEmN0bDAwJGN0bDAwJHJkb1NDRAUVY3RsMDAkY3RsMDAkcmRvRG9ja2V0BRVjdGwwMCRjdGwwMCRyZG9Eb2NrZXRCr9pvCeQgJ0+MKPRmu8C3sLr8pBbg5qLrS+bRsp1CvQ==" />
 </div>
 
 <script type="text/javascript">
-    //<![CDATA[
-    var theForm = document.forms['aspnetForm'];
-    if (!theForm) {
-        theForm = document.aspnetForm;
+//<![CDATA[
+var theForm = document.forms['aspnetForm'];
+if (!theForm) {
+    theForm = document.aspnetForm;
+}
+function __doPostBack(eventTarget, eventArgument) {
+    if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
+        theForm.__EVENTTARGET.value = eventTarget;
+        theForm.__EVENTARGUMENT.value = eventArgument;
+        theForm.submit();
     }
-    function __doPostBack(eventTarget, eventArgument) {
-        if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
-            theForm.__EVENTTARGET.value = eventTarget;
-            theForm.__EVENTARGUMENT.value = eventArgument;
-            theForm.submit();
-        }
-    }
-    //]]>
+}
+//]]>
 </script>
 
 
-<script src="/WebResource.axd?d=ZseFxRmodsjlJy9k0UdiXxfb7wQAfWNAtk-hWKsIVwqttbSJWpLjYBJmam7CfEZLJLf7sKFty6JfANmeDb1yOD4h9KMbXr56yCcCUvQ6KBI1&amp;t=635418424260000000" type="text/javascript"></script>
+<script src="/WebResource.axd?d=ZseFxRmodsjlJy9k0UdiXxfb7wQAfWNAtk-hWKsIVwqttbSJWpLjYBJmam7CfEZLJLf7sKFty6JfANmeDb1yOD4h9KMbXr56yCcCUvQ6KBI1&amp;t=635802997220000000" type="text/javascript"></script>
 
 
-<script src="/ScriptResource.axd?d=CstK0QUeC6UgJxjcwNFQnmNU5LCrhv_1DNqBWYQFlruk3nqi-gZivC6CFr1o8GCQHYjfVhKU61ts25hHIAABePh5-LO_YboVufIcLhIQWOanCmERl4KhY_gAo1GGy3flt8kCRgH0BAxQsNjYJpm1sa65rC4GaBckIkfJxPLaWf01&amp;t=42300a4d" type="text/javascript"></script>
-<script src="/Telerik.Web.UI.WebResource.axd?_TSM_HiddenField_=ctl00_ctl00_RadScriptManager1_TSM&amp;compress=1&amp;_TSM_CombinedScripts_=%3b%3bSystem.Web.Extensions%2c+Version%3d4.0.0.0%2c+Culture%3dneutral%2c+PublicKeyToken%3d31bf3856ad364e35%3aen-US%3af319b152-218f-4c14-829d-050a68bb1a61%3aea597d4b%3ab25378d2" type="text/javascript"></script>
+<script src="/ScriptResource.axd?d=CstK0QUeC6UgJxjcwNFQnmNU5LCrhv_1DNqBWYQFlruk3nqi-gZivC6CFr1o8GCQHYjfVhKU61ts25hHIAABePh5-LO_YboVufIcLhIQWOanCmERl4KhY_gAo1GGy3flt8kCRgH0BAxQsNjYJpm1sa65rC4GaBckIkfJxPLaWf01&amp;t=62fc1f78" type="text/javascript"></script>
+<script src="/ScriptResource.axd?d=4nsLQ6xlIjLQ81q7Gm6-6me-Cx1KegEN6fC7vQACSfrr7hQq3mvzQsWOkF11oMfavtSZSXHriDY8B3oiUQ_HlYHJRzwynPjFZM4Pkat3aP80wgWM5FHxG6ufwyt3ZvD9i5iNE_Dhsdcvih3nvxi6Dql2YtSRPfRWovcCNr71bXw1&amp;t=5f9d5645" type="text/javascript"></script>
+<script src="/ScriptResource.axd?d=tzJUV736PNbMd9Jma4rOzBvn1b-k-BjURIVUwJNmIWRhSRm2m956ccZM25S0hzZhg_XMUYgQBPmE5-3yD20LCb7I84JLHOOY1EpbZ8jMzWE-jN9X8PiD6JmecUdb-d6J-Tj9lDN9wOqTtpAX7S1Vo2QCy9PTDffRTlUl709aXIchWqifBx-zDc9zTR2BkIN_0&amp;t=5f9d5645" type="text/javascript"></script>
 <script type="text/javascript">
-    //<![CDATA[
-    if (typeof(Sys) === 'undefined') throw new Error('ASP.NET Ajax client-side framework failed to load.');
-    //]]>
+//<![CDATA[
+function WebForm_OnSubmit() {
+if (typeof(ValidatorOnSubmit) == "function" && ValidatorOnSubmit() == false) return false;
+return true;
+}
+//]]>
+</script>
+
+<div class="aspNetHidden">
+
+	<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="CF2965E9" />
+	<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEdAAgIRroofcspric++RThX0WUdcLA2cVr55mmAI/xV+qwRAMiFNqFT7E2zKelBoXU3xbDDU+RV/jOi+vSugvNJrSXAeQgnDYEcS/A3pq4nSD4D0Ddcr9W1vG3+GTAwlOJUM51PENixjB8uIhh9HSYVMY81TqJGMO3GEtAB5QnaLsNtBidVfxP4yM9PkCiWId2DKGCefe4UhtUVdxMw2wJ/wo8" />
+</div>
+    <div class="noindex">
+	    <script type="text/javascript">
+//<![CDATA[
+Sys.WebForms.PageRequestManager._initialize('ctl00$ctl00$RadScriptManager1', 'aspnetForm', [], [], [], 90, 'ctl00$ctl00');
+//]]>
+</script>
+
+    </div>
+	<div class="container well well-lg">
+            <div class="noindex">
+			    <div class="row bannerStyle">
+				    <div class="col-md-6 col-xs-12">
+                         <a id="ctl00_ctl00_hypSealLink" href="../"><img id="ctl00_ctl00_imgSeal" class="SCUSSeal" src="../images/banner_h120.jpg" alt="Supreme Court of the United States" /></a>
+				    </div>
+				    <div class="col-md-6 col-xs-12" style="font-size: 9pt;">
+					    <div class="Div1">
+                            <a id="ctl00_ctl00_wucBannerMenu_Hyperlink42" href="../visiting/visiting.aspx">Visiting the Court</a> &nbsp;|&nbsp;
+        <a id="ctl00_ctl00_wucBannerMenu_Hyperlink53" href="../visiting/touringthebuilding.aspx">Touring the Building</a> &nbsp;|&nbsp;
+        <a id="ctl00_ctl00_wucBannerMenu_Hyperlink1" href="../visiting/exhibition.aspx">Exhibitions</a>
+					    </div>
+					    <div class="pull-right search">
+						    <div id="ctl00_ctl00_pnlSearch">
+
+                                <table>
+							        <tr>
+                                        <td>
+                                            <span id="ctl00_ctl00_lblSearchOn" style="font-weight:bold;">Search: </span>&nbsp;
+                                            <span title="Radio button - Search All Documents"><input id="ctl00_ctl00_rdoSCD" type="radio" name="ctl00$ctl00$USSC" value="rdoSCD" checked="checked" /><label for="ctl00_ctl00_rdoSCD">All Documents</label></span>
+                                            <span title="Radio Button - Search Docket"><input id="ctl00_ctl00_rdoDocket" type="radio" name="ctl00$ctl00$USSC" value="rdoDocket" /><label for="ctl00_ctl00_rdoDocket">Docket</label></span>
+					    <a id="ctl00_ctl00_SearchCenter" href="../search_center.aspx" style="font-size:small; float:right">Advanced Search</a>
+                                        </td>
+                                    </tr>
+                                    <tr>
+							            <td>
+                                            <span id="ctl00_ctl00_lblForDocuments" style="font-weight:bold;">Enter Search Text:</span>
+                                            <input name="ctl00$ctl00$txtSearch" type="text" id="ctl00_ctl00_txtSearch" /><input name="ctl00$ctl00$txbhidden" type="text" id="ctl00_ctl00_txbhidden" style="visibility: hidden; display: none;" />&nbsp;
+                                            <input type="submit" name="ctl00$ctl00$cmdSearch" value="Search" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdSearch&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_cmdSearch" title="Perform quick search" /> &nbsp;
+                                            <input type="submit" name="ctl00$ctl00$cmdHelp" value="Help" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdHelp&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_cmdHelp" title="Search help tips" /><br />
+
+                                                <span id="ctl00_ctl00_RegularExpressionValidator2" style="display:inline-block;height:20px;visibility:hidden;">Search term too short </span>
+
+
+                                            <span id="ctl00_ctl00_SearchVal" style="display:inline-block;height:20px;visibility:hidden;">Invalid text in search term. Try again</span>
+                                        </td>
+                                    </tr>
+                                </table>
+
+</div>
+					    </div>
+				    </div>
+			    </div>
+			    <div class="row" style="margin-bottom: 5px; margin-top: 5px;">
+				    <div class="col-lg-10 col-md-10">
+					    <div id="sitemappath">
+					        <span id="ctl00_ctl00_SiteMapPath1" style="color:#ED0303;font-size:1em;"><a href="#ctl00_ctl00_SiteMapPath1_SkipLink"><img alt="Skip Navigation Links" src="/WebResource.axd?d=WLY2oepp1eKPePERXTuqUau_buIJz5S7ntqiGL3pUm39ydKxNwryN9m5LqCjmtlpSPkXXzclABxfMGVVXMTu6J6S8rDd4o05EnrXXVm10l81&amp;t=635802997220000000" width="0" height="0" style="border-width:0px;" /></a><span><a title="Supreme Court Home" href="/default.aspx" style="color:#507CD1;font-weight:bold;">Home</a></span><span style="color:#507CD1;font-weight:bold;"> | </span><span><a title="Opinions" href="/opinions/opinions.aspx" style="color:#284E98;font-weight:bold;">Opinions</a></span><span style="color:#507CD1;font-weight:bold;"> | </span><span style="color:Red;font-weight:bold;"></span><span style="color:Red;"><span style='color:Red;font-weight:bold;'>2015 Term Opinions of the Court</span></span><a id="ctl00_ctl00_SiteMapPath1_SkipLink"></a></span>
+				        </div>
+				    </div>
+                    <div class="col-lg-2 col-md-2 text-right">
+
+                    </div>
+			    </div>
+			    <div class="navbar navbar-inverse" role="navigation">
+				    <div class="container-fluid">
+						    <!-- menu starts here -->
+
+<div class="navbar-header">
+    <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+        <span class="sr-only">Toggle navigation</span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+    </button>
+</div>
+<div class="navbar-collapse collapse">
+    <ul class="nav navbar-nav">
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_HyperLink5" class="dropdown-toggle" href="opinions.aspx">Opinions</a>
+                <ul class="dropdown-menu">
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink30" href="slipopinion/15">Latest Slip Opinions</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink31" href="relatingtoorders/15">Opinions Relating to Orders</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink32" href="in-chambers/15">In-Chambers Opinions</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink1" href="opinions.aspx">Slip opinions - Earlier Terms</a></li>
+                    <!-- li><a id="ctl00_ctl00_wucNewMenu1_HyperLink34" href="counsellist.aspx">Counsel Listings</a></li -->
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink35" href="boundvolumes.aspx">Bound Volumes</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink36" href="../media/media.aspx">Media Files Related to Opinions</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink37" href="Cited_URL_List.aspx">Internet Sources Cited in Opinions</a></li>
+                    <li>&nbsp;</li>
+                </ul>
+        </li>
+        <li class="dropdown"><a id="ctl00_ctl00_wucNewMenu1_hl" class="dropdown-toggle" href="../oral_arguments/oral_arguments.aspx">Oral Arguments</a>
+                <ul class="dropdown-menu">
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink23" href="../oral_arguments/2016TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2016)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink15" href="../oral_arguments/2015TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2015)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink9" href="../oral_arguments/2014termcourtcalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2014)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink8" href="../oral_arguments/2013TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2013)</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink10" href="../oral_arguments/argument_calendars.aspx">Argument Calendars</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink11" href="../oral_arguments/hearinglist.aspx">Hearing Lists</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink12" href="../visiting/visitorsguidetooralargument.aspx">Visitor's Guide to Oral Argument</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink13" href="../oral_arguments/argument_transcript.aspx">Argument Transcripts</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink14" href="../oral_arguments/argument_audio.aspx">Argument Audio</a></li>
+                    <li>&nbsp;</li>
+                </ul>
+        </li>
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_HyperLink41" class="dropdown-toggle" href="../case_documents.aspx">Case Documents</a>
+                <ul class="dropdown-menu">
+                    <li><a id="ctl00_ctl00_wucNewMenu1_hldocket" href="../docket/docket.aspx">Docket Search</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink18" href="../redirect.aspx?newURL=www.americanbar.org/publications/preview_home/alphabetical.html">On-Line MERITS BRIEFS</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink17" href="../oral_arguments/briefsource.aspx">Where to Find Briefs</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_hypOrdersOfCourt" href="../orders/ordersofthecourt/15">Orders of the Court - 2015 Term</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink43" href="../orders/orders.aspx#Orders">Orders - Earlier Term</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink67" href="../orders/orders.aspx#OrdersByCircuit">Orders by Circuit</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink68" href="../orders/orders.aspx#GrantedNotedCases">Granted/Noted Cases List</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink39" href="../orders/journal.aspx">Journal</a></li>
+                    <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink7" href="../SpecMastRpt/SpecMastRpt.aspx">Special Master Reports</a></li>
+                    <li>&nbsp;</li>
+                </ul>
+        </li>
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_HyperLink69" class="dropdown-toggle" href="../rules_guidance.aspx">Rules & Guidance</a>
+            <ul class="dropdown-menu">
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink3" href="../ctrules/ctrules.aspx">Court Rules</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink4" href="../casehand/casehand.aspx">Guides for Counsel</a>
+                    <ul class="dropdown-menu sub-menu">
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink26" href="../casehand/guidetofilingpaidcases2014.pdf" target="_blank">Guide to Filing Paid Cases (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink6" href="../casehand/courtspecchart02162010.aspx">Paid Cases Brief Chart</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink27" href="../casehand/guideforifpcases2014.pdf" target="_blank">Guide to Filing <i>In Forma Pauperis</i> Cases (PDF) </a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink28" href="../casehand/guideforcounsel.pdf" target="_blank">Guide for Counsel in Cases to be Argued (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink29" href="../oral_arguments/2010ElectronicMeritsBriefsSubmissionGuidelines.pdf" target="_blank">Electronic Merits Briefs Submission Guidelines (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink16" href="../deliveryofdocuments.aspx">Delivery of Documents to the Clerk's Office</a></li>
+                    </ul>
+                </li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink2" href="../bar/baradmissions.aspx">Supreme Court Bar</a>
+                    <ul class="dropdown-menu sub-menu">
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink20" href="../bar/barinstructions.pdf" target="_blank">Bar Admissions Instructions (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink19" href="../bar/barapplication.pdf" target="_blank">Bar Admissions Forms (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink21" href="../bar/smallGroups_ArguDays_instr.pdf" target="_blank">Small Group Admissions - Argument Days (PDF)</a></li>
+                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink22" href="../bar/largeGroups_NonArgument_Instr.pdf" target="_blank">Large Group Admissions - Nonargument Days (PDF)</a></li>
+                    </ul>
+                </li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HypCaseDistribution" href="../casedistribution/casedistributionschedule.aspx">Case Distribution Schedule</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink40" href="../casehand/waiver.pdf" target="_blank">Waiver Form (PDF)</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink70" href="../orders/courtorders/ALLOTMENTORDER9-28-10.pdf" target="_blank">Circuit Assignments of Justices</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink71" href="../about/Circuit%20Map.pdf" target="_blank">&nbsp;&nbsp;&nbsp;&nbsp; - Circuit Map</a></li>
+                <li>&nbsp;</li>
+            </ul>
+        </li>
+
+            <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_hypCourtInfo" class="dropdown-toggle" href="../publicinfo/publicinfo.aspx">News Media</a>
+            <ul class="dropdown-menu">
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink57" href="../publicinfo/press/pressreleases.aspx">Press Releases</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink58" href="../publicinfo/media/mediaadvisories.aspx">Media Advisories</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink61" href="../publicinfo/press/presscredentials.aspx">Press Credentials</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink62" href="../publicinfo/reportersguide.pdf" target="_blank">A Reporter's Guide to Applications (PDF)</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink59" href="../publicinfo/speeches/speeches.aspx">Speeches</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink60" href="../publicinfo/year-end/year-endreports.aspx">Chief Justice's Year-End Reports on the Federal Judiciary</a></li>
+                <li>&nbsp;</li>
+            </ul>
+        </li>
+        <li class="dropdown">
+            <a id="ctl00_ctl00_wucNewMenu1_hypAboutCourt" class="dropdown-toggle" href="../about/about.aspx">About the Court</a>
+            <ul class="dropdown-menu">
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink46" href="../about/briefoverview.aspx">Brief Overview</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink47" href="../about/biographies.aspx">Biographies of Current Justices</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink48" href="../about/members.aspx">Justices 1789 to Present</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink49" href="../about/courtbuilding.aspx">The Supreme Court Building</a></li>
+                <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink45" href="../redirect.aspx?federal=y&amp;newURL=www.archives.gov/historical-docs/document.html?doc=3&amp;title.raw=Constitution%252">Constitution</a></li>
+                <li>&nbsp;</li>
+            </ul>
+        </li>
+    </ul>
+</div>
+						    <!-- menu ends here -->
+				    </div>
+			    </div>
+            </div>
+			<div class="row">
+				<div class="col-lg-12 col-md-12 col-sm-12" id="mainbody">
+
+
+<div class="col-sm-12 sectiontitle">
+	<div id="sectionbanner5">
+		<div id="pagetitle">
+			<h3><span id="ctl00_ctl00_MainEditable_mainContent_lblTitle" style="font-weight:bold;">2015 Term Opinions of the Court</span></h3>
+		</div>
+	</div>
+</div>
+<p align="center"><font size="+1">Slip Opinions, <i>Per Curiams</i> (PC), and Original Case Decrees
+(D)</font></p>
+
+<p>The "slip" opinion is the second version of an opinion. It is sent to the printer later in the day
+on which the "bench" opinion is released by the Court. Each slip opinion has the same elements as the
+bench opinion--majority or plurality opinion, concurrences or dissents, and a prefatory syllabus--but
+may contain corrections not appearing in the bench opinion. The slip opinions collected here are those
+issued during <span id="ctl00_ctl00_MainEditable_mainContent_lblTerms">October Term 2015 (October 5, 2015, through October 2, 2016)</span>. These opinions are posted on the Website
+within minutes after the bench opinions are issued and will remain posted until the opinions for the
+entire Term are published in the bound volumes of the United States Reports. For further information,
+see <a id="ctl00_ctl00_MainEditable_mainContent_lbnDefA" href="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$MainEditable$mainContent$lbnDefA&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, true))">Column Header Definitions</a> and
+<a href="/opinions/info_opinions.aspx">Information About Opinions</a>.</p>
+
+<p><b>Caution:</b> These electronic opinions may contain computer-generated errors or other deviations
+from the official printed slip opinion pamphlets. Moreover, a slip opinion is replaced by a paginated
+version of the case in the preliminary print, and, subsequently, by the final version of the case in
+a U. S. Reports bound volume. In case of discrepancies
+between the print and electronic versions of a slip opinion, the print version controls. However, where
+the electronic version has been designated “revised,” the electronic version controls to the extent that
+it differs from the print version with regard to the noted revision. In case of discrepancies between the
+slip opinion and any later official version of the opinion—<i>i.e.</i>, the preliminary print or bound volume version—the later version controls.</p>
+<br />
+
+<center>
+
+		<table class="table table-bordered" style="text-align: left;"  cellspacing="0" cellpadding="2">
+			<tr>
+			<th style="text-align: center;" width="20" scope="col">R-</th>
+			<th style="text-align: center;" width="60" scope="col">Date</th>
+			<th style="text-align: center;" width="60" scope="col">Docket</th>
+			<th style="text-align: center;" width="360" scope="col">Name</th>
+<th style="text-align: center;" width="60" scope="col">Revised</th>
+
+			<th style="text-align: center;" width="20" scope="col">J.</th>
+			<th style="text-align: center;" width="40" scope="col">Pt.</th>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">18</td>
+				<td style="text-align: center;">1/25/16</td>
+				<td style="text-align: center;">15-278</td>
+				<td><a href='/opinions/15pdf/15-278_2co3.pdf' target='_blank' title=" The Ninth Circuit failed to apply correctly the standards of Fifth Third Bancorp v. Dudenhoeffer, 573 U. S. ___, in evaluating respondents’ complaint for breach of the duty of prudence against Employee Retirement and Income Security Act of 1974 fiduciaries.">Amgen Inc. v. Harris</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">PC</td>
+				<td style="text-align: center;">577/2</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">17</td>
+				<td style="text-align: center;">1/25/16</td>
+				<td style="text-align: center;">15-493</td>
+				<td><a href='/opinions/15pdf/15-493_5h26.pdf' target='_blank' title=" The Idaho Supreme Court, which like any other state or federal court, is bound by this Court’s interpretation of federal law, erred in awarding attorney’s fees under 42 U. S. C. §1988 to a prevailing defendant without first determining that the plaintiff’s action was frivolous, unreasonable, or without foundation.">James v. Boise</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">PC</td>
+				<td style="text-align: center;">577/2</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">16</td>
+				<td style="text-align: center;">1/25/16</td>
+				<td style="text-align: center;">14-840</td>
+				<td><a href='/opinions/15pdf/14-840- new_o75q.pdf' target='_blank' title=" The Federal Power Act authorizes FERC to regulate the compensation that wholesale market operators pay to electricity consumers for commitments not to use power during peak demand periods; FERC’s compensation formula is not arbitrary and capricious.">FERC v. Electric Power Supply Assn.</a></td>
+				<td style='text-align: center;'><a href='/opinions/15pdf/14-840_diff_pok0.pdf' target='_blank'>1/28/16</a></td>
+				<td style="text-align: center;">EK</td>
+				<td style="text-align: center;">577/2</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">15</td>
+				<td style="text-align: center;">1/25/16</td>
+				<td style="text-align: center;">14-510</td>
+				<td><a href='/opinions/15pdf/14-510_pm02.pdf' target='_blank' title=" Equitable tolling does not apply to the presentment of the Menominee Tribe’s Indian Self-Determination and Education Assistance Act claims.">Menominee Tribe of Wis. v. United States</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">A</td>
+				<td style="text-align: center;">577/2</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">14</td>
+				<td style="text-align: center;">1/25/16</td>
+				<td style="text-align: center;">14-1095</td>
+				<td><a href='/opinions/15pdf/14-1095_2d8f.pdf' target='_blank' title=" A challenge to the sufficiency of the evidence supporting a conviction should be assessed against the elements of the charged crime, not against the elements set forth in an erroneous jury instruction; in addition, 18 U. S. C.§3282(a)’s statute-of-limitations bar is a nonjurisdictional defense that cannot successfully be raised for the first time on appeal.">Musacchio v. United States</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">T</td>
+				<td style="text-align: center;">577/2</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">13</td>
+				<td style="text-align: center;">1/25/16</td>
+				<td style="text-align: center;">14-280</td>
+				<td><a href='/opinions/15pdf/14-280_3204.pdf' target='_blank' title=" The prohibition on mandatory life without parole for juvenile offenders announced in Miller v. Alabama, 567 U. S. ___, ___, is a new substantive rule that is retroactive in cases on state collateral review.">Montgomery v. Louisiana</a></td>
+				<td style='text-align: center;'><a href='/opinions/15pdf/14-280_diff_ifkn.pdf' target='_blank'>1/27/16</a></td>
+				<td style="text-align: center;">K</td>
+				<td style="text-align: center;">577/2</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">12</td>
+				<td style="text-align: center;">1/20/16</td>
+				<td style="text-align: center;">14-1516</td>
+				<td><a href='/opinions/15pdf/14-1516_2co3.pdf' target='_blank' title=" Certiorari dismissed as improvidently granted.">Duncan v. Owens</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">PC</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">11</td>
+				<td style="text-align: center;">1/20/16</td>
+				<td style="text-align: center;">14-857</td>
+				<td><a href='/opinions/15pdf/14-857 - new_gfbi.pdf' target='_blank' title=" Because an unaccepted settlement offer or offer of judgment does not moot a plaintiff’s case, the District Court retained jurisdiction to adjudicate respondent’s complaint in this Telephone Consumer Protection Act case; petitioner’s status as a federal contractor does not entitle it to immunity from suit under the TCPA.">Campbell-Ewald v. Gomez</a></td>
+				<td style='text-align: center;'><a href='/opinions/15pdf/14-857diff_2924.pdf' target='_blank'>2/09/16</a></td>
+				<td style="text-align: center;">G</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">10</td>
+				<td style="text-align: center;">1/20/16</td>
+				<td style="text-align: center;">14-723</td>
+				<td><a href='/opinions/15pdf/14-723_1bn2.pdf' target='_blank' title=" When a participant in an employee benefit plan governed by the Employee Retirement Income Security Act of 1974 (ERISA) wholly dissipates a third-party personal injury settlement on nontraceable assets, a plan fiduciary seeking reimbursement under the plan’s subrogation clause may not file suit under ERISA §502(a)(3) “to obtain . . . equitable relief” by attaching the participant’s general assets.">Montanile v. Board of Trustees of Nat. Elevator Industry Health Benefit Plan</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">T</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">9</td>
+				<td style="text-align: center;">1/20/16</td>
+				<td style="text-align: center;">14-449</td>
+				<td><a href='/opinions/15pdf/14-449_9o7d.pdf' target='_blank' title=" The Eighth Amendment does not require capital-sentencing courts to instruct a jury that mitigating circumstances need not be proved beyond a reasonable doubt; and the Constitution did not require severance of the joint sentencing proceedings for two brothers whose convictions arose out of a single chain of events.">Kansas v. Carr</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">AS</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">8</td>
+				<td style="text-align: center;">1/12/16</td>
+				<td style="text-align: center;">14-7505</td>
+				<td><a href='/opinions/15pdf/14-7505_5ie6.pdf' target='_blank' title=" Florida’s capital punishment sentencing scheme, which requires a judge to find and weigh any aggravating and mitigating circumstances independently of the jury’s advisory sentence, violates the Sixth Amendment in light of Ring v. Arizona, 536 U. S. 584.">Hurst v. Florida</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">SS</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">7</td>
+				<td style="text-align: center;">1/12/16</td>
+				<td style="text-align: center;">14-844</td>
+				<td><a href='/opinions/15pdf/14-844_21ok.pdf' target='_blank' title=" Where an in forma pauperis prisoner is required to pay federal-court filing fees in more than one civil action, 28 U. S. C. §1915(b)(2) calls for simultaneous, not sequential, recoupment of multiple monthly installment payments.">Bruce v. Samuels</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">G</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">6</td>
+				<td style="text-align: center;">12/14/15</td>
+				<td style="text-align: center;">14-1372</td>
+				<td><a href='/opinions/15pdf/14-1372_1p23.pdf' target='_blank' title=" The Sixth Circuit erred in overturning respondent’s death sentence on habeas review because the Kentucky Supreme Court did not unreasonably apply clearly established federal law in affirming the trial court’s exclusion of a juror who could not give sufficient assurance of neutrality or impartiality in considering whether to impose the death penalty.">White v. Wheeler</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">PC</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">5</td>
+				<td style="text-align: center;">12/14/15</td>
+				<td style="text-align: center;">14-462</td>
+				<td><a href='/opinions/15pdf/14-462_2co3.pdf' target='_blank' title=" The Federal Arbitration Act pre-empts the California Court of Appeal’s interpretation of an arbitration agreement’s choice of law provision—that binding arbitration was unenforceable where the parties intended a pre-empted California law to govern—so the state court must enforce the agreement.">DIRECTV, Inc. v. Imburgia</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">B</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">4</td>
+				<td style="text-align: center;">12/08/15</td>
+				<td style="text-align: center;">14-990</td>
+				<td><a href='/opinions/15pdf/14-990_10n2.pdf' target='_blank' title=" Title 28 U. S. C. §2284 entitles petitioners to make their case—that Maryland’s 2011 congressional redistricting plan burdens their First Amendment right of political association—before a three-judge court.">Shapiro v. McManus</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">AS</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">3</td>
+				<td style="text-align: center;">12/01/15</td>
+				<td style="text-align: center;">13-1067</td>
+				<td><a href='/opinions/15pdf/13-1067_onkq.pdf' target='_blank' title=" Respondent’s federal suit against petitioner, the Austrian state-owned railway, which arose from traumatic injuries she suffered while attempting to board a train in Austria, was not “based upon” the U. S. sale of a Eurail pass for purposes of 28 U. S. C. §1605(a)(2), the “commercial activity” exception to the Foreign Sovereign Immunities Act, and is therefore barred by sovereign immunity.">OBB Personenverkehr AG v. Sachs</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">R</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">2</td>
+				<td style="text-align: center;">11/09/15</td>
+				<td style="text-align: center;">14-1143</td>
+				<td><a href='/opinions/15pdf/14-1143_f20h.pdf' target='_blank' title=" The Fifth Circuit erred in denying qualified immunity to Trooper Mullenix, because existing precedent does not clearly establish that he acted unreasonably when he shot and killed a fleeing suspect in an attempt to disable the suspect’s vehicle.">Mullenix v. Luna</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">PC</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+			<tr>
+				<td style="text-align: center;">1</td>
+				<td style="text-align: center;">10/05/15</td>
+				<td style="text-align: center;">14-848</td>
+				<td><a href='/opinions/15pdf/14-848_pok0.pdf' target='_blank' title=" Under this Court’s “rule of contemporary assessment of counsel’s conduct,” Lockhart v. Fretwell, 506 U. S. 364, 372, Kulbicki’s counsel’s failure to unearth a 1991 report on a then-uncontroversial mode of ballistics analysis, identify its methodological flaw, and use that flaw against the State’s expert witness did not constitute deficient performance.">Maryland v. Kulbicki</a></td>
+				<td style='text-align: center;'>&nbsp;</td>
+				<td style="text-align: center;">PC</td>
+				<td style="text-align: center;">577/1</td>
+			</tr>
+
+		</table>
+
+
+</center>
+
+<br />
+
+
+				</div>
+			</div>
+		</div>
+	<div class="container well">
+        <div class="noindex">
+		    <div class="container">
+			    <div class="row">
+				    <div class="col-lg-12 col-md-12 col-sm-12">
+
+					    <div id="versiontext" class="text-center"  style="display:block; width: auto;"><span id="ctl00_ctl00_lbltoday">February 11, 2016</span>
+						    |  Version 2014.1</div>
+					    <div class="text-center"  id="footertext">
+					       <a id="ctl00_ctl00_hypHome" href="../">Home</a>
+                            |
+					       <a id="ctl00_ctl00_hypHelp" href="../help.aspx">Help</a>
+						    |
+					       <a id="ctl00_ctl00_hpsitemap" href="../sitemap.aspx">Site Map</a>
+						    |
+					       <a id="ctl00_ctl00_HypContactUs" href="../contact/contactus.aspx">Contact Us</a>
+						    |
+					       <a id="ctl00_ctl00_HypAboutUs" href="../about/about_us.aspx">About Us</a>
+						    |
+					       <a id="ctl00_ctl00_HypFAQ" href="../faq.aspx">FAQ</a>
+						    |
+                           <a id="ctl00_ctl00_HypJobs" href="../jobs/jobs.aspx">Jobs</a>
+                            |
+                           <a id="ctl00_ctl00_HypLinks" href="../links/links.aspx">Links</a>
+                            |
+                           <a id="ctl00_ctl00_Hyperlink63" href="../publicinfo/buildingregulations.aspx">Building Regulations</a><br />
+
+					       <a id="ctl00_ctl00_HypWebPolicy" href="../policies/web_policies_and_notices.aspx">Website Policies and Notices</a>
+						    |
+					       <a id="ctl00_ctl00_HypPrivacy" href="../policies/privacy_notice.aspx">Privacy Policy</a>
+                            |
+					       <a id="ctl00_ctl00_hypUSA" href="../redirect.aspx?federal=y&amp;newURL=www.usa.gov">USA.GOV</a><br />
+
+					       <span style="display:block; margin-top: 5px; font-size: 14pt;font-weight:bold; color: #000;">Supreme Court of the United States</span>
+					    </div>
+
+				    </div>
+			    </div>
+		    </div>
+        </div>
+	</div>
+
+
+<script type="text/javascript">
+//<![CDATA[
+var Page_Validators =  new Array(document.getElementById("ctl00_ctl00_RegularExpressionValidator2"), document.getElementById("ctl00_ctl00_SearchVal"));
+//]]>
 </script>
 
 <script type="text/javascript">
-    //<![CDATA[
-    function WebForm_OnSubmit() {
-        if (typeof(ValidatorOnSubmit) == "function" && ValidatorOnSubmit() == false) return false;
+//<![CDATA[
+var ctl00_ctl00_RegularExpressionValidator2 = document.all ? document.all["ctl00_ctl00_RegularExpressionValidator2"] : document.getElementById("ctl00_ctl00_RegularExpressionValidator2");
+ctl00_ctl00_RegularExpressionValidator2.controltovalidate = "ctl00_ctl00_txtSearch";
+ctl00_ctl00_RegularExpressionValidator2.errormessage = "Search term too short ";
+ctl00_ctl00_RegularExpressionValidator2.evaluationfunction = "RegularExpressionValidatorEvaluateIsValid";
+ctl00_ctl00_RegularExpressionValidator2.validationexpression = "^[\\s\\S]{3,}$";
+var ctl00_ctl00_SearchVal = document.all ? document.all["ctl00_ctl00_SearchVal"] : document.getElementById("ctl00_ctl00_SearchVal");
+ctl00_ctl00_SearchVal.controltovalidate = "ctl00_ctl00_txtSearch";
+ctl00_ctl00_SearchVal.errormessage = "Invalid text in search term. Try again";
+ctl00_ctl00_SearchVal.evaluationfunction = "RegularExpressionValidatorEvaluateIsValid";
+ctl00_ctl00_SearchVal.validationexpression = "[\\w\\s-/\"\'() /*@.]*";
+//]]>
+</script>
+
+
+<script type="text/javascript">
+//<![CDATA[
+
+var Page_ValidationActive = false;
+if (typeof(ValidatorOnLoad) == "function") {
+    ValidatorOnLoad();
+}
+
+function ValidatorOnSubmit() {
+    if (Page_ValidationActive) {
+        return ValidatorCommonOnSubmit();
+    }
+    else {
         return true;
     }
-    //]]>
-</script>
+}
 
-<div class="aspNetHidden">
+document.getElementById('ctl00_ctl00_RegularExpressionValidator2').dispose = function() {
+    Array.remove(Page_Validators, document.getElementById('ctl00_ctl00_RegularExpressionValidator2'));
+}
 
-    <input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="CF2965E9" />
-    <input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEdAAhfp79ePDq24g1p5rNabk6WdcLA2cVr55mmAI/xV+qwRAMiFNqFT7E2zKelBoXU3xbDDU+RV/jOi+vSugvNJrSXAeQgnDYEcS/A3pq4nSD4D0Ddcr9W1vG3+GTAwlOJUM51PENixjB8uIhh9HSYVMY81TqJGMO3GEtAB5QnaLsNtGnSiR9+4EdhuvZPKLD5bZ5nuXfAlwqyZC0x1tuqtGQJ" />
-</div>
-<script type="text/javascript">
-    //<![CDATA[
-    Sys.WebForms.PageRequestManager._initialize('ctl00$ctl00$RadScriptManager1', 'aspnetForm', [], [], [], 90, 'ctl00$ctl00');
-    //]]>
-</script>
-
-<div class="container well well-lg">
-<div class="row bannerStyle">
-    <div class="col-md-6 col-xs-12">
-        <a id="ctl00_ctl00_hypSealLink" href="../../default.aspx"><img id="ctl00_ctl00_imgSeal" class="SCUSSeal" src="../../images/banner_h120.jpg" alt="Supreme Court of the United States" /></a>
-    </div>
-    <div class="col-md-6 col-xs-12" style="font-size: 9pt;">
-        <div class="Div1">
-            <a id="ctl00_ctl00_wucBannerMenu_Hyperlink42" href="../../visiting/visiting.aspx">Visiting the Court</a> &nbsp;|&nbsp;
-            <a id="ctl00_ctl00_wucBannerMenu_Hyperlink53" href="../../visiting/touringthebuilding.aspx">Touring the Building</a> &nbsp;|&nbsp;
-            <a id="ctl00_ctl00_wucBannerMenu_Hyperlink1" href="../../visiting/exhibition.aspx">Exhibitions</a>
-        </div>
-        <div class="pull-right search">
-            <div id="ctl00_ctl00_pnlSearch">
-
-                <table>
-                    <tr>
-                        <td>
-                            <span id="ctl00_ctl00_lblSearchOn" style="font-weight:bold;">Search: </span>&nbsp;
-                            <span title="Radio button - Search All Documents"><input id="ctl00_ctl00_rdoSCD" type="radio" name="ctl00$ctl00$USSC" value="rdoSCD" checked="checked" /><label for="ctl00_ctl00_rdoSCD">All Documents</label></span>
-                            <span title="Radio Button - Search Docket"><input id="ctl00_ctl00_rdoDocket" type="radio" name="ctl00$ctl00$USSC" value="rdoDocket" /><label for="ctl00_ctl00_rdoDocket">Docket</label></span>
-                        </td>
-                    </tr>
-                    <tr>
-                        <td>
-                            <span id="ctl00_ctl00_lblForDocuments" style="font-weight:bold;">Enter Search Text:</span>
-                            <input name="ctl00$ctl00$txtSearch" type="text" id="ctl00_ctl00_txtSearch" /><input name="ctl00$ctl00$txbhidden" type="text" id="ctl00_ctl00_txbhidden" style="visibility: hidden; display: none;" />&nbsp;
-                            <input type="submit" name="ctl00$ctl00$cmdSearch" value="Search" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdSearch&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_cmdSearch" title="Perform quick search" /> &nbsp;
-                            <input type="submit" name="ctl00$ctl00$cmdHelp" value="Help" onclick="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$cmdHelp&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, false))" id="ctl00_ctl00_cmdHelp" title="Search help tips" /><br />
-
-                            <span id="ctl00_ctl00_RegularExpressionValidator2" style="display:inline-block;height:20px;visibility:hidden;">Search must be 3 char.</span>
-
-
-                            <span id="ctl00_ctl00_SearchVal" style="display:inline-block;height:20px;visibility:hidden;">Invalid text in search term. Try again</span>
-
-                        </td>
-                    </tr>
-                </table>
-
-            </div>
-        </div>
-    </div>
-</div>
-<div class="row" style="margin-bottom: 5px;">
-    <div class="col-lg-10 col-md-10">
-        <div id="sitemappath">
-            <span id="ctl00_ctl00_SiteMapPath1" style="color:#ED0303;font-size:1em;"><a href="#ctl00_ctl00_SiteMapPath1_SkipLink"><img alt="Skip Navigation Links" src="/WebResource.axd?d=WLY2oepp1eKPePERXTuqUau_buIJz5S7ntqiGL3pUm39ydKxNwryN9m5LqCjmtlpSPkXXzclABxfMGVVXMTu6J6S8rDd4o05EnrXXVm10l81&amp;t=635418424260000000" width="0" height="0" style="border-width:0px;" /></a><span><a title="Supreme Court Home" href="/default.aspx" style="color:#507CD1;font-weight:bold;">Home</a></span><span style="color:#507CD1;font-weight:bold;"> | </span><span><a title="Opinions" href="/opinions/opinions.aspx" style="color:#284E98;font-weight:bold;">Opinions</a></span><span style="color:#507CD1;font-weight:bold;"> | </span><span style="color:Red;font-weight:bold;"></span><span style="color:Red;">2014 Term Opinions of the Court</span><a id="ctl00_ctl00_SiteMapPath1_SkipLink"></a></span>
-        </div>
-    </div>
-    <div class="col-lg-2 col-md-2 text-right">
-
-    </div>
-</div>
-<div class="navbar navbar-inverse" role="navigation">
-    <div class="container-fluid">
-        <!-- menu starts here -->
-
-        <div class="navbar-header">
-            <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                <span class="sr-only">Toggle navigation</span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-                <span class="icon-bar"></span>
-            </button>
-
-        </div>
-        <div class="navbar-collapse collapse">
-            <ul class="nav navbar-nav">
-                <li class="dropdown">
-                    <a id="ctl00_ctl00_wucNewMenu1_HyperLink5" class="dropdown-toggle" href="../opinions.aspx">Opinions</a>
-                    <ul class="dropdown-menu">
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink30" href="../slipopinions.aspx">Latest Slip Opinions</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink31" href="../relatingtoorders.aspx">Opinions Relating to Orders</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink32" href="../in-chambers.aspx">In-Chambers Opinions</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink1" href="../opinions.aspx">Slip opinions - Earlier Terms</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink34" href="../counsellist.aspx">Counsel Listings</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink35" href="../boundvolumes.aspx">Bound Volumes</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink36" href="../../media/media.aspx">Media Files Related to Opinions</a></li>
-                        <li>&nbsp;</li>
-                    </ul>
-                </li>
-                <li class="dropdown"><a id="ctl00_ctl00_wucNewMenu1_hl" class="dropdown-toggle" href="../../oral_arguments/oral_arguments.aspx">Oral Arguments</a>
-                    <ul class="dropdown-menu">
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink15" href="../../oral_arguments/2014TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2014)</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink9" href="../../oral_arguments/2013termcourtcalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2013)</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink8" href="../../oral_arguments/2012TermCourtCalendar.pdf" target="_blank">Supreme Court Calendar (PDF) (October Term 2012)</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink10" href="../../oral_arguments/argument_calendars.aspx">Argument Calendars</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink11" href="../../oral_arguments/hearinglist.aspx">Hearing Lists</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink12" href="../../visiting/visitorsguidetooralargument.aspx">Visitor's Guide to Oral Argument</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink13" href="../../oral_arguments/argument_transcript.aspx">Argument Transcripts</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink14" href="../../oral_arguments/argument_audio.aspx">Argument Audio</a></li>
-                        <li>&nbsp;</li>
-                    </ul>
-                </li>
-                <li class="dropdown">
-                    <a id="ctl00_ctl00_wucNewMenu1_HyperLink41" class="dropdown-toggle" href="../../case_documents.aspx">Case Documents</a>
-                    <ul class="dropdown-menu">
-                        <li><a id="ctl00_ctl00_wucNewMenu1_hldocket" href="../../docket/docket.aspx">Docket Search</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink18" href="../../redirect.aspx?newURL=www.americanbar.org/publications/preview_home/alphabetical.html">On-Line MERITS BRIEFS</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink17" href="../../oral_arguments/briefsource.aspx">Where to Find Briefs</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_hypOrdersOfCourt" href="../../orders/ordersofthecourt/14">Orders of the Court - 2014 Term</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink43" href="../../orders/orders.aspx#Orders">Orders - Earlier Term</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink67" href="../../orders/orders.aspx#OrdersByCircuit">Orders by Circuit</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink68" href="../../orders/orders.aspx#GrantedNotedCases">Granted/Noted Cases List</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink39" href="../../orders/journal.aspx">Journal</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink7" href="../../SpecMastRpt/SpecMastRpt.aspx">Special Master Reports</a></li>
-                        <li>&nbsp;</li>
-                    </ul>
-                </li>
-                <li class="dropdown">
-                    <a id="ctl00_ctl00_wucNewMenu1_HyperLink69" class="dropdown-toggle" href="../../rules_guidance.aspx">Rules & Guidance</a>
-                    <ul class="dropdown-menu">
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink3" href="../../ctrules/ctrules.aspx">Court Rules</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink4" href="../../casehand/casehand.aspx">Guides for Counsel</a>
-                            <ul class="dropdown-menu sub-menu">
-                                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink26" href="../../casehand/guidetofilingpaidcases2012.pdf" target="_blank">Guide to Filing Paid Cases (PDF)</a></li>
-                                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink6" href="../../casehand/courtspecchart02162010.aspx">Paid Cases Brief Chart</a></li>
-                                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink27" href="../../casehand/guideforifpcases2012.pdf" target="_blank">Guide to Filing <i>In Forma Pauperis</i> Cases (PDF) </a></li>
-                                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink28" href="../../oral_arguments/guideforcounsel.pdf" target="_blank">Guide for Counsel in Cases to be Argued (PDF)</a></li>
-                                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink29" href="../../oral_arguments/2010ElectronicMeritsBriefsSubmissionGuidelines.pdf" target="_blank">Electronic Merits Briefs Submission Guidelines (PDF)</a></li>
-                                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink16" href="../../deliveryofdocuments.aspx">Delivery of Documents to the Clerk's Office</a></li>
-                            </ul>
-                        </li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink2" href="../../bar/baradmissions.aspx">Supreme Court Bar</a>
-                            <ul class="dropdown-menu sub-menu">
-                                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink20" href="../../bar/barinstructions.pdf" target="_blank">Bar Admissions Instructions (PDF)</a></li>
-                                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink19" href="../../bar/barapplication.pdf" target="_blank">Bar Admissions Forms (PDF)</a></li>
-                                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink21" href="../../bar/smallGroups_ArguDays_instr.pdf" target="_blank">Small Group Admissions - Argument Days (PDF)</a></li>
-                                <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink22" href="../../bar/largeGroups_NonArgument_Instr.pdf" target="_blank">Large Group Admissions - Nonargument Days (PDF)</a></li>
-                            </ul>
-                        </li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HypCaseDistribution" href="../../casedistribution/casedistributionschedule.aspx">Case Distribution Schedule</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink40" href="../../casehand/waiver.pdf" target="_blank">Waiver Form (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink70" href="../../orders/courtorders/ALLOTMENTORDER9-28-10.pdf" target="_blank">Circuit Assignments of Justices</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_HyperLink71" href="../../about/Circuit%20Map.pdf" target="_blank">&nbsp;&nbsp;&nbsp;&nbsp; - Circuit Map</a></li>
-                        <li>&nbsp;</li>
-                    </ul>
-                </li>
-
-                <li class="dropdown">
-                    <a id="ctl00_ctl00_wucNewMenu1_hypCourtInfo" class="dropdown-toggle" href="../../publicinfo/publicinfo.aspx">News Media</a>
-                    <ul class="dropdown-menu">
-                        <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink57" href="../../publicinfo/press/pressreleases.aspx">Press Releases</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink58" href="../../publicinfo/media/mediaadvisories.aspx">Media Advisories</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink59" href="../../publicinfo/speeches/speeches.aspx">Speeches</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink62" href="../../publicinfo/reportersguide.pdf" target="_blank">A Reporter's Guide to Applications (PDF)</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink60" href="../../publicinfo/year-end/year-endreports.aspx">Chief Justice's Year-End Reports on the Federal Judiciary</a></li>
-                        <li>&nbsp;</li>
-                    </ul>
-                </li>
-                <li class="dropdown">
-                    <a id="ctl00_ctl00_wucNewMenu1_hypAboutCourt" class="dropdown-toggle" href="../../about/about.aspx">About the Court</a>
-                    <ul class="dropdown-menu">
-                        <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink46" href="../../about/briefoverview.aspx">Brief Overview</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink47" href="../../about/biographies.aspx">Biographies of Current Justices</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink48" href="../../about/members.aspx">Justices 1789 to Present</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink49" href="../../about/courtbuilding.aspx">The Supreme Court Building</a></li>
-                        <li><a id="ctl00_ctl00_wucNewMenu1_Hyperlink45" href="../../redirect.aspx?federal=y&amp;newURL=www.archives.gov/historical-docs/document.html?doc=3&amp;title.raw=Constitution%252">Constitution</a></li>
-                        <li>&nbsp;</li>
-                    </ul>
-                </li>
-            </ul>
-        </div>
-        <!-- menu ends here -->
-    </div>
-</div>
-
-<div class="row">
-    <div class="col-lg-12 col-md-12 col-sm-12" id="mainbody">
-
-
-        <div class="col-sm-12 sectiontitle">
-            <div id="sectionbanner5">
-                <div id="pagetitle">
-                    <h3><span id="ctl00_ctl00_MainEditable_mainContent_lblTitle" style="font-weight:bold;">2014 Term Opinions of the Court</span></h3>
-                </div>
-            </div>
-        </div>
-        <p align="center"><font size="+1">Slip Opinions, <i>Per Curiams</i> (PC), and Original Case Decrees
-            (D)</font></p>
-
-        <p>The "slip" opinion is the second version of an opinion. It is sent to the printer later in the day
-            on which the "bench" opinion is released by the Court. Each slip opinion has the same elements as the
-            bench opinion--majority or plurality opinion, concurrences or dissents, and a prefatory syllabus--but
-            may contain corrections not appearing in the bench opinion. The slip opinions collected here are those
-            issued during <span id="ctl00_ctl00_MainEditable_mainContent_lblTerms">October Term 2014 (October 6, 2014, through October 4, 2015)</span>. These opinions are posted on the Website
-            within minutes after the bench opinions are issued and will remain posted until the opinions for the
-            entire Term are published in the bound volumes of the United States Reports. For further information,
-            see <a id="ctl00_ctl00_MainEditable_mainContent_lbnDefA" href="javascript:WebForm_DoPostBackWithOptions(new WebForm_PostBackOptions(&quot;ctl00$ctl00$MainEditable$mainContent$lbnDefA&quot;, &quot;&quot;, true, &quot;&quot;, &quot;&quot;, false, true))">Column Header Definitions</a> and the file entitled
-            <a href="/opinions/info_opinions.aspx">Information About Opinions</a>.</p>
-
-        <p><b>Caution:</b> These electronic opinions may contain computer-generated errors or other deviations
-            from the official printed slip opinion pamphlets. Moreover, a slip opinion is replaced within a few
-            months by a paginated version of the case in the preliminary print, and--one year after the issuance
-            of that print--by the final version of the case in a U. S. Reports bound volume. In case of discrepancies
-            between the print and electronic versions of a slip opinion, the print version controls. In case of
-            discrepancies between the slip opinion and any later official version of the opinion, the later version
-            controls.</p>
-        <br />
-
-        <center>
-
-            <table class="table table-bordered" style="text-align: left;"  cellspacing="0" cellpadding="2">
-                <tr>
-                    <th style="text-align: center;" width="20" scope="col">R-</th>
-                    <th style="text-align: center;" width="60" scope="col">Date</th>
-                    <th style="text-align: center;" width="60" scope="col">Docket</th>
-                    <th style="text-align: center;" width="400" scope="col">Name</th>
-                    <th style="text-align: center;" width="20" scope="col">J.</th>
-                    <th style="text-align: center;" width="40" scope="col">Pt.</th>
-                </tr>
-
-                <tr>
-                    <td style="text-align: center;">1</td>
-                    <td style="text-align: center;">10/06/14</td>
-                    <td style="text-align: center;">13-946</td>
-                    <td><a href='/opinions/14pdf/13-946_adbc.pdf' target='_blank' title=" The Ninth Circuit erred in granting habeas relief based on its own precedent, where this Court's case law had not 'clearly establish[ed]' that a defendant adequately apprised of the possibility of conviction on an aiding-and-abetting theory can nevertheless be deprived of adequate notice by a prosecutorial decision to focus on another theory at trial, see 28 U. S. C. 2254(d)(1).">Lopez v. Smith</a></td>
-                    <td style="text-align: center;">574/1</td>
-                    <td style="text-align: center;">574/1</td>
-                </tr>
-
-            </table>
-
-
-        </center>
-
-        <br />
-
-
-    </div>
-</div>
-</div>
-<div class="container well">
-    <div class="container">
-        <div class="row">
-            <div class="col-lg-12 col-md-12 col-sm-12">
-
-                <div id="versiontext" class="text-center"  style="display:block; width: auto;"><span id="ctl00_ctl00_lbltoday">October 08, 2014</span>
-                    |  Version 2014.1</div>
-                <div class="text-center"  id="footertext">
-                    <a id="ctl00_ctl00_hypHome" href="../../">Home</a>
-                    |
-                    <a id="ctl00_ctl00_hypHelp" href="../../help.aspx">Help</a>
-                    |
-                    <a id="ctl00_ctl00_hpsitemap" href="../../sitemap.aspx">Site Map</a>
-                    |
-                    <a id="ctl00_ctl00_HypContactUs" href="../../contact/contactus.aspx">Contact Us</a>
-                    |
-                    <a id="ctl00_ctl00_HypAboutUs" href="../../about/about_us.aspx">About Us</a>
-                    |
-                    <a id="ctl00_ctl00_HypFAQ" href="../../faq.aspx">FAQ</a>
-                    |
-                    <a id="ctl00_ctl00_HypJobs" href="../../jobs/jobs.aspx">Jobs</a>
-                    |
-                    <a id="ctl00_ctl00_HypLinks" href="../../links/links.aspx">Links</a>
-                    |
-                    <a id="ctl00_ctl00_Hyperlink63" href="../../publicinfo/buildingregulations.aspx">Building Regulations</a><br />
-
-                    <a id="ctl00_ctl00_HypWebPolicy" href="../../policies/web_policies_and_notices.aspx">Website Policies and Notices</a>
-                    |
-                    <a id="ctl00_ctl00_HypPrivacy" href="../../policies/privacy_notice.aspx">Privacy Policy</a>
-                    |
-                    <a id="ctl00_ctl00_hypUSA" href="../../redirect.aspx?federal=y&amp;newURL=www.usa.gov">USA.GOV</a><br />
-
-                    <span style="display:block; margin-top: 5px; font-size: 14pt;font-weight:bold; color: #000;">Supreme Court of the United States</span>
-                </div>
-
-            </div>
-        </div>
-    </div>
-</div>
-
-
-<script type="text/javascript">
-    //<![CDATA[
-    var Page_Validators =  new Array(document.getElementById("ctl00_ctl00_RegularExpressionValidator2"), document.getElementById("ctl00_ctl00_SearchVal"));
-    //]]>
-</script>
-
-<script type="text/javascript">
-    //<![CDATA[
-    var ctl00_ctl00_RegularExpressionValidator2 = document.all ? document.all["ctl00_ctl00_RegularExpressionValidator2"] : document.getElementById("ctl00_ctl00_RegularExpressionValidator2");
-    ctl00_ctl00_RegularExpressionValidator2.controltovalidate = "ctl00_ctl00_txtSearch";
-    ctl00_ctl00_RegularExpressionValidator2.errormessage = "Search must be 3 char.";
-    ctl00_ctl00_RegularExpressionValidator2.evaluationfunction = "RegularExpressionValidatorEvaluateIsValid";
-    ctl00_ctl00_RegularExpressionValidator2.validationexpression = "^[\\s\\S]{3,}$";
-    var ctl00_ctl00_SearchVal = document.all ? document.all["ctl00_ctl00_SearchVal"] : document.getElementById("ctl00_ctl00_SearchVal");
-    ctl00_ctl00_SearchVal.controltovalidate = "ctl00_ctl00_txtSearch";
-    ctl00_ctl00_SearchVal.errormessage = "Invalid text in search term. Try again";
-    ctl00_ctl00_SearchVal.evaluationfunction = "RegularExpressionValidatorEvaluateIsValid";
-    ctl00_ctl00_SearchVal.validationexpression = "[\\w\\s-/?\"\'&/*.]*";
-    //]]>
-</script>
-
-
-<script type="text/javascript">
-    //<![CDATA[
-
-    var Page_ValidationActive = false;
-    if (typeof(ValidatorOnLoad) == "function") {
-        ValidatorOnLoad();
-    }
-
-    function ValidatorOnSubmit() {
-        if (Page_ValidationActive) {
-            return ValidatorCommonOnSubmit();
-        }
-        else {
-            return true;
-        }
-    }
-
-    document.getElementById('ctl00_ctl00_RegularExpressionValidator2').dispose = function() {
-        Array.remove(Page_Validators, document.getElementById('ctl00_ctl00_RegularExpressionValidator2'));
-    }
-
-    document.getElementById('ctl00_ctl00_SearchVal').dispose = function() {
-        Array.remove(Page_Validators, document.getElementById('ctl00_ctl00_SearchVal'));
-    }
-    //]]>
+document.getElementById('ctl00_ctl00_SearchVal').dispose = function() {
+    Array.remove(Page_Validators, document.getElementById('ctl00_ctl00_SearchVal'));
+}
+//]]>
 </script>
 </form>
 </body>


### PR DESCRIPTION
Updated scotus scrapers and associated example html files to reflect new site format, which now includes a 'Revised' column in the tables.  Also added a new convert_date_string() method to lib/string_utils.py to get valid date() object form a given date string