### PR TITLE
Fixing New York Court of Appeals scraper

### DIFF
--- a/opinions/opinion_template.py
+++ b/opinions/opinion_template.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from lxml import html
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.string_utils import titlecase
+from juriscraper.lib.string_utils import convert_date_string
 
 
 class Site(OpinionSite):
@@ -72,8 +73,7 @@ class Site(OpinionSite):
             here: http://docs.python.org/2/library/datetime.html
         """
         path = '//path/to/text/text()'
-        return [datetime.strptime(date_string, '%m/%d/%Y').date()
-                for date_string in self.html.xpath(path)]
+        return [convert_date_string(date_string) for date_string in self.html.xpath(path)]
 
     def _get_precedential_statuses(self):
         """ In most cases, this field should be normalized to either

--- a/tests/examples/opinions/united_states/ny_example.html
+++ b/tests/examples/opinions/united_states/ny_example.html
@@ -1,41 +1,71 @@
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/Other.dwt" codeOutsideHTMLIsLocked="false" --><head>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-<meta http-equiv="cache-control" content="max-age=0">
-<meta http-equiv="cache-control" content="no-cache">
-<meta http-equiv="expires" content="-1">
-<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT">
-<meta http-equiv="pragma" content="no-cache">
-<meta http-equiv="expires" content="timestamp">
+<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/Decisions Page.dwt" codeOutsideHTMLIsLocked="false" -->
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <!-- InstanceBeginEditable name="doctitle" -->
-<title>June 2014 Decision</title>
+<title></title>
 <!-- InstanceEndEditable -->
-<script type="text/javascript" src="ny_example_files/jquery.htm"></script>
-<script type="text/javascript" src="ny_example_files/ddaccordion.htm"></script>
-
-
-<script type="text/javascript">
-function popup(mylink, windowname)
-{
-if (! window.focus)return true;
-var href;
-if (typeof(mylink) == 'string')
-   href=mylink;
-else
-   href=mylink.href;
-window.open(href, windowname, 'width=500,height=300,scrollbars=yes');
-return false;
-}
-<!-- Function to create Pop-Up Window -->
-</script>
+<!-- InstanceBeginEditable name="head" -->
+<!-- InstanceEndEditable -->
 <style type="text/css">
-<!--
 body {
-	background-image: url(../../../images/coaback.jpg);
-	margin-top: 0px;
+	background-image: url(../../../images/coabackgrd.jpg);
+}
+#MainHeader {
+	position:absolute;
+	width:518px;
+	height:81px;
+	z-index:auto;
+	left: 245px;
+	top: 7px;
+}
+#MainSearch {
+	position:absolute;
+	width:280px;
+	height:80px;
+	z-index:auto;
+	float: left;
+}
+#MainBody {
+	position:absolute;
+	width:850px;
+	height:115px;
+	z-index:auto;
+	left: 245px;
+	top: 133px;
+}
+#BodyDiv {
+	background-color: #FFFFFF;
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+	padding-left: 5px;
+	padding-top: 5px;
+}
+}
+#Menubar {
+	top: 500px;
+	width:280px;
+	height:60px;
+}
+#awmAnchor-menu {
+	position:absolute;
+	width:801px;
+	height:33px;
+	z-index:1;
+	left: 245px;
+	top: 94px;
+}
+#SearchDiv {
+	position:absolute;
+	width:324px;
+	height:78px;
+	z-index:2;
+	left: 767px;
+	top: 8px;
+	text-align: right;
 }
 body,td,th {
-	font-family: Trebuchet MS, Arial, Helvetica, sans-serif;
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
 	font-size: small;
 }
 a:link {
@@ -50,537 +80,90 @@ a:hover {
 a:active {
 	text-decoration: none;
 }
--->
 </style>
-<!-- InstanceBeginEditable name="head" -->
-<!-- InstanceEndEditable -->
 </head>
 
 <body>
 <!-- DO NOT MOVE! The following AllWebMenus linking code section must always be placed right AFTER the BODY tag-->
 <!-- ******** BEGIN ALLWEBMENUS CODE FOR menu ******** -->
-<script type="text/javascript">var MenuLinkedBy="AllWebMenus [4]",awmMenuName="menu",awmBN="848";awmAltUrl="";</script><script charset="UTF-8" src="ny_example_files/menu.htm" type="text/javascript"></script><script type="text/javascript">awmBuildMenu();</script>
+<script type="text/javascript">var MenuLinkedBy="AllWebMenus [4]",awmMenuName="menu",awmBN="848";awmAltUrl="";</script><script charset="UTF-8" src="../../../menu.js" type="text/javascript"></script><script type="text/javascript">awmBuildMenu();</script>
 <!-- ******** END ALLWEBMENUS CODE FOR menu ******** -->
-<table cellpadding="1" align="center" border="0" width="800">
-  <tbody><tr>
-    <td><table cellpadding="0" cellspacing="0" border="0" width="100%">
-      <tbody><tr>
-        <td width="65%"><img src="ny_example_files/coatitlesm.jpg" alt="Court of Appeals Title" height="82" width="517"></td>
-        <td align="right" valign="top" width="35%"><table cellpadding="0" cellspacing="0" border="0" width="100%">
-          <tbody><tr>
-            <td align="right">
-            <table cellpadding="0" cellspacing="0" border="0">
-         <tbody><tr>
-            <td valign="middle"><form name="gs" method="GET" action="http://search.nycourts.gov/search" onsubmit="return (this.q.value == '') ? false : true;">
-               <table cellpadding="0" cellspacing="0" border="0">
-                  <tbody><tr>
 
-                     <td>
-                        <table cellpadding="4" cellspacing="0"></table>
-                     </td>
-                  </tr>
-                  <tr>
-                     <td>
-                        <table cellpadding="0" cellspacing="0">
-                           <tbody><tr>
-                              <td valign="top"><font size="-1"><input name="q" size="32" maxlength="256" type="text"></font></td>
+<div id="MainHeader"><img src="../../../images/coatitlesmIII.gif" width="517" height="82" />
 
-                              <td align="center" valign="middle"><font size="-1">&nbsp;<input name="btnG" value="Search" type="submit">
-                              </font><font size="-2">&nbsp;<br></font></td>
-                              </tr>
-                        </tbody></table>
-                     </td>
-                  </tr>
-               </tbody></table>
-               <input name="client" value="appeals_frontend" type="hidden">
 
-               <input name="output" value="xml_no_dtd" type="hidden">
-               <input name="proxystylesheet" value="appeals_frontend" type="hidden">
-               <input name="sort" value="date:D:L:d1" type="hidden">
-               <input name="entqr" value="0" type="hidden">
-               <input name="oe" value="UTF-8" type="hidden"><input name="ie" value="UTF-8" type="hidden">
-               <input name="ud" value="1" type="hidden">
-               <input name="proxyreload" value="1" type="hidden">
-               <input name="site" value="appeals" type="hidden"></form>
-            </td>
-
-         </tr>
-      </tbody></table>
-
-          </td></tr>
-        </tbody></table>
-          <a href="http://iapps.courts.state.ny.us/lawReporting/CourtOfAppealsSearch" style="color: #f7d385">Advanced Decision Search </a></td>
-      </tr>
-    </tbody></table></td>
-  </tr>
-  <tr>
-    <td><img src="ny_example_files/spacer.htm" alt="Spacer" height="1" width="1"></td>
-  </tr>
-  <tr>
-    <td><span id="awmAnchor-menu"></span></td>
-  </tr>
-  <tr>
-    <td><img src="ny_example_files/spacer.htm" alt="Spacer" height="1" width="1"></td>
-  </tr>
-  <tr>
-    <td><img src="ny_example_files/spacer.htm" alt="Spacer" height="1" width="1"></td>
-  </tr>
-  <tr>
-    <td><img src="ny_example_files/spacer.htm" alt="Spacer" height="1" width="1"></td>
-  </tr>
-  <tr>
-    <td><img src="ny_example_files/spacer.htm" alt="Spacer" height="1" width="1"></td>
-  </tr>
-  <tr>
-    <td><img src="ny_example_files/spacer.htm" alt="Spacer" height="1" width="1"></td>
-  </tr>
-  <tr>
-    <td><img src="ny_example_files/spacer.htm" alt="Spacer" height="1" width="1"></td>
-  </tr>
-  <tr>
-    <td><!-- InstanceBeginEditable name="Main Body" -->
-      <table summary="Main Page Centered Table" cellpadding="5" cellspacing="0" border="0" width="100%">
-        <tbody><tr bgcolor="#FFFFFF">
-          <td valign="top"><table summary="Main Page Centered Table" cellpadding="5" cellspacing="0" border="0" width="100%">
-            <tbody><tr bgcolor="#FFFFFF">
-              <td bgcolor="#FFFFFF" valign="top"><p><span style="font-size: small; font-weight: bold;"><img src="ny_example_files/arrow.gif" alt="" align="absmiddle" height="18" width="16"><a href="http://www.courts.state.ny.us/ctapps/index.htm">Home</a> <img src="ny_example_files/arrow.gif" alt="" align="absmiddle" height="18" width="16"><a href="http://www.courts.state.ny.us/ctapps/decisions.htm">Court Decisions</a> <img src="ny_example_files/arrow.gif" alt="" align="absmiddle" height="18" width="16">June 2014 Decisions</span></p>
-                <div align="justify">
-                  <hr>
-                  <table cellpadding="3" cellspacing="4" bgcolor="#FFFFFF" border="0" width="100%">
-                    <tbody><tr>
-                      <td colspan="4" bgcolor="#FFFFFF"><font face="Arial, Helvetica, sans-serif" size="+1">June 30, 2014</font></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><strong><font face="Arial, Helvetica, sans-serif" size="2">Decision 
-                        List </font></strong></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/DecisionList063014.pdf">PDF</a></b></font></div></td>
-                      <td align="center">&nbsp;</td>
-                      <td bgcolor="#FFFFFF"><font face="Arial, Helvetica, sans-serif" size="2">Entries 
-                        for Cases and Motions </font></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 178 SSM 14</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/SSM14ent14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/SSM14ent14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Thomas Boyle v. Starwood Hotels &amp; Resorts Worldwide, Inc.</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 133</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/133opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/133opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Mark Garrett</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          131</font></strong><br>
-                          <strong><font face="Arial, Helvetica, sans-serif" size="2">No. 130</font></strong></p>
-</div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/130-131opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/130-131opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Cooperstown Holstein Corporation v. Town of Middlefield</font><br>
-                        <font face="Arial, Helvetica, sans-serif" size="2">In the Matter of Mark S. Wallach, as Chapter 7 Trustee for Norse Energy Corp. USA v. Town of Dryden</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          129</font></strong><br>
-                        </p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/129opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/129opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. John F. Haggerty, Jr.</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 119</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/119opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/119opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Patrick Lynch v. The City of New York</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          105</font></strong><br>
-                        </p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/105opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/105opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Roman Baret</font></p></td>
-                    </tr>
-                    <tr>
-                      <td colspan="4" bgcolor="#FFFFFF"><hr></td>
-                    </tr>
-                    <tr>
-                      <td colspan="4" bgcolor="#FFFFFF"><font face="Arial, Helvetica, sans-serif" size="+1">June 26, 2014</font></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><strong><font face="Arial, Helvetica, sans-serif" size="2">Decision 
-                        List </font></strong></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/DecisionList062614.pdf">PDF</a></b></font></div></td>
-                      <td align="center">&nbsp;</td>
-                      <td bgcolor="#FFFFFF"><font face="Arial, Helvetica, sans-serif" size="2">Entries 
-                        for Cases and Motions </font></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 177 SSM 13</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/SSM13ent14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/SSM13ent14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">In
- the Matter of Kelley S. Boyd v. New York State Division of Housing v. 
-New York State Division of Housing and Community Renewal</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 176 SSM 10</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/SSM10ent14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/SSM10ent14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Jeffrey Johnson</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          140</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/140mem14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/140mem14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">In the Matter of Pablo Costello v. New York State Board of Parole</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          134</font></strong><br>
-                        </p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/134opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/134opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">In
- the Matter of New York Statewide Coalition of Hispanic Chambers of 
-Commerce v. The New York City Department of Health and Mental Hygiene</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 132</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/132opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/132opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Oliverio Galindo</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          121</font></strong><br>
-                        </p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/121opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/121opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Norex Petroleum Limited v. Leonard Blavatnik</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          106</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/106opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/106opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">In
- the Matter of the Hon. Cathryn M. Doyle, a Judge of the Surrogate's 
-Court, Albany County / State Commission on Judicial Conduct</font></p></td>
-                    </tr>
-                    <tr>
-                      <td colspan="4" bgcolor="#FFFFFF"><hr></td>
-                    </tr>
-                    <tr>
-                      <td colspan="4" bgcolor="#FFFFFF"><font face="Arial, Helvetica, sans-serif" size="+1">June 12, 2014</font></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><strong><font face="Arial, Helvetica, sans-serif" size="2">Decision 
-                        List </font></strong></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/DecisionList061214.pdf">PDF</a></b></font></div></td>
-                      <td align="center">&nbsp;</td>
-                      <td bgcolor="#FFFFFF"><font face="Arial, Helvetica, sans-serif" size="2">Entries 
-                        for Cases and Motions </font></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 120</font></strong><br>
-                          <strong><font face="Arial, Helvetica, sans-serif" size="2">No. 94</font></strong><br>
-                          <strong><font face="Arial, Helvetica, sans-serif" size="2">No. 93</font></strong> </p>
-</div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/120-93-94opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/120-93-94opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Vinod Patel</font><br>
-                        <font face="Arial, Helvetica, sans-serif" size="2">The People v. Kevin Kruger</font><br>
-                        <font face="Arial, Helvetica, sans-serif" size="2">The People v. Churchill Andrews</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 118</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/118opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/118opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Lionel McCray</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          115</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/115mem14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/115mem14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">In the Matter of Thomas P. O'Neill v. Ann Pfau</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          114</font></strong><br>
-                          <strong><font face="Arial, Helvetica, sans-serif" size="2">No. 113</font></strong></p>
-</div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/113-114opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/113-114opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Shawn Giles v. A. Gi Yi</font><br>
-                        <font face="Arial, Helvetica, sans-serif" size="2">Christopher Hamilton v. John Miller</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 111</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/111mem14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/111mem14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Jamel Walston</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          102</font></strong><br>
-                        </p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/102opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/102opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Daniel Capruso v. Village of Kings Point / State of New York v. Village of Kings Point</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          100</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/100opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/100opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Hazel E. Gordon</font></p></td>
-                    </tr>
-                    <tr>
-                      <td colspan="4" bgcolor="#FFFFFF"><hr></td>
-                    </tr>
-                    <tr>
-                      <td colspan="4" bgcolor="#FFFFFF"><font face="Arial, Helvetica, sans-serif" size="+1">June 10, 2014</font></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><strong><font face="Arial, Helvetica, sans-serif" size="2">Decision 
-                        List </font></strong></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/DecisionList061014.pdf">PDF</a></b></font></div></td>
-                      <td align="center">&nbsp;</td>
-                      <td bgcolor="#FFFFFF"><font face="Arial, Helvetica, sans-serif" size="2">Entries 
-                        for Cases and Motions </font></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 175 SSM 11</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/SSM11ent14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/SSM11ent14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Guillermo Robles v. New York City Housing Authority</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 117</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/117opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/117opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Anner Rivera</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          112</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/112CTQ8opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/112CTQ8opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Quadrant Structured Products Co., Ltd. v. Vincent Vertin</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          110</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/110opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/110opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">KeySpan Gas East Coporation v. Munich Reinsurance America, Inc.</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 109</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/109opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/109opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Morpheus Capital Advisors LLC v. UBS AG</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          99</font></strong><br>
-                        </p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/99opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/99opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">In the Matter of New York State Commission on Judicial Conduct v. Seth Rubenstein</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          98</font></strong><br>
-                          <strong><font face="Arial, Helvetica, sans-serif" size="2">No. 97</font></strong></p>
-</div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/97-98opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/97-98opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. George F. Fazio</font><br>
-                        <font face="Arial, Helvetica, sans-serif" size="2">The People v. Neil Gilotti</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 59</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/59opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/59opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">In the Matter of Working Families Party v. Fern A. Fisher</font></p></td>
-                    </tr>
-                    <tr>
-                      <td colspan="4" bgcolor="#FFFFFF"><hr></td>
-                    </tr>
-                    <tr>
-                      <td colspan="4" bgcolor="#FFFFFF"><font face="Arial, Helvetica, sans-serif" size="+1">June 5, 2014</font></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF" width="21%"><strong><font face="Arial, Helvetica, sans-serif" size="2">Decision 
-                        List </font></strong></td>
-                      <td width="9%"><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/DecisionList060514.pdf">PDF</a></b></font></div></td>
-                      <td align="center" width="9%">&nbsp;</td>
-                      <td bgcolor="#FFFFFF" width="70%"><font face="Arial, Helvetica, sans-serif" size="2">Entries 
-                        for Cases and Motions </font></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 174 SSM 9</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/SSM9ent14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/SSM9ent14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Joseph Catalano v. Laurie Tanner</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 116</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/116opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/116opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">In the Matter of Antwaine T.</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          108</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/108opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/108opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Patricia Fratangelo</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          107</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/107mem14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/107mem14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Sidney Wisdom</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 104</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/104mem14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/104mem14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Sharmelle Johnson</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          103</font></strong><br>
-                        </p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/103opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/103opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">The People v. Joseph Dumay</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          101</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/101opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/101opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">Rhonda Wittorf v. City of New York</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 96</font></strong></p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/96opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/96opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">IDT Corp v. Tyco Group, S.A.R.L.</font></p></td>
-                    </tr>
-                    <tr>
-                      <td bgcolor="#FFFFFF"><div align="justify">
-                        <p><strong><font face="Arial, Helvetica, sans-serif" size="2">No. 
-                          95</font></strong><br>
-                        </p>
-                      </div></td>
-                      <td><div align="center"><font face="Arial, Helvetica, sans-serif" size="2"><b><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/95opn14-Decision.pdf">PDF</a></b></font></div></td>
-                      <td align="center"><strong><a href="http://www.courts.state.ny.us/ctapps/Decisions/2014/Jun14/95opn14-Decision.wpd">WPD</a></strong></td>
-                      <td bgcolor="#FFFFFF"><p><font face="Arial, Helvetica, sans-serif" size="2">In the Matter of Town of Islip v. New York State Public Employment Relations Board</font></p></td>
-                    </tr>
-                    <tr>
-                      <td colspan="4" bgcolor="#FFFFFF"><hr></td>
-                    </tr>
-                  </tbody></table>
-                </div></td>
-            </tr>
-            <tr bgcolor="#FFFFFF">
-              <td valign="top">&nbsp;</td>
-            </tr>
-            <tr bgcolor="#FFFFFF">
-              <td><hr></td>
-            </tr>
-          </tbody></table></td>
+</div>
+<div id="SearchDiv">
+<form action="http://search.nycourts.gov/search?btnG=Search&client=appeals_frontend&output=xml_no_dtd&proxystylesheet=appeals_frontend&sort=date%3AD%3AL%3Ad1&entqr=0&oe=UTF-8&ie=UTF-8&ud=1&proxyreload=1&site=appeals " method="post" style="margin-bottom: 0px;">
+  <p>
+  <input name="SearchString" size="20" maxlength="100" style="background-color: threedlightshadow; height: 80%; padding-top: 0px; padding-right: 0px;" type="text">
+  <input name="Action" value="Search Site" style="font-size: 0.9em; background-color: rgb(247,211,133); border: thin solid rgb(112, 120, 161); color: Black;" type="submit">
+  <span style="text-align: right"></span>  <span style="text-align: right"></span> </p>
+</form>
+<a href="http://iapps.courts.state.ny.us/lawReporting/CourtOfAppealsSearch" style="color: #f7d385">Advanced Decision Search </a>
+</div>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<div id="awmAnchor-menu"></div>
+<p>&nbsp;</p>
+<div id="MainBody"><!-- InstanceBeginEditable name="MainBodyEdit" -->
+  <div id="BodyDiv"><img src="../../../images/arrow.gif" width="16" height="18" align="absmiddle" /><a href="index.htm">Home</a> <img src="../../../images/arrow.gif" width="16" height="18" align="absmiddle" /><a href="decisions.htm">Court Decisions</a> <img src="../../../images/arrow.gif" width="16" height="18" align="absmiddle" />
+    <strong>February 2016  Decisions
+    </strong>
+    <hr />
+    <table width="100%" border="0">
+        <tr>
+          <td width="35%"><strong>February 11, 2016</strong></td>
+          <td width="9%">&nbsp;</td>
+          <td width="8%">&nbsp;</td>
+          <td width="48%">&nbsp;</td>
         </tr>
-        <tr bgcolor="#FFFFFF">
-          <td valign="top">&nbsp;</td>
+        <tr>
+          <td><strong>Decision List</strong></td>
+          <td align="center"><a href="DecisionList021116.pdf">PDF</a></td>
+          <td>&nbsp;</td>
+          <td><strong>Entries for Cases and Motions</strong></td>
         </tr>
-        <tr bgcolor="#FFFFFF">
-          <td><hr></td>
+        <tr>
+          <td><strong>No. 20</strong></td>
+          <td align="center"><a href="20mem16-Decision.pdf">PDF</a></td>
+          <td align="center"><a href="20mem16-Decision.wpd">WPD</a></td>
+          <td>The Matter of Exeter Building Corp. v. Town of Newburgh</td>
         </tr>
-      </tbody></table>
-    <!-- InstanceEndEditable --></td>
-  </tr>
-  <tr>
-    <td>&nbsp;</td>
-  </tr>
-</tbody></table>
-
-
-</body><!-- InstanceEnd --></html>
+        <tr>
+          <td><strong>No. 19</strong></td>
+          <td align="center"><a href="19opn16-Decision.pdf">PDF</a></td>
+          <td align="center"><a href="19opn16-Decision.wpd">WPD</a></td>
+          <td>The People v. Lawrence Watson</td>
+        </tr>
+        <tr>
+          <td><strong>No. 16</strong></td>
+          <td align="center"> <a href="16opn16-Decision.pdf">PDF</a></td>
+          <td align="center"><a href="16opn16-Decision.wpd">WPD</a></td>
+          <td>The People v. Freddie Thompson</td>
+        </tr>
+        <tr>
+          <td><strong>No. 7</strong></td>
+          <td align="center"><a href="7opn16-Decision.pdf">PDF</a></td>
+          <td align="center"><a href="7opn16-Decision.wpd">WPD</a></td>
+          <td>Yousufu Sangaray v. West River Associates</td>
+        </tr>
+        <tr>
+          <td><strong>No. 4</strong></td>
+          <td align="center"><a href="4opn16-Decision.pdf">PDF</a></td>
+          <td align="center"><a href="4opn16-Decision.wpd">WPD</a></td>
+          <td>Selective Insurance Company of America v. County of Rensselaer</td>
+        </tr>
+        <tr>
+          <td><strong>No. 3</strong></td>
+          <td align="center"><a href="3opn16-Decision.pdf">PDF</a></td>
+          <td align="center"><a href="3opn16-Decision.wpd">WPD</a></td>
+          <td>Sean R. v. BMW of North America</td>
+        </tr>
+    </table>
+    <p>&nbsp;</p>
+  </div>
+<!-- InstanceEndEditable --></div>
+<p>&nbsp;</p>
+</body>
+<!-- InstanceEnd --></html>

--- a/tests/examples/opinions/united_states/ny_example_2.html
+++ b/tests/examples/opinions/united_states/ny_example_2.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/Other.dwt" codeOutsideHTMLIsLocked="false" -->
 <head>
@@ -9,10 +10,10 @@
 <meta http-equiv="pragma" content="no-cache" />
 <meta http-equiv="expires" content="timestamp" />
 <!-- InstanceBeginEditable name="doctitle" -->
-<title>December 2014 Decisions</title>
+<title>December 2015 Decisions</title>
 <!-- InstanceEndEditable -->
-<script type="text/javascript" src="../Nov14/jquery.min.js"></script>
-<script type="text/javascript" src="../Nov14/ddaccordion.js"></script>
+<script type="text/javascript" src="../Sep15/jquery.min.js"></script>
+<script type="text/javascript" src="../Sep15/ddaccordion.js"></script>
 
 
 <SCRIPT TYPE="text/javascript">
@@ -60,7 +61,7 @@ a:active {
 <body>
 <!-- DO NOT MOVE! The following AllWebMenus linking code section must always be placed right AFTER the BODY tag-->
 <!-- ******** BEGIN ALLWEBMENUS CODE FOR menu ******** -->
-<script type="text/javascript">var MenuLinkedBy="AllWebMenus [4]",awmMenuName="menu",awmBN="848";awmAltUrl="";</script><script charset="UTF-8" src="../Nov14/menu.js" type="text/javascript"></script><script type="text/javascript">awmBuildMenu();</script>
+<script type="text/javascript">var MenuLinkedBy="AllWebMenus [4]",awmMenuName="menu",awmBN="848";awmAltUrl="";</script><script charset="UTF-8" src="../Sep15/menu.js" type="text/javascript"></script><script type="text/javascript">awmBuildMenu();</script>
 <!-- ******** END ALLWEBMENUS CODE FOR menu ******** -->
 <table width="800" border="0" align="center" cellpadding="1">
   <tr>
@@ -115,176 +116,309 @@ a:active {
     </table></td>
   </tr>
   <tr>
-    <td><img src="../Nov14/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
+    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
   </tr>
   <tr>
     <td><span id='awmAnchor-menu'></span></td>
   </tr>
   <tr>
-    <td><img src="../Nov14/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
+    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
   </tr>
   <tr>
-    <td><img src="../Nov14/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
+    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
   </tr>
   <tr>
-    <td><img src="../Nov14/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
+    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
   </tr>
   <tr>
-    <td><img src="../Nov14/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
+    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
   </tr>
   <tr>
-    <td><img src="../Nov14/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
+    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
   </tr>
   <tr>
-    <td><img src="../Nov14/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
+    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
   </tr>
   <tr>
     <td><!-- InstanceBeginEditable name="Main Body" -->
       <table width="100%" border="0" cellpadding="5" cellspacing="0" summary="Main Page Centered Table">
         <tr bgcolor="#FFFFFF">
-          <td valign="top"><div align="justify">
-            <hr />
-            <table border="0" width="100%" cellspacing="4" cellpadding="3" bgcolor="#FFFFFF">
-              <tr>
-                <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">December 18, 2014</font></td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">Decision
-                  List </font></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="DecisionList121814.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF">&nbsp;</td>
-                <td bgcolor="#FFFFFF"><font size="2" face="Arial, Helvetica, sans-serif">Entries
-                  for Cases and Motions</font></td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 228</font></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="228opn14-Decision.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="228opn14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">172 Van Duzer Realty Corp. v. Globe Alumni Student Assistance Association, Inc.</td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 226/227</font></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="226-227mem14-Decision.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="226-227mem14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">The People v. Dwight Giles / The People v. Sean Hawkins</td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 225</font></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="225opn14-Decision.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="225opn14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">In the Matter of Mark Ford v. New York State Racing and Wagering Board</td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 220</font></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="220opn14-Decision.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="220opn14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">Allison Gammons v. City of New York</td>
-              </tr>
-              <tr>
-                <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
-              </tr>
-              <tr>
-                <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">December 17, 2014</font></td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">Decision
-                  List </font></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="DecisionList121714.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF">&nbsp;</td>
-                <td bgcolor="#FFFFFF"><font size="2" face="Arial, Helvetica, sans-serif">Entries
-                  for Cases and Motions </font></td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 237 SSM 28</font></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="SSM28-237ent14-Decision.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="SSM28-237ent14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">Mary T. Heltz v. Bruce S. Barratt</td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong>No. 236 SSM 25</strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="SSM25-236ent14-Decision.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="SSM25-236ent14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">In the Matter of Suzanne Lozinak v. Board of Williamsville Central School</td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 224 </font></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="224opn14-Decision.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="224opn14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">In the Matter of State of New York v. Michael M.</td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 221</font></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="221opn14-Decision.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="221opn14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">Trump Village Section 3, Inc. v. City of New York</td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 218</font></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="218opn14-Decision.pdf">PDF</a></strong></td>
-                <td align="center" bgcolor="#FFFFFF"><strong><a href="218opn14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">The People v. Raul Johnson</td>
-              </tr>
-              <tr>
-                <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
-              </tr>
-              <tr>
-                <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">December 16, 2014</font></td>
-              </tr>
-              <tr>
-                <td width="21%" bgcolor="#FFFFFF"><strong><font size="2" face="Arial, Helvetica, sans-serif">Decision
-                  List </font></strong></td>
-                <td width="9%"><div align="center"><strong><font face="Arial, Helvetica, sans-serif" size="2"><a href="DecisionList121614.pdf">PDF</a></font></strong></div></td>
-                <td width="9%" align="center">&nbsp;</td>
-                <td width="70%" bgcolor="#FFFFFF"><font size="2" face="Arial, Helvetica, sans-serif">Entries
-                  for Cases and Motions </font></td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><div align="justify">
-                  <p><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 235 SSM 24</font></strong></p>
-                  </div></td>
-                <td align="center"><strong><a href="SSM24mem14-Decision.pdf">PDF</a></strong></td>
-                <td align="center"><strong><a href="SSM24mem14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">The People v. Robert L. Ingram</td>
-              </tr>
-              <tr>
-                <td height="27" bgcolor="#FFFFFF"><div align="justify">
-                  <p><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 223</font></strong><br />
-                  </p>
-                </div></td>
-                <td align="center"><strong><a href="223opn14-Decision.pdf">PDF</a></strong></td>
-                <td align="center"><strong><a href="223opn14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">In the Matter of Delilah Rigano v. Vibar Construction</td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><div align="justify">
-                  <p><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 222</font></strong></p>
-                </div></td>
-                <td align="center"><strong><a href="222mem14-Decision.pdf">PDF</a></strong></td>
-                <td align="center"><strong><a href="222mem14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">The People v. On Sight Mobile Opticians</td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><div align="justify">
-                  <p><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 219</font></strong></p>
-                </div></td>
-                <td align="center"><strong><a href="219opn14-Decision.pdf">PDF</a></strong></td>
-                <td align="center"><strong><a href="219opn14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">The People v. Clifford Jones</td>
-              </tr>
-              <tr>
-                <td bgcolor="#FFFFFF"><div align="justify">
-                  <p><strong><font size="2" face="Arial, Helvetica, sans-serif">No. 205</font></strong><br />
-                    </p>
-                  </div></td>
-                <td align="center"><strong><a href="205opn14-Decision.pdf">PDF</a></strong></td>
-                <td align="center"><strong><a href="205opn14-Decision.wpd">WPD</a></strong></td>
-                <td bgcolor="#FFFFFF">The People v. Graham Reid</td>
-              </tr>
-              <tr>
-                <td colspan="4" bgcolor="#FFFFFF"><hr /></td>
-              </tr>
-            </table>
-          </div></td>
+          <td valign="top" bgcolor="#FFFFFF"><p><span style="font-size: small; font-weight: bold;"><img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" /><a href="../../../index.htm">Home</a> <img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" /><a href="../../../decisions.htm">Court Decisions</a> <img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" />December 2015 Decisions</span></p>
+            <div align="justify">
+              <hr />
+            </div></td>
+        </tr>
+
+        <tr bgcolor="#FFFFFF">
+          <td valign="top"><table width="100%" border="0">
+            <tr>
+              <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">December 17, 2015</font></td>
+            </tr>
+            <tr>
+              <td><strong>Decision List</strong></td>
+              <td align="center"><a href="DecisionList121715.pdf">PDF</a></td>
+              <td align="center">&nbsp;</td>
+              <td><strong>Entries for Cases and Motions</strong></td>
+            </tr>
+            <tr>
+              <td>No. 206 </td>
+              <td align="center"><a href="206opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="206opn15-Decision.wpd">WPD</a></td>
+              <td> The People v. Victor Soto</td>
+            </tr>
+            <tr>
+              <td>No. 199 </td>
+              <td align="center"><a href="199opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="199opn15-Decision.wpd">WPD</a></td>
+              <td>The People v. Anthony V. Pavone</td>
+            </tr>
+            <tr>
+              <td>No. 196 </td>
+              <td align="center"><a href="196opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="196opn15-Decision.wpd">WPD</a></td>
+              <td>The People v. Todd Holley</td>
+            </tr>
+            <tr>
+              <td>No. 195 </td>
+              <td align="center"><a href="195opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="195opn15-Decision.wpd">WPD</a></td>
+              <td>The People v. Kaity Marshall</td>
+            </tr>
+            <tr>
+              <td>No. 193 </td>
+              <td align="center"><a href="193opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="193opn15-Decision.wpd">WPD</a></td>
+              <td>The People v. Natanael Sagastumeal Varenga</td>
+            </tr>
+            <tr>
+              <td>No.  178  </td>
+              <td align="center"><a href="178opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="178opn15-Decision.wpd">WPD</a></td>
+              <td>The People v. Mark Jurgins</td>
+            </tr>
+            <tr>
+              <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
+            </tr>
+            <tr>
+              <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">December 16, 2015</font></td>
+            </tr>
+            <tr>
+              <td><strong>Decision List</strong></td>
+              <td align="center"><a href="DecisionList121615.pdf">PDF</a></td>
+              <td>&nbsp;</td>
+              <td><strong>Entries for Cases and Motions</strong></td>
+            </tr>
+            <tr>
+              <td>No. 201</td>
+              <td align="center"><a href="201opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="201opn15-Decision.wpd">WPD</a></td>
+              <td>The People v. Luis Ortiz</td>
+            </tr>
+            <tr>
+              <td>No. 200</td>
+              <td align="center"><a href="200opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="200opn15-Decision.wpd">WPD</a></td>
+              <td>Rita Cusimano v. Andrew V. Schnurr Bernard V. Strianese</td>
+            </tr>
+            <tr>
+              <td>No. 198</td>
+              <td align="center"><a href="198opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="198opn15-Decision.wpd">WPD</a></td>
+              <td><p>The Matter of Ricardo Suarez v. Melissa Williams</p></td>
+            </tr>
+            <tr>
+              <td>No. 191 and 192</td>
+              <td align="center"><a href="191-192opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="191-192opn15-Decision.wpd">WPD</a></td>
+              <td>The People v. Luciano Rosario, The People v. Marcos Llibre</td>
+            </tr>
+            <tr>
+              <td>No. 163</td>
+              <td align="center"><a href="163opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="163opn15-Decision.wpd">WPD</a></td>
+              <td>Edwin Davis v. South Nassau  Communities</td>
+            </tr>
+            <br />
+              <!--<td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">December 23, 2015</font></td>
+              </tr><tr>
+             <td><strong>Decision List</strong></td>
+             <td align="center"><a href="DecisionList112315.pdf">PDF</a></td>
+             <td align="center">&nbsp;</td>
+             <td><strong>Entries for Cases and Motions</strong></td>
+           </tr>
+           <tr>
+             <td><strong>No. 211 SSM 17</strong></td>
+             <td align="center"><a href="SSM17ent15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="SSM17ent15-Decision.wpd">WPD</a></td>
+             <td>Ainsworth M. Bennett v. St. John's Home</td>
+           </tr>
+           <tr>
+             <td><strong>No. 177</strong></td>
+             <td align="center"><a href="177opn15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="177opn15-Decision.wpd">WPD</a></td>
+             <td>The Matter of Crystal Hawkins v. Elizabeth Berlin</td>
+           </tr>
+           <tr>
+             <td><strong>No. 175</strong></td>
+             <td align="center"><a href="175opn15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="175opn15-Decision.wpd">WPD</a></td>
+             <td>The People v. Ally Golo</td>
+           </tr>
+           <tr>
+             <td><strong>No. 174</strong></td>
+             <td align="center"><a href="174opn15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="174opn15-Decision.wpd">WPD</a></td>
+             <td>The People v. Julio Negron</td>
+           </tr>
+           <tr>
+             <td><strong>No. 166</strong></td>
+             <td align="center"><a href="166-opn15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="166-opn15-Decision.wpd">WPD</a></td>
+             <td>The People v. Everett M. Durant</td>
+           </tr>
+           <tr>
+             <td><strong>No. 165 </strong></td>
+             <td align="center"><a href="165opn15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="165opn15-Decision.wpd">WPD</a></td>
+             <td>The People v. Nugene Ambers</td>
+           </tr>
+                <tr>
+                  <td><strong>No. 164</strong></td>
+                  <td align="center"><a href="164opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="164opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Davon Harris</td>
+                </tr>
+                <tr>
+                  <td><strong>No. 162</strong></td>
+                  <td align="center"><a href="162mem15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="162mem15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Alma Caldavado</td>
+                </tr>
+                <tr>
+                  <td><strong>No. 157</strong></td>
+                  <td align="center"><a href="157opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="157opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v Frankie Hatton</td>
+                </tr>
+                 <tr>
+                  <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
+                </tr>
+                <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">December 19, 2015</font></td>
+                </tr>
+                <tr>
+                  <td><strong>Decision List</strong></td>
+                  <td align="center"><a href="DecisionList111915.pdf">PDF</a></td>
+                  <td align="center">&nbsp;</td>
+                  <td><strong>Entries for Cases and Motions</strong></td>
+                </tr>
+                <tr>
+                  <td><strong>No.210 SSM 22</strong></td>
+                  <td align="center"><a href="SSM22ent15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="SSM22ent15-Decision.wpd">WPD</a></td>
+                  <td>Switzerland Green v. Metropolitan Transportation Authority Bus Company</td>
+                </tr>
+                <tr>
+                  <td height="26"><strong>No.176</strong></td>
+                  <td align="center"><a href="176opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="176opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Samuel Small, Also Known as Samuel Smalls</td>
+                </tr>
+                <tr>
+                  <td><strong>No.160</strong></td>
+                  <td align="center"><a href="160opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="160opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Antonio Martinez</td>
+                </tr>
+                <tr>
+                  <td><strong>No.158</strong></td>
+                  <td align="center"><a href="158mem15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="158mem15-Decision.wpd">WPD</a></td>
+                  <td>The Matter of Estevan Gentil v. Hon. Ira Margulis</td>
+                </tr>
+                <tr>
+                  <td><strong>No.154</strong></td>
+                  <td align="center"><a href="154opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="154opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Matthew P.</td>
+                </tr>
+                <tr>
+                  <td><strong>No.152</strong></td>
+                  <td align="center"><a href="152opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="152opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Willie L. Wragg</td>
+                </tr>
+                <tr>
+                  <td><strong>No.151</strong></td>
+                  <td align="center"><a href="151opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="151opn15-Decision.wpd">WPD</a></td>
+                  <td>The Matter of Sierra Club v. Village of Painted Post</td>
+                </tr>
+                <tr>
+                  <td height="24"><strong>No.139</strong></td>
+                  <td align="center"><a href="139opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="139opn15-Decision.wpd">WPD</a></td>
+                  <td>The Matter of Walter E. Carver v. State of New York</td>
+                </tr>
+                <tr>
+                  <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
+                </tr>-->
+                <tr>
+                  <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
+                </tr>
+                <tr>
+                  <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">December 15, 2015</font></td>
+                </tr>
+            <tr>
+              <td width="24%"><strong>Decision List</strong></td>
+              <td width="7%" align="center"><a href="DecisionList121515.pdf">PDF</a></td>
+              <td width="12%">&nbsp;</td>
+              <td width="57%"><strong>Entries for Cases and Motions</strong></td>
+               <tr>
+              <td>No. 214 </td>
+              <td align="center"><a href="214ent15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="214ent15-Decision.wpd">WPD</a></td>
+              <td>Doctor Fred L. Pasternack v. Laboratory Corporation of America Holdings</td>
+            </tr>
+   <td>No. 213 SSM 28</td>
+            <td align="center"><a href="SSM28ent15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="SSM28ent15-Decision.wpd">WPD</a></td>
+              <td>Steven C. Ridge v. Alice Gold</td>
+            </tr>
+            <tr>
+              <td>No. 212 SSM 23</td>
+
+              <td align="center"><a href="SSM23mem15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="SSM23mem15-Decision.wpd">WPD</a></td>
+              <td>The People v. Karl Chu-Joi</td>
+            </tr>
+            <tr>
+              <td>No. 202</td>
+              <td align="center"><a href="202mem15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="202mem15-Decision.wpd">WPD</a></td>
+              <td>Matter of RAM I LLC v. New York State Division of Housing and Community Renewal</td>
+            </tr>
+            <tr>
+              <td>No. 197</td>
+              <td align="center"><a href="197mem15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="197mem15-Decision.wpd">WPD</a></td>
+              <td>The People v. Dennis P. Smalls</td>
+            </tr>
+            <tr>
+              <td>No. 153</td>
+              <td align="center"><a href="153opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="153opn15-Decision.wpd">WPD</a></td>
+              <td>Pegasus Aviation I, Inc. v. Varig Logistica S.A.</td>
+            </tr>
+            <tr>
+              <td>No. 131</td>
+              <td align="center"><a href="131opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="131opn15-Decision.wpd">WPD</a></td>
+              <td>The Ministers and Missionaries Benefit Board v. Leon Snow v. The Estate of Clark Flesher</td>
+            </tr>
+            <tr>
+              <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
+            </tr>
+          </table></td>
         </tr>
         <tr bgcolor="#FFFFFF">
           <td><hr /></td>

--- a/tests/examples/opinions/united_states/ny_example_3.html
+++ b/tests/examples/opinions/united_states/ny_example_3.html
@@ -1,42 +1,71 @@
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/Other.dwt" codeOutsideHTMLIsLocked="false" -->
+<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/Decisions Page.dwt" codeOutsideHTMLIsLocked="false" -->
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta http-equiv="cache-control" content="max-age=0" />
-<meta http-equiv="cache-control" content="no-cache" />
-<meta http-equiv="expires" content="-1" />
-<meta http-equiv="expires" content="Tue, 01 Jan 1980 1:00:00 GMT" />
-<meta http-equiv="pragma" content="no-cache" />
-<meta http-equiv="expires" content="timestamp" />
 <!-- InstanceBeginEditable name="doctitle" -->
-<title>October 2015 Decisions</title>
+<title></title>
 <!-- InstanceEndEditable -->
-<script type="text/javascript" src="../Sep15/jquery.min.js"></script>
-<script type="text/javascript" src="../Sep15/ddaccordion.js"></script>
-
-
-<SCRIPT TYPE="text/javascript">
-function popup(mylink, windowname)
-{
-if (! window.focus)return true;
-var href;
-if (typeof(mylink) == 'string')
-   href=mylink;
-else
-   href=mylink.href;
-window.open(href, windowname, 'width=500,height=300,scrollbars=yes');
-return false;
-}
-<!-- Function to create Pop-Up Window -->
-</SCRIPT>
+<!-- InstanceBeginEditable name="head" -->
+<!-- InstanceEndEditable -->
 <style type="text/css">
-<!--
 body {
-	background-image: url(../../../images/coaback.jpg);
-	margin-top: 0px;
+	background-image: url(../../../images/coabackgrd.jpg);
+}
+#MainHeader {
+	position:absolute;
+	width:518px;
+	height:81px;
+	z-index:auto;
+	left: 245px;
+	top: 7px;
+}
+#MainSearch {
+	position:absolute;
+	width:280px;
+	height:80px;
+	z-index:auto;
+	float: left;
+}
+#MainBody {
+	position:absolute;
+	width:850px;
+	height:115px;
+	z-index:auto;
+	left: 245px;
+	top: 133px;
+}
+#BodyDiv {
+	background-color: #FFFFFF;
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
+	padding-left: 5px;
+	padding-top: 5px;
+}
+}
+#Menubar {
+	top: 500px;
+	width:280px;
+	height:60px;
+}
+#awmAnchor-menu {
+	position:absolute;
+	width:801px;
+	height:33px;
+	z-index:1;
+	left: 245px;
+	top: 94px;
+}
+#SearchDiv {
+	position:absolute;
+	width:324px;
+	height:78px;
+	z-index:2;
+	left: 767px;
+	top: 8px;
+	text-align: right;
 }
 body,td,th {
-	font-family: Trebuchet MS, Arial, Helvetica, sans-serif;
+	font-family: "Trebuchet MS", Arial, Helvetica, sans-serif;
 	font-size: small;
 }
 a:link {
@@ -51,205 +80,145 @@ a:hover {
 a:active {
 	text-decoration: none;
 }
--->
 </style>
-<!-- InstanceBeginEditable name="head" -->
-<!-- InstanceEndEditable -->
 </head>
 
 <body>
 <!-- DO NOT MOVE! The following AllWebMenus linking code section must always be placed right AFTER the BODY tag-->
 <!-- ******** BEGIN ALLWEBMENUS CODE FOR menu ******** -->
-<script type="text/javascript">var MenuLinkedBy="AllWebMenus [4]",awmMenuName="menu",awmBN="848";awmAltUrl="";</script><script charset="UTF-8" src="../Sep15/menu.js" type="text/javascript"></script><script type="text/javascript">awmBuildMenu();</script>
+<script type="text/javascript">var MenuLinkedBy="AllWebMenus [4]",awmMenuName="menu",awmBN="848";awmAltUrl="";</script><script charset="UTF-8" src="../../../menu.js" type="text/javascript"></script><script type="text/javascript">awmBuildMenu();</script>
 <!-- ******** END ALLWEBMENUS CODE FOR menu ******** -->
-<table width="800" border="0" align="center" cellpadding="1">
-  <tr>
-    <td><table width="100%" border="0" cellspacing="0" cellpadding="0">
-      <tr>
-        <td width="65%"><img src="../../../images/coatitlesm.jpg" width="517" height="82" alt="Court of Appeals Title" /></td>
-        <td width="35%" align="right" valign="top"><table width="100%" border="0" cellspacing="0" cellpadding="0">
-          <tr>
-            <td align="right">
-            <table border="0" cellpadding="0" cellspacing="0">
-         <tr>
-            <td valign="middle"><form name="gs" method="GET" action="http://search.nycourts.gov/search" onsubmit="return (this.q.value == '') ? false : true;">
-               <table border="0" cellpadding="0" cellspacing="0">
-                  <tr>
 
-                     <td>
-                        <table cellpadding="4" cellspacing="0"></table>
-                     </td>
-                  </tr>
-                  <tr>
-                     <td>
-                        <table cellpadding="0" cellspacing="0">
-                           <tr>
-                              <td valign="top"><font size="-1"><input type="text" name="q" size="32" maxlength="256" value=""></font></td>
+<div id="MainHeader"><img src="../../../images/coatitlesmIII.gif" width="517" height="82" />
 
-                              <td align="center" valign="middle"><font size="-1">&nbsp;<input type="submit" name="btnG" value="Search">
-                              </font><font size="-2">&nbsp;<br></font></td>
-                              </tr>
-                        </table>
-                     </td>
-                  </tr>
-               </table>
-               <input type="hidden" name="client" value="appeals_frontend">
 
-               <input type="hidden" name="output" value="xml_no_dtd">
-               <input type="hidden" name="proxystylesheet" value="appeals_frontend">
-               <input type="hidden" name="sort" value="date:D:L:d1">
-               <input type="hidden" name="entqr" value="0">
-               <input type="hidden" name="oe" value="UTF-8"><input type="hidden" name="ie" value="UTF-8">
-               <input type="hidden" name="ud" value="1">
-               <input type="hidden" name="proxyreload" value="1">
-               <input type="hidden" name="site" value="appeals"></form>
-            </td>
-
-         </tr>
-      </table>
-
-          </tr>
-        </table>
-          <a href="http://iapps.courts.state.ny.us/lawReporting/CourtOfAppealsSearch" style="color: #f7d385">Advanced Decision Search </a></td>
-      </tr>
-    </table></td>
-  </tr>
-  <tr>
-    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
-  </tr>
-  <tr>
-    <td><span id='awmAnchor-menu'></span></td>
-  </tr>
-  <tr>
-    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
-  </tr>
-  <tr>
-    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
-  </tr>
-  <tr>
-    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
-  </tr>
-  <tr>
-    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
-  </tr>
-  <tr>
-    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
-  </tr>
-  <tr>
-    <td><img src="../Sep15/images/spacer.gif" width="1" height="1" alt="Spacer" /></td>
-  </tr>
-  <tr>
-    <td><!-- InstanceBeginEditable name="Main Body" -->
-      <table width="100%" border="0" cellpadding="5" cellspacing="0" summary="Main Page Centered Table">
-        <tr bgcolor="#FFFFFF">
-          <td valign="top" bgcolor="#FFFFFF"><p><span style="font-size: small; font-weight: bold;"><img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" /><a href="../../../index.htm">Home</a> <img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" /><a href="../../../decisions.htm">Court Decisions</a> <img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" />October 2015 Decisions</span></p>
-            <div align="justify">
-              <hr />
-            </div></td>
+</div>
+<div id="SearchDiv">
+<form action="http://search.nycourts.gov/search?btnG=Search&client=appeals_frontend&output=xml_no_dtd&proxystylesheet=appeals_frontend&sort=date%3AD%3AL%3Ad1&entqr=0&oe=UTF-8&ie=UTF-8&ud=1&proxyreload=1&site=appeals " method="post" style="margin-bottom: 0px;">
+  <p>
+  <input name="SearchString" size="20" maxlength="100" style="background-color: threedlightshadow; height: 80%; padding-top: 0px; padding-right: 0px;" type="text">
+  <input name="Action" value="Search Site" style="font-size: 0.9em; background-color: rgb(247,211,133); border: thin solid rgb(112, 120, 161); color: Black;" type="submit">
+  <span style="text-align: right"></span>  <span style="text-align: right"></span> </p>
+</form>
+<a href="http://iapps.courts.state.ny.us/lawReporting/CourtOfAppealsSearch" style="color: #f7d385">Advanced Decision Search </a>
+</div>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+<div id="awmAnchor-menu"></div>
+<p>&nbsp;</p>
+<div id="MainBody"><!-- InstanceBeginEditable name="MainBodyEdit" -->
+  <div id="BodyDiv"><img src="../../../images/arrow.gif" width="16" height="18" align="absmiddle" /><a href="index.htm">Home</a> <img src="../../../images/arrow.gif" width="16" height="18" align="absmiddle" /><a href="decisions.htm">Court Decisions</a> <img src="../../../images/arrow.gif" width="16" height="18" align="absmiddle" />
+    <strong>January 2016 Decisions
+    </strong>
+    <hr />
+    <table width="100%" border="0">
+        <tr>
+          <td><strong>January 14, 2016</strong></td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
         </tr>
-        <tr bgcolor="#FFFFFF">
-          <td valign="top"><table width="100%" border="0"><br />
-                <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">October 20, 2015</font></td>
-            </tr>
-            <tr>
-              <td><strong>Decision List</strong></td>
-              <td align="center"><a href="DecisionList102015.pdf">PDF</a><a href="../Sep15/DecisionList092215.pdf"></a></td>
-              <td align="center">&nbsp;</td>
-              <td><strong>Entries for Cases and Motions</strong></td>
-              <tr>
-              <td valign="top"><strong>No. 144-146</strong></td>
-              <td align="center" valign="top"><a href="144-146opn15-Decision.pdf">PDF</a></td>
-              <td align="center" valign="top"><a href="144-146opn15-Decision.wpd">WPD</a></td>
-              <td valign="top"><p>Leonard Hutchinson v. Sheridan Hill House Corp. <br />
-                Matvey Zelichenko v. 301 Oriental Boulevard <br />
-                Maureen Adler v. QPI-VIII
-
-
-
-            </tr>
-               <tr>
-                 <td height="22"><strong>No. 141</strong></td>
-                 <td align="center"><a href="141mem15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="141mem15-Decision.wpd">WPD</a></td>
-                 <td>The People v. Thomas Barnes</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 138</strong></td>
-                 <td align="center"><a href="138mem15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="138mem15-Decision.wpd">WPD</a></td>
-                 <td>The People v. Vincent Izzo</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 129</strong></td>
-                 <td align="center"><a href="129opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="129opn15-Decision.wpd">WPD</a></td>
-                 <td>Remet Corporation v. The Estate of James R. Pyne</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 127</strong></td>
-                 <td align="center"><a href="127opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="127opn15-Decision.wpd">WPD</a></td>
-                 <td>The People of the State of New York v.<br />
-Sprint Nextel Corp.</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 90</strong></td>
-                 <td align="center"><a href="90opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="90opn15-Decision.wpd">WPD</a></td>
-                 <td>Jacqueline El-Dehdan v. Salim El-Dehdan, Also Known as <br />
-Sam Reed</td>
-               </tr>
-               <tr>
-                 <td><font size="+1" face="Arial, Helvetica, sans-serif">October 15, 2015</font></td>
-                 <td align="center">&nbsp;</td>
-                 <td align="center">&nbsp;</td>
-                 <td>&nbsp;</td>
-               </tr>
-               <tr>
-                 <td><strong>Decision List</strong></td>
-                 <td align="center"><a href="DecisionList101515.pdf">PDF</a><a href="../Sep15/DecisionList092215.pdf"></a></td>
-                 <td align="center"><a href="180opn15-Decision.wpd"></a></td>
-                 <td><strong>Entries for Cases and Motion</strong>s</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 180</strong></td>
-                 <td align="center"><a href="180opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="180opn15-Decision.wpd">WPD</a></td>
-                 <td>The People v. Jose Martinez Baxin</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 140</strong></td>
-                 <td align="center"><a href="140opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="140opn15-Decision.wpd">WPD</a></td>
-                 <td>The People v. Michael Sans</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 137</strong></td>
-                 <td align="center"><a href="137opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="137opn15-Decision.wpd">WPD</a></td>
-                 <td>he People v. Dupree Harris</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 128</strong></td>
-                 <td align="center"><a href="128mem15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="128mem15-Decision.wpd">WPD</a></td>
-                 <td>The People v. James R. Poleun</td>
-               </tr>
- <td width="48%" colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
- </tr>
-          </table></td>
+        <tr>
+          <td><strong>Decision List</strong></td>
+          <td align="center"><a href="DecisionList011416.pdf">PDF</a></td>
+          <td>&nbsp;</td>
+          <td><strong>Entries for Cases and Motions</strong></td>
         </tr>
-      </table>
-      <table width="100%" border="0" cellpadding="5" cellspacing="0" summary="Main Page Centered Table">
-        <tr bgcolor="#FFFFFF">
-          <td><hr /></td>
+        <tr>
+          <td><strong>No. 9</strong></td>
+          <td align="center"><a href="9ent16-Decision.pdf">PDF</a></td>
+          <td align="center"><a href="9ent16-Decision.wpd">WPD</a></td>
+          <td>The Matter of Rokhaya Cisse v. Christopher Graham</td>
         </tr>
-      </table>
-    <!-- InstanceEndEditable --></td>
-  </tr>
-  <tr>
-    <td>&nbsp;</td>
-  </tr>
-</table>
+        <tr>
+          <td><strong>No. 6</strong></td>
+          <td align="center"><a href="6ent16-Decision.pdf">PDF</a></td>
+          <td align="center"><a href="6ent16-Decision.wpd">WPD</a></td>
+          <td>The People v. Scott Barden</td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td><strong>January 12, 2016</strong></td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td><strong>Decision List</strong></td>
+          <td align="center"><a href="DecisionList011216.pdf">PDF</a></td>
+          <td>&nbsp;</td>
+          <td><strong>Entries for Cases and Motions</strong></td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td><strong>January 7, 2016</strong></td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td><strong>Decision List</strong></td>
+          <td align="center"><a href="DecisionList010716.pdf">PDF</a></td>
+          <td>&nbsp;</td>
+          <td><strong>Entries for Cases and Motions</strong></td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+
+          <td width="35%"><strong>January 5, 2016</strong></td>
+          <td width="9%">&nbsp;</td>
+          <td width="8%">&nbsp;</td>
+          <td width="48%">&nbsp;</td>
+        </tr>
+        <tr>
+          <td><strong>Decision List</strong></td>
+          <td align="center"><a href="DecisionList010516.pdf">PDF</a></td>
+          <td>&nbsp;</td>
+          <td><strong>Entries for Cases and Motions</strong></td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <td align="center">&nbsp;</td>
+          <td align="center">&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <td align="center">&nbsp;</td>
+          <td align="center">&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <td align="center">&nbsp;</td>
+          <td align="center">&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <td align="center">&nbsp;</td>
+          <td align="center">&nbsp;</td>
+          <td>&nbsp;</td>
+        </tr>
+    </table>
+    <p>&nbsp;</p>
+  </div>
+<!-- InstanceEndEditable --></div>
+<p>&nbsp;</p>
 </body>
 <!-- InstanceEnd --></html>

--- a/tests/examples/opinions/united_states/ny_example_4.html
+++ b/tests/examples/opinions/united_states/ny_example_4.html
@@ -1,3 +1,4 @@
+
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/Other.dwt" codeOutsideHTMLIsLocked="false" -->
 <head>
@@ -9,7 +10,7 @@
 <meta http-equiv="pragma" content="no-cache" />
 <meta http-equiv="expires" content="timestamp" />
 <!-- InstanceBeginEditable name="doctitle" -->
-<title>October 2015 Decisions</title>
+<title>November 2015 Decisions</title>
 <!-- InstanceEndEditable -->
 <script type="text/javascript" src="../Sep15/jquery.min.js"></script>
 <script type="text/javascript" src="../Sep15/ddaccordion.js"></script>
@@ -142,186 +143,210 @@ a:active {
     <td><!-- InstanceBeginEditable name="Main Body" -->
       <table width="100%" border="0" cellpadding="5" cellspacing="0" summary="Main Page Centered Table">
         <tr bgcolor="#FFFFFF">
-          <td valign="top" bgcolor="#FFFFFF"><p><span style="font-size: small; font-weight: bold;"><img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" /><a href="../../../index.htm">Home</a> <img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" /><a href="../../../decisions.htm">Court Decisions</a> <img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" />October 2015 Decisions</span></p>
+          <td valign="top" bgcolor="#FFFFFF"><p><span style="font-size: small; font-weight: bold;"><img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" /><a href="../../../index.htm">Home</a> <img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" /><a href="../../../decisions.htm">Court Decisions</a> <img src="../../../images/arrow.gif" alt="" width="16" height="18" align="absmiddle" />November 2015 Decisions</span></p>
             <div align="justify">
               <hr />
             </div></td>
         </tr>
+
         <tr bgcolor="#FFFFFF">
           <td valign="top"><table width="100%" border="0"><br />
+              <tr>
+                <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">November 24, 2015</font></td>
+              </tr>
+              <tr>
+                <td bgcolor="#FFFFFF"><strong>Decision List</strong></td>
+                <td align="center" valign="top" bgcolor="#FFFFFF"><a href="DecisionList112415.pdf">PDF</a></td>
+                <td align="center" valign="top" bgcolor="#FFFFFF">&nbsp;</td>
+                <td bgcolor="#FFFFFF"><strong>Entries for Cases and Motions</strong></td>
+              </tr>
+              <tr>
+                <td bgcolor="#FFFFFF"><strong>No. 209  SSM 26</strong></td>
+                <td align="center" valign="top" bgcolor="#FFFFFF"><a href="SSM26mem15-Decision.pdf">PDF</a></td>
+                <td align="center" valign="top" bgcolor="#FFFFFF"><a href="SSM26mem15-Decision.wpd">WPD</a></td>
+                <td valign="top" bgcolor="#FFFFFF">The People v. Stephen Pellegrino</td>
+              </tr>
+              <tr>
+                <td bgcolor="#FFFFFF"><strong>No. 207  SSM 24 / No. 208  SSM 25</strong></td>
+                <td align="center" valign="top" bgcolor="#FFFFFF"><a href="SSM24-25mem15-Decision.pdf">PDF</a></td>
+                <td align="center" valign="top" bgcolor="#FFFFFF"><a href="SSM24-25mem15-Decision.wpd">WPD</a></td>
+                <td valign="top" bgcolor="#FFFFFF">The People v. Mactar Sougou /The People v. Rita Thompson</td>
+              </tr>
+              <tr>
+                <td bgcolor="#FFFFFF"><strong>No. 170</strong></td>
+                <td align="center" valign="top" bgcolor="#FFFFFF"><a href="170mem15-Decision.pdf">PDF</a></td>
+                <td align="center" valign="top" bgcolor="#FFFFFF"><a href="170mem15-Decision.wpd">WPD</a></td>
+                <td bgcolor="#FFFFFF">The People v. Abdelouahad Afilal</td>
+              </tr>
+              <tr>
+                <td valign="top" bgcolor="#FFFFFF"><strong>No. 167 / No. 168 / No. 169</strong></td>
+                <td align="center" valign="top" bgcolor="#FFFFFF"><a href="167-168-169opn15-Decision.pdf">PDF</a></td>
+                <td align="center" valign="top" bgcolor="#FFFFFF"><a href="167-168-169opn15-Decision.wpd">WPD</a></td>
+                <td valign="top" bgcolor="#FFFFFF">The People v. Joseph Conceicao / The People v. Federico Perez / The People v. Javier Sanchez</td>
+              </tr>
+              <tr>
+                <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
+              </tr>
+              <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">November 23, 2015</font></td>
+           </tr><tr>
+             <td><strong>Decision List</strong></td>
+             <td align="center"><a href="DecisionList112315.pdf">PDF</a></td>
+             <td align="center">&nbsp;</td>
+             <td><strong>Entries for Cases and Motions</strong></td>
+           </tr>
+           <tr>
+             <td><strong>No. 211 SSM 17</strong></td>
+             <td align="center"><a href="SSM17ent15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="SSM17ent15-Decision.wpd">WPD</a></td>
+             <td>Ainsworth M. Bennett v. St. John's Home</td>
+           </tr>
+           <tr>
+             <td><strong>No. 177</strong></td>
+             <td align="center"><a href="177opn15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="177opn15-Decision.wpd">WPD</a></td>
+             <td>The Matter of Crystal Hawkins v. Elizabeth Berlin</td>
+           </tr>
+           <tr>
+             <td><strong>No. 175</strong></td>
+             <td align="center"><a href="175opn15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="175opn15-Decision.wpd">WPD</a></td>
+             <td>The People v. Ally Golo</td>
+           </tr>
+           <tr>
+             <td><strong>No. 174</strong></td>
+             <td align="center"><a href="174opn15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="174opn15-Decision.wpd">WPD</a></td>
+             <td>The People v. Julio Negron</td>
+           </tr>
+           <tr>
+             <td><strong>No. 166</strong></td>
+             <td align="center"><a href="166-opn15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="166-opn15-Decision.wpd">WPD</a></td>
+             <td>The People v. Everett M. Durant</td>
+           </tr>
+           <tr>
+             <td><strong>No. 165 </strong></td>
+             <td align="center"><a href="165opn15-Decision.pdf">PDF</a></td>
+             <td align="center"><a href="165opn15-Decision.wpd">WPD</a></td>
+             <td>The People v. Nugene Ambers</td>
+           </tr>
                 <tr>
-                  <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">October 23, 2015</font></td>
+                  <td><strong>No. 164</strong></td>
+                  <td align="center"><a href="164opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="164opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Davon Harris</td>
                 </tr>
                 <tr>
-                  <td bgcolor="#FFFFFF"><strong>Decision List</strong></td>
-                  <td align="center" bgcolor="#FFFFFF"><a href="DecisionList102315.pdf">PDF</a></td>
-                  <td bgcolor="#FFFFFF">&nbsp;</td>
-                  <td bgcolor="#FFFFFF"><strong>Entries for Cases and Motions</strong></td>
+                  <td><strong>No. 162</strong></td>
+                  <td align="center"><a href="162mem15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="162mem15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Alma Caldavado</td>
                 </tr>
                 <tr>
+                  <td><strong>No. 157</strong></td>
+                  <td align="center"><a href="157opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="157opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v Frankie Hatton</td>
+                </tr>
+                 <tr>
                   <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
                 </tr>
-                <tr>
-                  <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">October 22, 2015</font></td>
+                <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">November 19, 2015</font></td>
                 </tr>
                 <tr>
                   <td><strong>Decision List</strong></td>
-                  <td align="center"><a href="DecisionList102215.pdf">PDF</a></td>
+                  <td align="center"><a href="DecisionList111915.pdf">PDF</a></td>
                   <td align="center">&nbsp;</td>
                   <td><strong>Entries for Cases and Motions</strong></td>
                 </tr>
                 <tr>
-                  <td valign="top"><strong>No. 205 SSM 18</strong></td>
-                  <td align="center" valign="top"><a href="SSM18mem15-Decision.pdf">PDF</a></td>
-                  <td align="center" valign="top"><a href="SSM18mem15-Decision.wpd">WPD</a></td>
-                  <td valign="top"><p>The Matter of Noel Olmosperez v. Andrea W. Evans</p></td>
+                  <td><strong>No.210 SSM 22</strong></td>
+                  <td align="center"><a href="SSM22ent15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="SSM22ent15-Decision.wpd">WPD</a></td>
+                  <td>Switzerland Green v. Metropolitan Transportation Authority Bus Company</td>
                 </tr>
                 <tr>
-                  <td valign="top"><strong>No. 179</strong></td>
-                  <td align="center" valign="top"><a href="179opn15-Decision.pdf">PDF</a></td>
-                  <td align="center" valign="top"><a href="179opn15-Decision.wpd">WPD</a></td>
-                  <td valign="top"><p>The People v. Jennifer Jorgensen</p></td>
+                  <td height="26"><strong>No.176</strong></td>
+                  <td align="center"><a href="176opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="176opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Samuel Small, Also Known as Samuel Smalls</td>
                 </tr>
                 <tr>
-                  <td valign="top"><strong>No. 143</strong></td>
-                  <td align="center" valign="top"><a href="143opn15-Decision.pdf">PDF</a></td>
-                  <td align="center" valign="top"><a href="143opn15-Decision.wpd">WPD</a></td>
-                  <td valign="top"><p>John Tipaldo v. Christopher Lynn</p></td>
+                  <td><strong>No.160</strong></td>
+                  <td align="center"><a href="160opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="160opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Antonio Martinez</td>
                 </tr>
                 <tr>
-                  <td height="43" valign="top"><strong>No. 136</strong></td>
-                  <td align="center" valign="top"><a href="136opn15-Decision.pdf">PDF</a></td>
-                  <td align="center" valign="top"><a href="136opn15-Decision.wpd">WPD</a></td>
-                  <td valign="top">The People of the State of New York<br />
-                  ex rel. Lesley M. DeLia v. Douglas Munsey</td>
+                  <td><strong>No.158</strong></td>
+                  <td align="center"><a href="158mem15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="158mem15-Decision.wpd">WPD</a></td>
+                  <td>The Matter of Estevan Gentil v. Hon. Ira Margulis</td>
                 </tr>
                 <tr>
-                  <td valign="top"><strong>No. 135</strong></td>
-                  <td align="center" valign="top"><a href="135mem15-Decision.pdf">PDF</a></td>
-                  <td align="center" valign="top"><a href="135mem15-Decision.wpd">WPD</a></td>
-                  <td valign="top"><p>The Matter of Anthony Bottom v. Anthony Annucci</p></td>
+                  <td><strong>No.154</strong></td>
+                  <td align="center"><a href="154opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="154opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Matthew P.</td>
                 </tr>
                 <tr>
-                  <td height="20" valign="top"><strong>No. 124</strong></td>
-                  <td align="center" valign="top"><a href="124mem15-Decision.pdf">PDF</a></td>
-                  <td align="center" valign="top"><a href="124mem15-Decision.wpd">WPD</a></td>
-                  <td valign="top"><p>The Matter of Jorge L.
-                  Linares v. Andrea W. Evans</p></td>
+                  <td><strong>No.152</strong></td>
+                  <td align="center"><a href="152opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="152opn15-Decision.wpd">WPD</a></td>
+                  <td>The People v. Willie L. Wragg</td>
                 </tr>
                 <tr>
-                  <td valign="top"><strong>No. 123</strong></td>
-                  <td align="center" valign="top"><a href="123opn15-Decision.pdf">PDF</a></td>
-                  <td align="center" valign="top"><a href="123opn15-Decision.wpd">WPD</a></td>
-                  <td valign="top"><p>The People v. Anthony Barksdale</p></td>
+                  <td><strong>No.151</strong></td>
+                  <td align="center"><a href="151opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="151opn15-Decision.wpd">WPD</a></td>
+                  <td>The Matter of Sierra Club v. Village of Painted Post</td>
                 </tr>
                 <tr>
-                  <td valign="top"><strong>No. 122</strong></td>
-                  <td align="center" valign="top"><a href="122opn15-Decision.pdf">PDF</a></td>
-                  <td align="center" valign="top"><a href="122opn15-Decision.wpd">WPD</a></td>
-                  <td valign="top">Nomura Asset Capital Corporation v. Cadwalader, Wickersham &amp; Taft </td>
+                  <td height="24"><strong>No.139</strong></td>
+                  <td align="center"><a href="139opn15-Decision.pdf">PDF</a></td>
+                  <td align="center"><a href="139opn15-Decision.wpd">WPD</a></td>
+                  <td>The Matter of Walter E. Carver v. State of New York</td>
                 </tr>
-
                 <tr>
                   <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
                 </tr>
-                <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">October 20, 2015</font></td>
+                <tr>
+                  <td colspan="4" bgcolor="#FFFFFF"><font size="+1" face="Arial, Helvetica, sans-serif">November 18, 2015</font></td>
                 </tr>
             <tr>
-              <td><strong>Decision List</strong></td>
-              <td align="center"><a href="DecisionList102015.pdf">PDF</a><a href="../Sep15/DecisionList092215.pdf"></a></td>
-              <td align="center">&nbsp;</td>
-              <td><strong>Entries for Cases and Motions</strong></td>
-              <tr>
-              <td valign="top"><strong>No. 144-146</strong></td>
-              <td align="center" valign="top"><a href="144-146opn15-Decision.pdf">PDF</a></td>
-              <td align="center" valign="top"><a href="144-146opn15-Decision.wpd">WPD</a></td>
-              <td valign="top"><p>Leonard Hutchinson v. Sheridan Hill House Corp. <br />
-                Matvey Zelichenko v. 301 Oriental Boulevard <br />
-                Maureen Adler v. QPI-VIII
-
-
-
+              <td width="24%"><strong>Decision List</strong></td>
+              <td width="7%" align="center"><a href="DecisionList111815.pdf">PDF</a></td>
+              <td width="12%">&nbsp;</td>
+              <td width="57%"><strong>Entries for Cases and Motions</strong></td>
+               <tr>
+              <td><strong>No.173</strong></td>
+              <td align="center"><a href="173mem15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="173mem15-Decision.wpd">WPD</a></td>
+              <td>In the Matter of Anthony Frank Fizzinoglia</td>
             </tr>
-               <tr>
-                 <td height="22"><strong>No. 141</strong></td>
-                 <td align="center"><a href="141mem15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="141mem15-Decision.wpd">WPD</a></td>
-                 <td>The People v. Thomas Barnes</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 138</strong></td>
-                 <td align="center"><a href="138mem15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="138mem15-Decision.wpd">WPD</a></td>
-                 <td>The People v. Vincent Izzo</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 129</strong></td>
-                 <td align="center"><a href="129opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="129opn15-Decision.wpd">WPD</a></td>
-                 <td>Remet Corporation v. The Estate of James R. Pyne</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 127</strong></td>
-                 <td align="center"><a href="127opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="127opn15-Decision.wpd">WPD</a></td>
-                 <td>The People of the State of New York v.<br />
-Sprint Nextel Corp.</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 90</strong></td>
-                 <td align="center"><a href="90opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="90opn15-Decision.wpd">WPD</a></td>
-                 <td>Jacqueline El-Dehdan v. Salim El-Dehdan, Also Known as <br />
-Sam Reed</td>
-               </tr>
-               <tr>
-                 <td>&nbsp;</td>
-                 <td align="center">&nbsp;</td>
-                 <td align="center">&nbsp;</td>
-                 <td>&nbsp;</td>
-               </tr>
-               <tr>
-                 <td><font size="+1" face="Arial, Helvetica, sans-serif">October 15, 2015</font></td>
-                 <td align="center">&nbsp;</td>
-                 <td align="center">&nbsp;</td>
-                 <td>&nbsp;</td>
-               </tr>
-               <tr>
-                 <td><strong>Decision List</strong></td>
-                 <td align="center"><a href="DecisionList101515.pdf">PDF</a><a href="../Sep15/DecisionList092215.pdf"></a></td>
-                 <td align="center"><a href="180opn15-Decision.wpd"></a></td>
-                 <td><strong>Entries for Cases and Motion</strong>s</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 180</strong></td>
-                 <td align="center"><a href="180opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="180opn15-Decision.wpd">WPD</a></td>
-                 <td>The People v. Jose Martinez Baxin</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 140</strong></td>
-                 <td align="center"><a href="140opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="140opn15-Decision.wpd">WPD</a></td>
-                 <td>The People v. Michael Sans</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 137</strong></td>
-                 <td align="center"><a href="137opn15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="137opn15-Decision.wpd">WPD</a></td>
-                 <td>he People v. Dupree Harris</td>
-               </tr>
-               <tr>
-                 <td><strong>No. 128</strong></td>
-                 <td align="center"><a href="128mem15-Decision.pdf">PDF</a></td>
-                 <td align="center"><a href="128mem15-Decision.wpd">WPD</a></td>
-                 <td>The People v. James R. Poleun</td>
-               </tr>
- <td width="48%" colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
- </tr>
+   <td><strong>No.171</strong></td>
+            <td align="center"><a href="171opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="171opn15-Decision.wpd">WPD</a></td>
+              <td>The People v. Daniel Israel</td>
+            </tr>
+            <tr>
+              <td><strong>No. 159</strong></td>
+
+              <td align="center"><a href="159opn15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="159opn15-Decision.wpd">WPD</a></td>
+              <td>The People v. Pettis Hardy</td>
+            </tr>
+            <tr>
+              <td><strong>No. 155</strong></td>
+              <td align="center"><a href="155mem15-Decision.pdf">PDF</a></td>
+              <td align="center"><a href="155mem15-Decision.wpd">WPD</a></td>
+              <td>The People v. Alfred Gary</td>
+            </tr>
+            <tr>
+              <td colspan="4" bgcolor="#FFFFFF">&nbsp;</td>
+            </tr>
           </table></td>
         </tr>
-      </table>
-      <table width="100%" border="0" cellpadding="5" cellspacing="0" summary="Main Page Centered Table">
         <tr bgcolor="#FFFFFF">
           <td><hr /></td>
         </tr>


### PR DESCRIPTION
Fixing New York Court of Appeals scraper, which broke due to some slight page format changes.  Updating html examples.  Updating opinion_template.py to referance/demonstarte new convert_date_string() function.