### PR TITLE
Fixing NH scraper to properly parse multi-case information associated with single pdf

### DIFF
--- a/opinions/united_states/state/nh.py
+++ b/opinions/united_states/state/nh.py
@@ -8,13 +8,16 @@
 # - 2014-10-17: Updated by mlr to fix regex error.
 # - 2015-06-04: Updated by bwc so regex catches comma, period, or whitespaces
 #   as separator. Simplified by mlr to make regexes more semantic.
-
-import time
+# - 2016-02-20: Updated by arderyp to handle strange format where multiple
+#   case names and docket numbers appear in anchor text for a single case
+#   pdf link. Multiple case names are concatenated, and docket numbers are
+#   concatenated with ',' delimiter
 
 import re
-from juriscraper.OpinionSite import OpinionSite
-
 from datetime import date
+
+from juriscraper.OpinionSite import OpinionSite
+from juriscraper.lib.string_utils import convert_date_string
 
 
 class Site(OpinionSite):
@@ -23,16 +26,21 @@ class Site(OpinionSite):
         self.url = 'http://www.courts.state.nh.us/supreme/opinions/{current_year}/index.htm'.format(
             current_year=date.today().year)
         self.court_id = self.__module__
-        self.case_name_regex = re.compile('(\d{4}-\d+(?!.*\d{4}-\d+))(?:,|\.|\s?) (.*)')
+        self.link_path = 'id("content")/div//ul//li//a[position()=1]'
+        self.link_text_regex = re.compile('(\d{4}-\d+(?!.*\d{4}-\d+))(?:,|\.|\s?) (.*)')
 
     def _get_case_names(self):
-        path = "id('content')/div//ul//li//a[position()=1]/text()"
         case_names = []
-        for text in self.html.xpath(path):
-            # Uses a negative look ahead to make sure to get the last
-            # occurrence of a docket number.
-            match_case_name = self.case_name_regex.search(text)
-            case_names.extend([match_case_name.group(2)])
+        for link in self.html.xpath(self.link_path):
+            # Text of some links includes info for multiple cases split by <br>
+            # so we'll iterate over each, extract the name, clean it up, then
+            # glue the names together to form one long name. (Example: Feb2016)
+            link_names = []
+            for text in link.xpath('text()'):
+                name_raw = self.link_text_regex.search(text).group(2)
+                if name_raw:
+                    link_names.append(' '.join(name_raw.split()))
+            case_names.append(' '.join(link_names))
         return case_names
 
     def _get_download_urls(self):
@@ -44,27 +52,28 @@ class Site(OpinionSite):
         return download_url
 
     def _get_case_dates(self):
-        path = "id('content')/div//strong"
-        path_2 = './following-sibling::ul[1]//li|../following-sibling::ul[1]//li'
         dates = []
-        for p_element in self.html.xpath(path):
-            try:
-                date_str = str(p_element.xpath('./text()')[0])
-                d = date.fromtimestamp(time.mktime(time.strptime(re.sub(' ', '', date_str), '%B%d,%Y')))
-                dates.extend([d] * len(p_element.xpath(path_2)))
-            except ValueError:
-                pass
-            except IndexError:
-                pass
+        path = 'id("content")/div//strong'
+        sub_path = './following-sibling::ul[1]//li|../following-sibling::ul[1]//li'
+        for element in self.html.xpath(path):
+            date = convert_date_string(element.xpath('text()')[0])
+            for case in element.xpath(sub_path):
+                dates.append(date)
         return dates
 
     def _get_precedential_statuses(self):
         return ['Published'] * len(self.case_names)
 
     def _get_docket_numbers(self):
-        path = "id('content')/div//ul//li//a[position()=1]/text()"
         docket_numbers = []
-        for text in self.html.xpath(path):
-            match_docket_nr = re.search('(.*\d{4}-\d+)(?:,|\.|\s?) (.*)', text)
-            docket_numbers.append(match_docket_nr.group(1))
+        for link in self.html.xpath(self.link_path):
+            # Text of some links includes info for multiple cases split by <br> so we'll
+            # iterate over each, extract the docket number, then glue the numbers together
+            # to create a single "xxx,yyy" docket number. (Example: Feb2016)
+            case_dockets = []
+            for text in link.xpath('text()'):
+                docket = self.link_text_regex.search(text).group(1)
+                if docket:
+                    case_dockets.append(docket)
+            docket_numbers.append(','.join(case_dockets))
         return docket_numbers

--- a/tests/examples/opinions/united_states/nh_example_2.html
+++ b/tests/examples/opinions/united_states/nh_example_2.html
@@ -1,0 +1,285 @@
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+"http://www.w3.org/TR/html4/loose.dtd">
+<html><!-- InstanceBegin template="/Templates/Supreme Court - Template.dwt" codeOutsideHTMLIsLocked="false" -->
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<!-- InstanceBeginEditable name="doctitle" -->
+<title>New Hampshire Judicial Branch - Supreme Court</title>
+<!-- InstanceEndEditable -->
+<script type="text/javascript"><!--
+function fsize(size,unit,id){
+  var vfontsize = document.getElementById(id);
+  if(vfontsize){
+   vfontsize.style.fontSize = size + unit;
+  }
+}
+var textsize = 1.2;
+function changetextsize(up){
+  if(up){
+   textsize = parseFloat(textsize)+.2;
+  }else{
+   textsize =parseFloat(textsize)-.2;
+  }
+}
+//--></script>
+
+<link rel="stylesheet" href="../../../style.css" type="text/css">
+
+<meta name="description" content="The website for the New Hampshire Judicial Branch of Government">
+<meta name="keywords" content="courts, supreme court, superior court, district court, probate court, family division, judiciary, justices, judges, law, NH, New Hampshire">
+<!-- InstanceBeginEditable name="head" --><!-- InstanceEndEditable -->
+</head>
+<body>
+<a href="#skip"></a>
+<div id="size">
+  <!-- InstanceBeginEditable name="Header" -->
+  <div id="masthead_supreme">
+    <div id="whitespace"><a href="../../../index.htm"><img src="../../../images/header4.jpg" alt="New Hampshire Judicial branch seal" width="378" height="98" border="0"></a></div>
+    <div id="tools"> <a href="../../../sitewidelinks/ada.htm" class="topnav">Accessibility Options</a> | <a href="../../../sitewidelinks/faqindex.htm" class="topnav">FAQ</a> | <a href="../../../sitewidelinks/sitemap.htm" class="topnav">Site Map</a> | <a href="../../../sitewidelinks/contacts.htm" class="topnav">Contact Us</a> | <a href="javascript:fsize(textsize,'em','content');" onClick="changetextsize(1);" class="topnav">Text +</a> <a href="javascript:fsize(textsize,'em','content');" onClick="changetextsize(0);" class="topnav">Text -</a> </div>
+  </div>
+  <!-- InstanceEndEditable -->
+  <div id="navcontainerbg">
+<div class="menu">
+<ul>
+	<li><a href="../../../index.htm">Home <span style="color: #999;">|</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+		<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+	</li>
+</ul>
+
+<ul>
+	<li><a href="../../index.htm">Supreme Court <span style="color: #999;">|</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+		<ul>
+	<li><a href="../../index.htm">Supreme Home</a></li>
+	<li><a href="../../welcome.htm">Welcome</a></li>
+	<li><a href="../../about.htm">About the Court</a></li>
+	<li><a href="../../../courtlocations/index.htm#supreme">Court Location</a></li>
+	<li><a href="../index.htm">Slip Opinions</a></li>
+	<li><a href="../../orders/index.htm">Orders</a></li>
+	<li><a href="../../forms/index.htm">Forms</a></li>
+	<li><a href="../../forms/Revdfeechanges.pdf">Filing Fees</a></li>
+	<li><a href="../../../rules/index.htm">Court Rules</a></li>
+		</ul>
+	<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+	</li>
+</ul>
+
+<ul>
+<li><a href="../../../superior/index.htm">Superior Court <span style="color: #999;">|</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+		<ul>
+			<li><a href="../../../superior/index.htm">Superior Home</a></li>
+	<li><a href="../../../superior/welcome.htm">Welcome</a></li>
+    <li><a href="../../../courtlocations/index.htm#superior">Court Locations</a></li>
+	<li><a href="../../../superior/forms/index.htm">Forms</a></li>
+    <li><a href="../../../superior/filing_fees.pdf">Filing Fees</a></li>
+	<li><a href="../../../rules/index.htm">Court Rules</a></li>
+	<li><a href="../../../superior/civilrulespp/index.htm">Civil Rules of Procedure</a></li>
+		</ul>
+		<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+	</li>
+
+</ul>
+<ul>
+	<li><a href="../../../circuitcourt/index.htm">Circuit Court <span style="color: #999;">|</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+		<ul>
+	<li><a href="../../../circuitcourt/index.htm">Circuit Court Home</a></li>
+	<li><a href="../../../district/index.htm"><span class="drop"><span>District Division</span>&raquo;</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+
+	<ul>
+	<li><a href="../../../district/index.htm">District Division Home</a></li>
+	<li><a href="../../../circuitcourt/welcome.htm">Welcome</a></li>
+    <li><a href="../../../courtlocations/index.htm#district">Court Locations</a></li>
+	<li><a href="../../../district/forms/index.htm">Forms</a></li>
+    <li><a href="../../../district/filing_fees.pdf">Filing Fees</a></li>
+	<li><a href="../../../rules/dmcr/index.htm">Court Rules</a></li>
+	<li><a href="../../../district/service_center.htm">Service Center</a></li>
+				</ul>
+				<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+			</li>
+
+	<li><a href="../../../probate/index.htm"><span class="drop"><span>Probate Division</span>&raquo;</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+
+		<ul>
+    <li><a href="../../../probate/index.htm">Probate Division Home</a></li>
+	<li><a href="../../../circuitcourt/welcome.htm">Welcome</a></li>
+	<li><a href="../../../courtlocations/index.htm#probate">Court Locations</a></li>
+	<li><a href="../../../courtlocations/atol.htm">Where to File a Case</a></li>
+	<li><a href="../../../probate/pcforms/index.htm">Forms</a></li>
+	<li><a href="../../../probate/probfilingfees.pdf">Filing Fees</a></li>
+	<li><a href="../../../rules/prob2/index.htm">Court Rules</a></li>
+				</ul>
+				<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+			</li>
+
+    <li><a href="../../../fdpp/index.htm"><span class="drop"><span>Family Division</span>&raquo;</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+
+		<ul>
+    <li><a href="../../../fdpp/index.htm">Family Division Home</a></li>
+	<li><a href="../../../circuitcourt/welcome.htm">Welcome</a></li>
+	<li><a href="../../../courtlocations/index.htm#family">Court Locations</a></li>
+	<li><a href="../../../fdpp/wheretofile.htm">Where to File a Case</a></li>
+	<li><a href="../../../fdpp/forms/index.htm">Forms</a></li>
+	<li><a href="../../../fdpp/filing_fees.pdf">Filing Fees</a></li>
+	<li><a href="../../../rules/family/index.htm">Court Rules</a></li>
+	<li><a href="../../../fdpp/service_center.htm">Service Center</a></li>
+				</ul>
+				<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+			</li>
+
+
+		</ul>
+		<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+	</li>
+	</ul>
+
+
+
+<ul>
+	<li><a href="../../../drugcourts/index.htm">Drug and Mental Health Courts <span style="color: #999;">|</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+	 	<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+	  </li>
+</ul>
+<ul>
+	<li><a href="../../../adrp/index.htm">Mediation &amp; Arbitration <span style="color: #999;">|</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+		<ul>
+	<li><a href="../../../adrp/index.htm">Mediation &amp; Arbitration Home</a></li>
+	<li><a href="../../../adrp/appellate/index.htm">Supreme Court Mediation</a></li>
+	<li><a href="../../../adrp/superior/index.htm">Superior Court Mediation</a></li>
+	<li><a href="../../../adrp/district/index.htm">Circuit Court District Division Mediation</a></li>
+	<li><a href="../../../adrp/probate/index.htm">Circuit Court Probate Division Mediation</a></li>
+	<li><a href="../../../adrp/family/index.htm">Circuit Court Family Division Mediation</a></li>
+	<li><a href="../../../adrp/business/index.htm">Business Court Mediation</a></li>
+    <li><a href="../../../adrp/foreclosure/index.htm">Foreclosure Mediation</a></li>
+		</ul>
+		<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+	</li>
+</ul>
+
+<ul>
+	<li><a href="../../../lawlibrary/index.htm">Law Library <span style="color: #999;">|</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+	 	<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+	  </li>
+</ul>
+<ul>
+	<li><a href="../../../nh-e-court-project/electronic-services.htm" id="eservices"><span id="eservices">Electronic Services</span><!--[if gt IE 6]><!--></a><!--<![endif]--><!--[if lt IE 7]><table border="0" cellpadding="0" cellspacing="0"><tr><td><![endif]-->
+	 	<!--[if lte IE 6]></td></tr></table></a><![endif]-->
+	  </li>
+</ul>
+
+</div>
+<!-- close "menu" div -->
+</div>
+
+
+  <div id="leftcol">
+  <div id="sectionLinks">
+    <h3><a href="../../index.htm">Supreme Court</a></h3>
+    <ul><li><a href="../../welcome.htm">Welcome</a></li>
+      <li><a href="../../about.htm">About the Court</a></li>
+      <li><a href="../../../courtlocations/index.htm#supreme">Court Location</a></li>
+      <li><a href="../../justices.htm">Meet the Justices</a></li>
+      <li><a href="../../../rules/index.htm">Court Rules</a></li>
+      <li><a href="../../accepted/index.htm">Cases Accepted</a></li>
+      <li><a href="../../orals/index.htm">Oral Argument Calendar</a></li>
+      <li><a href="../../orders/index.htm">Orders</a></li>
+	  <li><a href="../../amicus/index.htm">Amicus Announcements</a></li>
+      <li><a href="../../request.htm">Request to Review File</a></li>
+      <li><a href="../../ebriefs/index.htm">eBriefs</a></li>
+	  <li><a href="../../../sitewidelinks/listservice.htm">List Service</a></li>
+	  <li><a href="../../../adrp/appellate/index.htm">Mediation</a></li>
+      <li><a href="../../../committees/adviscommrules/index.htm">Advisory Committee on Rules</a></li>
+      <li></li>
+    </ul>
+  </div>
+   <div class="relatedLinks">
+    <h3><span class="resourceboxlabel">Case Decisions</span></h3>
+    <ul>
+      <li><a href="../index.htm">Opinions</a></li>
+	  <li><a href="../../3jx/index.htm">3JX Final Orders</a></li>
+      <li><a href="../../finalorders/index.htm">Other Final Orders</a></li>
+      <li></li>
+      <li></li>
+    </ul>
+  </div>
+</div>
+<!--end navBar div -->
+<div id="rightcol">
+<form method="GET" action="http://search.nh.gov/courts-search.htm">
+ <input type="hidden" name="ul" id="ul" value="http://www.courts.state.nh.us/" />
+ <input type="text" name="q" size="15" id="q" alt="text"onblur="this.value = this.value || this.defaultValue;" onfocus="this.value == this.defaultValue && (this.value = '');" value="Search...">
+ <input type="submit" name="goButton" value="Go" alt="submit">
+</form>
+  <div class="quicklinks">
+    <div class="quicklinkstitle">Quick Links </div>
+    <div class="quicklinksclear"><a href="../../forms/index.htm"><img src="../../../images/icon_forms.jpg" alt="Forms Icon" width="35" height="35" border="0" align="left"></a>
+        <div class="quicklinksitem"><a href="../../forms/index.htm">Forms </a></div>
+    </div>
+	  <div class="quicklinksclear"><a href="../../forms/Revdfeechanges.pdf"><img src="../../../images/icon_fees.jpg" alt="Forms Icon" width="35" height="35" border="0" align="left"></a>
+        <div class="quicklinksitem"><a href="../../forms/Revdfeechanges.pdf">Filing Fees</a></div>
+    </div>
+    <div class="quicklinksclear"><a href="../../faq.htm"><img src="../../../images/icon_faq.jpg" alt="Forms Icon" width="35" height="35" border="0" align="left"></a>
+        <div class="quicklinksitem"><a href="../../faq.htm">FAQ</a></div>
+    </div>
+    <div class="quicklinksclear"><a href="../../../courtlocations/index.htm"><img src="../../../images/icon_contact.jpg" alt="Forms Icon" width="35" height="35" border="0" align="left"></a>
+        <div class="quicklinksitem"><a href="../../../courtlocations/index.htm">Contact</a></div>
+    </div>
+  </div>
+  <div class="findyourcourtcontainer">
+    <a href="../../../courtlocations/index.htm"><img src="../../../images/findyourcourt2.jpg" alt="Image: Find Your Court!" border="0"></a>
+    <a href="http://www.courts.nh.gov/cstream/index.asp"><img src="../../../images/webcast-icon.jpg" alt="Image: Find Your Court!" width="145" height="89" border="0"></a> </div>
+  <h3>&nbsp;</h3>
+</div>
+
+<!--end rightcol -->
+<a name="skip" id="skip"></a>
+<!-- InstanceBeginEditable name="Title" -->
+<div id="courtheader">
+  <div id="courtheadertext" >Supreme Court  - 2016 Opinions</div>
+</div>
+<!-- InstanceEndEditable -->
+
+<!-- InstanceBeginEditable name="Content" -->
+<div id="content">
+  <div class="section">
+    <p><b>NOTICE:</b> These opinions are subject to motions for rehearing under Rule 22 as well as formal revision before publication in the New Hampshire Reports. Readers are requested to notify the Reporter, Supreme Court of New Hampshire, One Charles Doe Drive, Concord, New Hampshire 03301, of any editorial errors in order that corrections may be made before the opinion goes to press. Errors may be reported by E-mail at the following address: <a href="mailto:reporter@courts.state.nh.us">reporter@courts.state.nh.us</a>. </p>
+    <p>Opinions are in Adobe Acrobat format (to download a free copy of Adobe Acrobat Reader, go to <a href="http://www.adobe.com" target="_blank">http://www.adobe.com</a>).    </p>
+    <p><a name="feb" id="feb"></a><strong>February 18, 2016</strong></p>
+    <ul>
+      <li><a href="/supreme/opinions/2016/2016013townofsalem.pdf">2014-0650, Appeal of Town of Salem &amp; a.;<br>
+        2014-0736, Town of Salem &amp; a. v. Local Government Center, Inc. &amp; a.</a></li>
+      <li><a href="/supreme/opinions/2016/2016014lafayettellc.pdf">2015-0143, Kelly Sanborn, Trustee of the 428 Lafayette, LLC Realty Trust &amp; a. v. 428 Lafayette, LLC &amp; a.; Andrew Cotrupi v. 428 Lafayette, LLC &amp; a.</a></li>
+    </ul>
+    <p><strong>February 12, 2016</strong></p>
+    <ul>
+      <li><a href="/supreme/opinions/2016/2016011boyer.pdf">2014-0725, The State of New Hampshire v. Tyler Boyer</a></li>
+      <li><a href="/supreme/opinions/2016/2016012olson.pdf">2015-0264, Jeremy Olson &amp; a. v. Town of Grafton</a></li>
+    </ul>
+<p><a name="jan" id="jan"></a><strong>January 26, 2016</strong></p>
+    <ul>
+      <li><a href="/supreme/opinions/2016/2016005roy.pdf">2014-0730, Jeffrey Roy v. Quality Pro Auto, LLC</a></li>
+      <li><a href="/supreme/opinions/2016/2016006castagnaro.pdf">2014-0782, Joseph Castagnaro v. The Bank of New York Mellon</a></li>
+      <li><a href="/supreme/opinions/2016/2016007nizhnikov.pdf">2014-0794, In the Matter of Marianna Nizhnikov and Alexander  Nizhnikov</a></li>
+      <li><a href="/supreme/opinions/2016/2016008concord.pdf">2014-0801, Appeal of City of Concord</a></li>
+      <li><a href="/supreme/opinions/2016/2016009smith.pdf">2015-0019, Jeffrey Smith v. Milko Pesa d/b/a Auto Milko</a></li>
+      <li><a href="/supreme/opinions/2016/2016010oldrepublic.pdf">2015-0123, Old Republic Insurance Company v. Stratford  Insurance Company</a></li>
+    </ul>
+<p><strong>January 12, 2016</strong></p>
+    <ul>
+      <li><a href="/supreme/opinions/2016/2016001grande.pdf">2013-0762, The State of New Hampshire v. Oscar Grande</a></li>
+      <li><a href="/supreme/opinions/2016/2016002dow.pdf">2014-0591, The State of New Hampshire v. Roland Dow</a></li>
+      <li><a href="/supreme/opinions/2016/2016003thi.pdf">2014-0674, Appeal of THI of New Hampshire at Derry, LLC</a></li>
+      <li><a href="/supreme/opinions/2016/2016004willette.pdf">2015-0108, Federal Home Loan Mortgage Corporation v.  Michelle Willette</a></li>
+    </ul>
+<p>&nbsp;</p>
+<p>&nbsp;</p>
+</div>
+</div>
+<!-- InstanceEndEditable -->
+<!--end content -->
+
+<div id="siteInfo">  <a href="../../../sitewidelinks/ada.htm" class="footernav">Accessibility Options</a> | <a href="../../../sitewidelinks/faqindex.htm" class="footernav">FAQ</a> | <a href="../../../sitewidelinks/sitemap.htm" class="footernav">Site Map</a> | <a href="../../../sitewidelinks/contacts.htm" class="footernav">Contact Us</a> | <a href="http://www.gencourt.state.nh.us" class="footernav">N.H. Legislative Branch</a> | <a href="http://www.nh.gov/government/state.html" class="footernav">N.H. Executive Branch</a> | <a href="http://www.nh.gov/" class="footernav">NH.Gov</a> | <a href="http://www.gencourt.state.nh.us/rsa/html/indexes/" class="footernav">Revised Statutes Online</a> </div>
+<br>
+</div>
+</body>
+<!-- InstanceEnd --></html>

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -824,7 +824,7 @@ class ScraperSpotTest(unittest.TestCase):
             ('2013-0893, Stephen E. Forster d/b/a Forster’s Christmas Tree',
              'Stephen E. Forster d/b/a Forster’s Christmas Tree'),
         )
-        regex = nh.Site().case_name_regex
+        regex = nh.Site().link_text_regex
         for test, result in string_pairs:
             try:
                 case_name = regex.search(test).group(2).strip()


### PR DESCRIPTION
The court recently published a case whose link text exhibited a new format by including multiple (2) case titles and multiple (2) docket numbers, separated by <br>.  This commit will detect both case names, clean them up, then glue them together.  It will also detect both docket numbers, and concatenate them with a ',' delimiter.  I've added a new html example for Feb2016 page to test against this use case in the future.  I also changed one line in tests/test.py, which was calling a property on the nh.py Site() class, which I renamed for clarity's sake.