### PR TITLE
Simplifying, documenting, and fixing nd/ndctapp scrapers.

### DIFF
--- a/opinions/united_states/state/ndctapp.py
+++ b/opinions/united_states/state/ndctapp.py
@@ -3,54 +3,23 @@
 # This court only hears cases that the ND Supreme Court assigns to it. As a
 # result, years can go by without a case from this court.
 
-
-from datetime import date
-from datetime import datetime
-
 from juriscraper.opinions.united_states.state import nd
-from lxml import html
 
 
 class Site(nd.Site):
-    def __init__(self, *args, **kwargs):
-        super(Site, self).__init__(*args, **kwargs)
-        self.court_id = self.__module__
-        today = date.today()
-        now = datetime.now()
-        self.url = 'http://www.ndcourts.gov/opinions/month/%s.htm' % (today.strftime("%b%Y"))
-        if today.day == 1 and now.hour < 16:
-            # On the first of the month, the page doesn't exist until later in
-            # the day, so when that's the case,  we don't do anything until
-            # after 16:00. If we try anyway, we get a 503 error. This simply
-            # aborts the crawler.
-            self.status = 200
-            self.html = html.fromstring('<html></html>')
+    """This class is almost an exact clone of the nd scraper.  They
+    both point to the same resource page, but they scrape different
+    data from that page.  The page presents both Supreme Court and
+    Appeal cases.  Appeal cases are posted VERY infrequently.  While
+    the nd scraper will look at the resource page and extract all of
+    the Supreme Court cases and exclude the Appeal cases, this scraper
+    will do the opposite.  That is, this scraper will only return the
+    appeal cases listed on the resource page.  Since Appeal cases are
+    posted very infrequently, it is completely normal for this scraper
+    to return zero results for very long periods of time.  At the time
+    of writing this (Feb 2016), the last legitimate Appeal case was
+    posted 8.5 years ago (Aug 2007).
+    """
 
-    def _post_parse(self):
-        # Remove any information that applies to non-appellate cases.
-        if self.neutral_citations:
-            delete_items = []
-            for i in range(0, len(self.neutral_citations)):
-                if 'App' not in self.neutral_citations[i]:
-                    delete_items.append(i)
-
-            for i in sorted(delete_items, reverse=True):
-                del self.download_urls[i]
-                del self.case_names[i]
-                del self.case_dates[i]
-                del self.precedential_statuses[i]
-                del self.docket_numbers[i]
-                del self.neutral_citations[i]
-                del self.case_name_shorts[i]
-                del self.blocked_statuses[i]
-        else:
-            # When there aren't any neutral cites that means everything is a
-            # supreme court case, and it all gets deleted.
-            self.download_urls = []
-            self.case_names = []
-            self.case_dates = []
-            self.precedential_statuses = []
-            self.docket_numbers = []
-            self.neutral_citations = []
-            self.case_name_shorts = []
-            self.blocked_statuses = []
+    def _should_scrape_case(self, citation):
+        return self._is_appellate_citation(citation)

--- a/tests/examples/opinions/united_states/nd_example_3.html
+++ b/tests/examples/opinions/united_states/nd_example_3.html
@@ -1,0 +1,103 @@
+ <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+ <html lang="en">
+ <head>
+     <title>August 2007</title>
+ </head>
+ <meta name="Description" content="North Dakota Supreme Court Opinions by month">
+ <script language="JavaScript" src="/js/opinions.js"></script>
+ <link rel="stylesheet" type="text/css" href="/ndsct.css">
+ <body>
+ <script language="JavaScript" src="/js/header.js"></script>
+ <br>
+ <center>
+     <font size="+2" color="Navy">August 2007</font>
+ </center>
+ <br><font size="+1">August 30, 2007</font>
+ <br><br>
+ <a href="/court/opinions/20060321.htm"> Lee v. Lee</a>, 2007 ND 147
+ <br>A trial court has subject matter jurisdiction to order a party to pay spousal support beyond the party's original spousal support obligation, even when the original obligation has already ended, when reconsideration of an interrelated child support obligation could constitute a change in circumstances for purposes of the spousal support obligation.
+ <br>A change in a child support obligation may constitute a material change in circumstances requiring reconsideration of an interrelated spousal support obligation.
+ <br>Attorney's fees will not be awarded absent a showing of need or a showing that an appeal was frivolous.
+ <br><a href="/court/opinions/20060356.htm"> Peterson v. Dakota Molding, Inc.</a>, 2007 ND 144
+ <br>In a garnishment proceeding, where a garnishee denies liability, the plaintiff may move the court for leave to file a supplemental complaint making the garnishee a party to the action, and setting forth the facts upon which the plaintiff claims to charge the garnishee. If probable cause is shown, the motion shall be granted.
+ <br>The question whether probable cause has been shown, so as to require leave to file a supplemental complaint making a garnishee a party to an action, depends on whether the evidence shows probable grounds for believing that the garnishee might be held liable.
+ <br>A term in an insurance policy should be construed to mean what a reasonable person in the position of the insured would think it meant. Limitations or exclusions from broad coverage must be clear and explicit. When the language of an insurance policy is clear and explicit, the language should not be strained in order to impose liability on the insurer.
+ <br><a href="/court/opinions/20070015.htm"> State v. Demars</a>, 2007 ND 145
+ <br>Denial of a motion to suppress evidence will not be reversed if there is sufficient competent evidence capable of supporting the court's findings, and if its decision is not contrary to the manifest weight of the evidence.
+ <br><a href="/court/opinions/20060377.htm"> State v. Kunze</a>, 2007 ND 143
+ <br>When a trial court concludes it is necessary to physically restrain a defendant at trial in front of the jury, the court must consider less restrictive, less prejudicial methods of restraint.
+ <br>To provide for meaningful appellate review, a trial court must articulate its reasons for placing the defendant in physical restraints on the record, including a discussion of less prejudicial alternatives.
+ <br><a href="/court/opinions/20060274.htm"> State v. Tibor</a>, 2007 ND 146
+ <br>A court does not abuse its discretion in allowing expert testimony about child sexual abuse accommodation syndrome if it finds the testimony may assist the jury in understanding the evidence or determine a fact in issue.
+ <br>Mere repetition of a child's out-of-court statements does not make them unduly prejudicial.<br>A conviction rests upon insufficient evidence only when, after reviewing the evidence in the light most favorable to the prosecution and giving the prosecution the benefit of all inferences reasonably to be drawn in its favor, no rational fact-finder could find the defendant guilty beyond a reasonable doubt.
+ <br><br><font size="+1">August 27, 2007</font>
+ <br><br><a href="/court/opinions/20060320.htm"> Tedford v. Workforce Safety and Insurance</a>, 2007 ND 142
+ <br>The retirement offset provision, N.D.C.C. 65-05-09.2, authorizing offset of social security retirement benefits against workers compensation disability benefits, does not apply to injured employees who were receiving benefits for a total disability prior to the statute's effective date.
+ <br>In determining whether an administrative agency acted without substantial justification, triggering an award of actual attorney fees and costs under N.D.C.C. 28-32-50(1), the fact that a judge at an earlier stage of the proceedings agreed with the agency's position is persuasive evidence that the position was substantially justified.
+ <br><br><font size="+1">August 24, 2007</font><br><br><a href="/court/opinions/20060308.htm"> Superior, Inc. v. Behlen Mfg.</a>, 2007 ND 141
+ <br>A contractual right to indemnification may be implied based on the special nature of the relationship between the parties, or when there are unique factors demonstrating that the parties intended the would-be indemnitor to bear the ultimate responsibility for a certain matter.
+ <br>Implied contractual indemnity is an equitable remedy that is available only if a party does not have an adequate remedy at law.
+ <br>Under the Uniform Commercial Code, a buyer may seek consequential damages from the seller when it incurs liability to a third party as a result of the use or resale of the seller's product.
+ <br><br><font size="+1">August 22, 2007</font><br><br><a href="/court/opinions/20060218.htm"> Burns v. Burns</a>, 2007 ND 134
+ <br>A continuance is the proper remedy for a party claiming surprise, and a judgment will not ordinarily be reversed on appeal for surprise when no request is made for a continuance at the time and there is no showing of inability to meet the situation.
+ <br>If evidence of domestic violence does not rise to the level to trigger the presumption against an award of custody, the court may still consider the evidence as one of the best interest factors.
+ <br>A district court's concerns about maintaining the custodial relationship that existed prior to the divorce and allowing the child to attend the same school and live in the same house are all valid considerations under N.D.C.C. 14-09-06.2(1)(d).
+ <br>Being a child's primary caretaker does not guaranty a custody award in a divorce action.<br><a href="/court/opinions/20070043.htm"> City of Fargo v. Malme</a>, 2007 ND 137
+ <br>Cities are creatures of statute and possess only those powers and authorities granted by statute or necessarily implied from an express statutory grant.
+ <br>Home rule charters allow cities to enact laws contrary to those of the state.
+ <br>The supersession provision in N.D.C.C. 40-05.1-05 applies only to those powers enumerated in N.D.C.C. 40-05.1-06, and those powers must also be included in the home rule charter and be implemented by ordinance.
+ <br>The rule of strict construction applies in defining municipal powers, and any doubt as to the existence or extent of municipal powers must be resolved against the municipality.
+ <br><a href="/court/opinions/20060380.htm"> Estate of Allmaras</a>, 2007 ND 130
+ <br>A conservator has discretionary authority to manage the protected person's estate, subject to the conservator's fiduciary responsibilities and taking into account any known estate plan of the protected person.
+ <br>A payable-on-death beneficiary has no present interest in the account, no right to prevent the depositor from removing the account funds and effectively destroying the beneficiary designation, and no right to preclude the depositor from changing or removing the beneficiaries on the account.
+ <br><a href="/court/opinions/20060303.htm"> Farmers Union Mut. Ins. Co. v. Assoc. Electric and Gas Ins. Services Ltd.</a>, 2007 ND 135
+ <br>Statutory interpretation is a question of law and fully reviewable on appeal.
+ <br>Words in a statute are given their plain, ordinary, and commonly understood meaning, unless defined by statute or unless a contrary intention plainly appears.
+ <br>Statutes are construed as a whole and are harmonized to give meaning to related provisions.
+ <br>If the language of a statute is clear and unambiguous, the letter of the statute cannot be disregarded under the pretext of pursuing its spirit.
+ <br>Under N.D.C.C. 26.1-41-17, which permits a basic no-fault insurer to seek equitable allocation and intercompany arbitration for no-fault benefits paid, "the motor vehicle liability insurer of a secured person" does not include an excess liability insurer.
+ <br><a href="/court/opinions/20060359.htm"> Graner v. Graner</a>, 2007 ND 139
+ <br>A district court's decision on a custodial parent's motion to relocate out-of-state will be reversed on appeal only if it is clearly erroneous.
+ <br>Increased visitation expenses and distance are not a sufficient basis to deny a custodial parent's motion to relocate.
+ <br>A court may not modify custody within two years of an order establishing custody, unless the court finds the modification is in the child's best interests and there is willful denial of visitation, the child's environment endangers the child's physical or emotional health or impairs the child's emotional development, or the noncustodial parent has had primary physical care of the child for longer than six months.
+ <br><a href="/court/opinions/20070004.htm"> J.P. v. Stark County Social Services</a>, 2007 ND 140
+ <br>When a medicaid recipient receives out-of-state medical care without prior approval when there is no emergency, payment may be covered only if there was good cause for not first securing approval, the care and services were not available in state, and the care and services were medically necessary.
+ <br><a href="/court/opinions/20070063.htm"> Riemers v. State</a>, 2007 ND App 4 - Court of Appeals
+ <br>A judgment of dismissal for failure to state a claim upon which relief can be granted will be affirmed by an appellate court if it cannot discern a potential for proof to support the claim.
+ <br>Under N.D.R.Civ.P. 12(c), if, on a motion for judgment on the pleadings, matters outside the pleadings are presented to and not excluded by the court, the motion must be treated as one for summary judgment under N.D.R.Civ.P. 56.
+ <br>The court, in deciding a motion for judgment on the pleadings, may consider, in addition to the pleadings, materials embraced by the pleadings and materials that are part of the public record without converting the motion to a summary judgment.
+ <br><a href="/court/opinions/20060329.htm"> State v. Kautzman</a>, 2007 ND 133
+ <br>A mistrial must be declared before the trial is over and before the jury has been discharged. When defense counsel moves for a mistrial, an instruction to the jury must be requested to properly preserve the question for appellate review.
+ <br>A judgment of acquittal may be entered only if the evidence is insufficient to sustain a conviction.
+ <br>For an offense to be a lesser included offense, it must be impossible to commit the greater offense without committing the lesser.
+ <br>If counsel does not object to the trial court's instructions, the issue is not adequately preserved and inquiry on appeal is limited to whether the court's failure to instruct the jury was obvious error affecting substantial rights.
+ <br>A party may not challenge as error a ruling or other trial proceeding invited by that party.
+ <br>A trial court has broad discretion when deciding evidentiary matters, and its admission or exclusion of evidence will not be overturned on appeal unless that discretion has been abused.
+ <br><a href="/court/opinions/20060340.htm"> State v. Muhle</a>, 2007 ND 131
+ <br>A court's evaluation of the trustworthiness of a child's out-of-court statement about alleged sexual abuse, may include these non-exclusive factors: (1) the spontaneity and consistent repetition of the statements, (2) the mental state of the declarant, (3) the use of terminology unexpected of a child of similar age, and (4) a lack of motive to fabricate.
+ <br>If a defendant has an opportunity to cross-examine a witness at trial, the admission of testimonial statements would not violate the Confrontation Clause.
+ <br>The proper remedy for unfair surprise is a continuance, but one must be requested.
+ <br>The term "statement," as used in N.D.R.Crim.P. 16(f), means a written or otherwise recorded statement made by the witness, codefendant, or other person.
+ <br><a href="/court/opinions/20060328.htm"> State v. Muhle</a>, 2007 ND 132
+ <br>A district court's evidentiary ruling is reviewed for an abuse of discretion.
+ <br>Out-of-court testimonial statements may not be admitted into evidence when the child is unavailable to testify unless the defendant has had an opportunity to cross-examine the child. If a defendant has an opportunity to cross-examine the witness at trial, the admission of testimonial statements would not violate the Confrontation Clause.
+ <br>Rule 16 of the North Dakota Rules of Criminal Procedure requires only "statements" be disclosed by the prosecution. "Statement" is defined technically and emphasizes formal, written, or recorded declarations.
+ <br>To establish a violation under <u>Brady v. Maryland</u>, the defendant must prove: (1) the government possessed evidence favorable to the defendant; (2) the defendant did not possess the evidence and could not have obtained it with reasonable diligence; (3) the prosecution suppressed the evidence; and (4) a reasonable probability exists that the outcome of the proceedings would have been different if the evidence had been disclosed.
+ <br>A conviction on the ground of insufficient evidence will be reversed only if, after viewing the evidence and all reasonable inferences in the light most favorable to the verdict, no rational factfinder could have found the defendant guilty beyond a reasonable doubt.
+ <br><a href="/court/opinions/20060369.htm"> State v. Washington</a>, 2007 ND 138
+ <br>The probable cause standard is the same for both searches and arrests.
+ <br>Once a vehicle has been validly stopped and its occupants lawfully detained, law enforcement officers may constitutionally order the driver and passengers out of the vehicle, even in situations not amounting to arrest.
+ <br>Law enforcement officers have the right to use appropriate forcible means to effectuate an arrest.
+ <br>An officer's subjective intent plays no role in ordinary probable cause Fourth Amendment analysis.
+ <br><a href="/court/opinions/20070055.htm"> Stephenson v. Hoeven</a>, 2007 ND 136
+ <br>Statutes are construed as a whole to give meaning, if possible, to every word, phrase, and sentence.
+ <br>An administrative agency may adopt specific rules of procedure when necessary to comply with requirements outside the administrative agencies practice act or when necessary to comply with the requirements of federal law.
+ <br><br><font size="+1">August 16, 2007</font><br><br><a href="/court/opinions/20070226.htm"> Disciplinary Board v. Light</a>, 2007 ND 129
+ <br>Interim suspension of lawyer ordered.<br><br><font size="+1">August 15, 2007</font>
+ <br><br><a href="/court/opinions/20070038.htm"> Riemers v. State</a>, 2007 ND App 3 - Court of Appeals
+ <br>Factual assertions in a brief do not raise an issue of material fact satisfying Rule 56(e) for purposes of resisting a motion for summary judgment.
+ <br>A party asserting a constitutional claim must do more than submit bare assertions and must bring up the heavy artillery or forego the claim.
+ <br><br>
+ <script language="JavaScript" src="/js/footer.js"></script>
+ </body>
+ </html> 

--- a/tests/examples/opinions/united_states/ndctapp_example_3.html
+++ b/tests/examples/opinions/united_states/ndctapp_example_3.html
@@ -1,0 +1,103 @@
+ <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+ <html lang="en">
+ <head>
+     <title>August 2007</title>
+ </head>
+ <meta name="Description" content="North Dakota Supreme Court Opinions by month">
+ <script language="JavaScript" src="/js/opinions.js"></script>
+ <link rel="stylesheet" type="text/css" href="/ndsct.css">
+ <body>
+ <script language="JavaScript" src="/js/header.js"></script>
+ <br>
+ <center>
+     <font size="+2" color="Navy">August 2007</font>
+ </center>
+ <br><font size="+1">August 30, 2007</font>
+ <br><br>
+ <a href="/court/opinions/20060321.htm"> Lee v. Lee</a>, 2007 ND 147
+ <br>A trial court has subject matter jurisdiction to order a party to pay spousal support beyond the party's original spousal support obligation, even when the original obligation has already ended, when reconsideration of an interrelated child support obligation could constitute a change in circumstances for purposes of the spousal support obligation.
+ <br>A change in a child support obligation may constitute a material change in circumstances requiring reconsideration of an interrelated spousal support obligation.
+ <br>Attorney's fees will not be awarded absent a showing of need or a showing that an appeal was frivolous.
+ <br><a href="/court/opinions/20060356.htm"> Peterson v. Dakota Molding, Inc.</a>, 2007 ND 144
+ <br>In a garnishment proceeding, where a garnishee denies liability, the plaintiff may move the court for leave to file a supplemental complaint making the garnishee a party to the action, and setting forth the facts upon which the plaintiff claims to charge the garnishee. If probable cause is shown, the motion shall be granted.
+ <br>The question whether probable cause has been shown, so as to require leave to file a supplemental complaint making a garnishee a party to an action, depends on whether the evidence shows probable grounds for believing that the garnishee might be held liable.
+ <br>A term in an insurance policy should be construed to mean what a reasonable person in the position of the insured would think it meant. Limitations or exclusions from broad coverage must be clear and explicit. When the language of an insurance policy is clear and explicit, the language should not be strained in order to impose liability on the insurer.
+ <br><a href="/court/opinions/20070015.htm"> State v. Demars</a>, 2007 ND 145
+ <br>Denial of a motion to suppress evidence will not be reversed if there is sufficient competent evidence capable of supporting the court's findings, and if its decision is not contrary to the manifest weight of the evidence.
+ <br><a href="/court/opinions/20060377.htm"> State v. Kunze</a>, 2007 ND 143
+ <br>When a trial court concludes it is necessary to physically restrain a defendant at trial in front of the jury, the court must consider less restrictive, less prejudicial methods of restraint.
+ <br>To provide for meaningful appellate review, a trial court must articulate its reasons for placing the defendant in physical restraints on the record, including a discussion of less prejudicial alternatives.
+ <br><a href="/court/opinions/20060274.htm"> State v. Tibor</a>, 2007 ND 146
+ <br>A court does not abuse its discretion in allowing expert testimony about child sexual abuse accommodation syndrome if it finds the testimony may assist the jury in understanding the evidence or determine a fact in issue.
+ <br>Mere repetition of a child's out-of-court statements does not make them unduly prejudicial.<br>A conviction rests upon insufficient evidence only when, after reviewing the evidence in the light most favorable to the prosecution and giving the prosecution the benefit of all inferences reasonably to be drawn in its favor, no rational fact-finder could find the defendant guilty beyond a reasonable doubt.
+ <br><br><font size="+1">August 27, 2007</font>
+ <br><br><a href="/court/opinions/20060320.htm"> Tedford v. Workforce Safety and Insurance</a>, 2007 ND 142
+ <br>The retirement offset provision, N.D.C.C. 65-05-09.2, authorizing offset of social security retirement benefits against workers compensation disability benefits, does not apply to injured employees who were receiving benefits for a total disability prior to the statute's effective date.
+ <br>In determining whether an administrative agency acted without substantial justification, triggering an award of actual attorney fees and costs under N.D.C.C. 28-32-50(1), the fact that a judge at an earlier stage of the proceedings agreed with the agency's position is persuasive evidence that the position was substantially justified.
+ <br><br><font size="+1">August 24, 2007</font><br><br><a href="/court/opinions/20060308.htm"> Superior, Inc. v. Behlen Mfg.</a>, 2007 ND 141
+ <br>A contractual right to indemnification may be implied based on the special nature of the relationship between the parties, or when there are unique factors demonstrating that the parties intended the would-be indemnitor to bear the ultimate responsibility for a certain matter.
+ <br>Implied contractual indemnity is an equitable remedy that is available only if a party does not have an adequate remedy at law.
+ <br>Under the Uniform Commercial Code, a buyer may seek consequential damages from the seller when it incurs liability to a third party as a result of the use or resale of the seller's product.
+ <br><br><font size="+1">August 22, 2007</font><br><br><a href="/court/opinions/20060218.htm"> Burns v. Burns</a>, 2007 ND 134
+ <br>A continuance is the proper remedy for a party claiming surprise, and a judgment will not ordinarily be reversed on appeal for surprise when no request is made for a continuance at the time and there is no showing of inability to meet the situation.
+ <br>If evidence of domestic violence does not rise to the level to trigger the presumption against an award of custody, the court may still consider the evidence as one of the best interest factors.
+ <br>A district court's concerns about maintaining the custodial relationship that existed prior to the divorce and allowing the child to attend the same school and live in the same house are all valid considerations under N.D.C.C. 14-09-06.2(1)(d).
+ <br>Being a child's primary caretaker does not guaranty a custody award in a divorce action.<br><a href="/court/opinions/20070043.htm"> City of Fargo v. Malme</a>, 2007 ND 137
+ <br>Cities are creatures of statute and possess only those powers and authorities granted by statute or necessarily implied from an express statutory grant.
+ <br>Home rule charters allow cities to enact laws contrary to those of the state.
+ <br>The supersession provision in N.D.C.C. 40-05.1-05 applies only to those powers enumerated in N.D.C.C. 40-05.1-06, and those powers must also be included in the home rule charter and be implemented by ordinance.
+ <br>The rule of strict construction applies in defining municipal powers, and any doubt as to the existence or extent of municipal powers must be resolved against the municipality.
+ <br><a href="/court/opinions/20060380.htm"> Estate of Allmaras</a>, 2007 ND 130
+ <br>A conservator has discretionary authority to manage the protected person's estate, subject to the conservator's fiduciary responsibilities and taking into account any known estate plan of the protected person.
+ <br>A payable-on-death beneficiary has no present interest in the account, no right to prevent the depositor from removing the account funds and effectively destroying the beneficiary designation, and no right to preclude the depositor from changing or removing the beneficiaries on the account.
+ <br><a href="/court/opinions/20060303.htm"> Farmers Union Mut. Ins. Co. v. Assoc. Electric and Gas Ins. Services Ltd.</a>, 2007 ND 135
+ <br>Statutory interpretation is a question of law and fully reviewable on appeal.
+ <br>Words in a statute are given their plain, ordinary, and commonly understood meaning, unless defined by statute or unless a contrary intention plainly appears.
+ <br>Statutes are construed as a whole and are harmonized to give meaning to related provisions.
+ <br>If the language of a statute is clear and unambiguous, the letter of the statute cannot be disregarded under the pretext of pursuing its spirit.
+ <br>Under N.D.C.C. 26.1-41-17, which permits a basic no-fault insurer to seek equitable allocation and intercompany arbitration for no-fault benefits paid, "the motor vehicle liability insurer of a secured person" does not include an excess liability insurer.
+ <br><a href="/court/opinions/20060359.htm"> Graner v. Graner</a>, 2007 ND 139
+ <br>A district court's decision on a custodial parent's motion to relocate out-of-state will be reversed on appeal only if it is clearly erroneous.
+ <br>Increased visitation expenses and distance are not a sufficient basis to deny a custodial parent's motion to relocate.
+ <br>A court may not modify custody within two years of an order establishing custody, unless the court finds the modification is in the child's best interests and there is willful denial of visitation, the child's environment endangers the child's physical or emotional health or impairs the child's emotional development, or the noncustodial parent has had primary physical care of the child for longer than six months.
+ <br><a href="/court/opinions/20070004.htm"> J.P. v. Stark County Social Services</a>, 2007 ND 140
+ <br>When a medicaid recipient receives out-of-state medical care without prior approval when there is no emergency, payment may be covered only if there was good cause for not first securing approval, the care and services were not available in state, and the care and services were medically necessary.
+ <br><a href="/court/opinions/20070063.htm"> Riemers v. State</a>, 2007 ND App 4 - Court of Appeals
+ <br>A judgment of dismissal for failure to state a claim upon which relief can be granted will be affirmed by an appellate court if it cannot discern a potential for proof to support the claim.
+ <br>Under N.D.R.Civ.P. 12(c), if, on a motion for judgment on the pleadings, matters outside the pleadings are presented to and not excluded by the court, the motion must be treated as one for summary judgment under N.D.R.Civ.P. 56.
+ <br>The court, in deciding a motion for judgment on the pleadings, may consider, in addition to the pleadings, materials embraced by the pleadings and materials that are part of the public record without converting the motion to a summary judgment.
+ <br><a href="/court/opinions/20060329.htm"> State v. Kautzman</a>, 2007 ND 133
+ <br>A mistrial must be declared before the trial is over and before the jury has been discharged. When defense counsel moves for a mistrial, an instruction to the jury must be requested to properly preserve the question for appellate review.
+ <br>A judgment of acquittal may be entered only if the evidence is insufficient to sustain a conviction.
+ <br>For an offense to be a lesser included offense, it must be impossible to commit the greater offense without committing the lesser.
+ <br>If counsel does not object to the trial court's instructions, the issue is not adequately preserved and inquiry on appeal is limited to whether the court's failure to instruct the jury was obvious error affecting substantial rights.
+ <br>A party may not challenge as error a ruling or other trial proceeding invited by that party.
+ <br>A trial court has broad discretion when deciding evidentiary matters, and its admission or exclusion of evidence will not be overturned on appeal unless that discretion has been abused.
+ <br><a href="/court/opinions/20060340.htm"> State v. Muhle</a>, 2007 ND 131
+ <br>A court's evaluation of the trustworthiness of a child's out-of-court statement about alleged sexual abuse, may include these non-exclusive factors: (1) the spontaneity and consistent repetition of the statements, (2) the mental state of the declarant, (3) the use of terminology unexpected of a child of similar age, and (4) a lack of motive to fabricate.
+ <br>If a defendant has an opportunity to cross-examine a witness at trial, the admission of testimonial statements would not violate the Confrontation Clause.
+ <br>The proper remedy for unfair surprise is a continuance, but one must be requested.
+ <br>The term "statement," as used in N.D.R.Crim.P. 16(f), means a written or otherwise recorded statement made by the witness, codefendant, or other person.
+ <br><a href="/court/opinions/20060328.htm"> State v. Muhle</a>, 2007 ND 132
+ <br>A district court's evidentiary ruling is reviewed for an abuse of discretion.
+ <br>Out-of-court testimonial statements may not be admitted into evidence when the child is unavailable to testify unless the defendant has had an opportunity to cross-examine the child. If a defendant has an opportunity to cross-examine the witness at trial, the admission of testimonial statements would not violate the Confrontation Clause.
+ <br>Rule 16 of the North Dakota Rules of Criminal Procedure requires only "statements" be disclosed by the prosecution. "Statement" is defined technically and emphasizes formal, written, or recorded declarations.
+ <br>To establish a violation under <u>Brady v. Maryland</u>, the defendant must prove: (1) the government possessed evidence favorable to the defendant; (2) the defendant did not possess the evidence and could not have obtained it with reasonable diligence; (3) the prosecution suppressed the evidence; and (4) a reasonable probability exists that the outcome of the proceedings would have been different if the evidence had been disclosed.
+ <br>A conviction on the ground of insufficient evidence will be reversed only if, after viewing the evidence and all reasonable inferences in the light most favorable to the verdict, no rational factfinder could have found the defendant guilty beyond a reasonable doubt.
+ <br><a href="/court/opinions/20060369.htm"> State v. Washington</a>, 2007 ND 138
+ <br>The probable cause standard is the same for both searches and arrests.
+ <br>Once a vehicle has been validly stopped and its occupants lawfully detained, law enforcement officers may constitutionally order the driver and passengers out of the vehicle, even in situations not amounting to arrest.
+ <br>Law enforcement officers have the right to use appropriate forcible means to effectuate an arrest.
+ <br>An officer's subjective intent plays no role in ordinary probable cause Fourth Amendment analysis.
+ <br><a href="/court/opinions/20070055.htm"> Stephenson v. Hoeven</a>, 2007 ND 136
+ <br>Statutes are construed as a whole to give meaning, if possible, to every word, phrase, and sentence.
+ <br>An administrative agency may adopt specific rules of procedure when necessary to comply with requirements outside the administrative agencies practice act or when necessary to comply with the requirements of federal law.
+ <br><br><font size="+1">August 16, 2007</font><br><br><a href="/court/opinions/20070226.htm"> Disciplinary Board v. Light</a>, 2007 ND 129
+ <br>Interim suspension of lawyer ordered.<br><br><font size="+1">August 15, 2007</font>
+ <br><br><a href="/court/opinions/20070038.htm"> Riemers v. State</a>, 2007 ND App 3 - Court of Appeals
+ <br>Factual assertions in a brief do not raise an issue of material fact satisfying Rule 56(e) for purposes of resisting a motion for summary judgment.
+ <br>A party asserting a constitutional claim must do more than submit bare assertions and must bring up the heavy artillery or forego the claim.
+ <br><br>
+ <script language="JavaScript" src="/js/footer.js"></script>
+ </body>
+ </html> 


### PR DESCRIPTION
The changes here do not present the most efficient approach to scraping the nd court page, as the new logic rebuilds the entire page's case data map for each of the standard getter methods.  However, the resource page never has that many results, and this new logic is still snappy/quick enough (no human noticable difference on my machine).  Ultimately, I think it makes the two scrapers' code more intelligible, simple, and a bit less repetitive.  Also, before this change, the nd.py scrapper was failing on the Aug2007 resource page (the most recent resource page to have an Appeal case posted).  That issue is fixed in this commit, and I've included the Aug2007 html as a test resource for both scrapers so that future changes must maintain their ability to scrape that page (assuming the whole format of the site doesn't change, in which case the old examples will be replaced with new examples).