### PR TITLE
Fixing idahoctapp_criminal by way of idaho_civil

### DIFF
--- a/opinions/united_states/state/idaho_civil.py
+++ b/opinions/united_states/state/idaho_civil.py
@@ -8,64 +8,54 @@ History:
    page.
  - 2015-10-20, mlr: Updated due to new page in use.
  - 2015-10-23, mlr: Updated to handle annoying situation.
+ - 2016-02-25 arderyp: Updated to catch "ORDER" (in addition to "Order") in download url text
 """
 
-from juriscraper.OpinionSite import OpinionSite
 from lxml import html
 
-from datetime import datetime
+from juriscraper.OpinionSite import OpinionSite
+from juriscraper.lib.string_utils import convert_date_string
 
 
 class Site(OpinionSite):
+    # Skip first row of table, it's a header
+    starting_table_row = '//table//tr[position() > 1]'
+
     def __init__(self, *args, **kwargs):
         super(Site, self).__init__(*args, **kwargs)
         self.url = 'http://www.isc.idaho.gov/appeals-court/isc_civil'
         self.court_id = self.__module__
 
     def _get_case_names(self):
-        path = '//table//tr[position() > 1]/td[3]'
         case_names = []
-        for e in self.html.xpath(path):
-            s = html.tostring(e, method='text', encoding='unicode').strip()
-            if s.strip():
-                case_names.append(s)
+        path = '%s/td[3]' % self.starting_table_row
+        for cell in self.html.xpath(path):
+            name_string = html.tostring(cell, method='text', encoding='unicode').strip()
+            if name_string:
+                case_names.append(name_string)
         return case_names
 
     def _get_download_urls(self):
-        path = '//table//tr[position() > 1]/td[4]//' \
+        path = self.starting_table_row + '/td[4]//' \
                '  a[contains(.//text(), "Opinion") or ' \
-               '    contains(.//text(), "Order")]/@href'
-        return [s for s in self.html.xpath(path)]
+               '    contains(.//text(), "Order") or ' \
+               '    contains(.//text(), "ORDER")]/@href'
+        return [url for url in self.html.xpath(path)]
 
     def _get_case_dates(self):
-        path = '//table//tr[position() > 1]/td[1]'
         case_dates = []
-        for e in self.html.xpath(path):
-            s = html.tostring(e, method='text', encoding='unicode').strip()
-            if not s:
-                # No content. Press on."
-                continue
-            s = s.replace('Sept', 'Sep')  # GIGO!
-            date_formats = ['%B %d, %Y',
-                            '%B %d %Y',
-                            '%b %d, %Y',
-                            '%b %d %Y']
-            for date_format in date_formats:
-                try:
-                    case_date = datetime.strptime(s, date_format).date()
-                    break
-                except ValueError:
-                    continue
-            case_dates.append(case_date)
+        path = '%s/td[1]' % self.starting_table_row
+        for cell in self.html.xpath(path):
+            date_string = html.tostring(cell, method='text', encoding='unicode').strip()
+            if date_string:
+                date_string = date_string.encode('ascii', 'ignore')
+                date_string = date_string.replace('Sept ', 'Sep ')  # GIGO!  (+1 by arderyp)
+                case_dates.append(convert_date_string(date_string))
         return case_dates
 
     def _get_docket_numbers(self):
-        path = '//table//tr[position() > 1]/td[2]//text()'
-        docket_numbers = []
-        for s in self.html.xpath(path):
-            if s.strip():
-                docket_numbers.append(s)
-        return docket_numbers
+        path = '%s/td[2]//text()' % self.starting_table_row
+        return [text.strip() for text in self.html.xpath(path) if text.strip()]
 
     def _get_precedential_statuses(self):
         return ["Published"] * len(self.case_names)

--- a/tests/examples/opinions/united_states/idahoctapp_criminal_example_2.html
+++ b/tests/examples/opinions/united_states/idahoctapp_criminal_example_2.html
@@ -1,0 +1,1731 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN"
+  "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" version="XHTML+RDFa 1.0" dir="ltr"
+  xmlns:content="http://purl.org/rss/1.0/modules/content/"
+  xmlns:dc="http://purl.org/dc/terms/"
+  xmlns:foaf="http://xmlns.com/foaf/0.1/"
+  xmlns:og="http://ogp.me/ns#"
+  xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+  xmlns:sioc="http://rdfs.org/sioc/ns#"
+  xmlns:sioct="http://rdfs.org/sioc/types#"
+  xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+  xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+
+<head profile="http://www.w3.org/1999/xhtml/vocab">
+  <meta charset="utf-8" />
+<link rel="shortcut icon" href="http://www.isc.idaho.gov/sites/all/themes/appeals/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+<link rel="canonical" href="/appeals-court/coa_criminal" />
+<meta name="Generator" content="Drupal 7 (http://drupal.org)" />
+<link rel="shortlink" href="/node/1802" />
+  <title>Idaho Court of Appeals Criminal Opinions | Supreme Court</title>
+  <style type="text/css" media="all">
+@import url("http://www.isc.idaho.gov/modules/system/system.base.css?o345r4");
+@import url("http://www.isc.idaho.gov/modules/system/system.menus.css?o345r4");
+@import url("http://www.isc.idaho.gov/modules/system/system.messages.css?o345r4");
+@import url("http://www.isc.idaho.gov/modules/system/system.theme.css?o345r4");
+</style>
+<style type="text/css" media="all">
+@import url("http://www.isc.idaho.gov/modules/aggregator/aggregator.css?o345r4");
+@import url("http://www.isc.idaho.gov/modules/comment/comment.css?o345r4");
+@import url("http://www.isc.idaho.gov/sites/all/modules/date/date_api/date.css?o345r4");
+@import url("http://www.isc.idaho.gov/sites/all/modules/date/date_popup/themes/datepicker.1.7.css?o345r4");
+@import url("http://www.isc.idaho.gov/modules/field/theme/field.css?o345r4");
+@import url("http://www.isc.idaho.gov/modules/node/node.css?o345r4");
+@import url("http://www.isc.idaho.gov/modules/search/search.css?o345r4");
+@import url("http://www.isc.idaho.gov/modules/user/user.css?o345r4");
+@import url("http://www.isc.idaho.gov/sites/all/modules/views/css/views.css?o345r4");
+</style>
+<style type="text/css" media="all">
+@import url("http://www.isc.idaho.gov/sites/all/modules/ctools/css/ctools.css?o345r4");
+@import url("http://www.isc.idaho.gov/sites/all/modules/print/css/printlinks.css?o345r4");
+@import url("http://www.isc.idaho.gov/sites/all/libraries/superfish/css/superfish.css?o345r4");
+@import url("http://www.isc.idaho.gov/sites/all/libraries/superfish/style/default.css?o345r4");
+</style>
+<style type="text/css" media="all">
+@import url("http://www.isc.idaho.gov/sites/all/themes/appeals/styles/bootstrap.css?o345r4");
+@import url("http://www.isc.idaho.gov/sites/all/themes/appeals/styles/style.css?o345r4");
+@import url("http://www.isc.idaho.gov/sites/all/themes/appeals/styles/local.css?o345r4");
+</style>
+  <script type="text/javascript" src="http://www.isc.idaho.gov/sites/all/modules/jquery_update/replace/jquery/1.10/jquery.min.js?v=1.10.2"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.migrateMute=true;jQuery.migrateTrace=false;
+//--><!]]>
+</script>
+<script type="text/javascript" src="http://www.isc.idaho.gov/sites/all/modules/jquery_update/replace/jquery-migrate/1.2.1/jquery-migrate.min.js?v=1.2.1"></script>
+<script type="text/javascript" src="http://www.isc.idaho.gov/misc/jquery.once.js?v=1.2"></script>
+<script type="text/javascript" src="http://www.isc.idaho.gov/misc/drupal.js?o345r4"></script>
+<script type="text/javascript" src="http://www.isc.idaho.gov/sites/all/libraries/superfish/jquery.hoverIntent.minified.js?o345r4"></script>
+<script type="text/javascript" src="http://www.isc.idaho.gov/sites/all/libraries/superfish/sfsmallscreen.js?o345r4"></script>
+<script type="text/javascript" src="http://www.isc.idaho.gov/sites/all/libraries/superfish/superfish.js?o345r4"></script>
+<script type="text/javascript" src="http://www.isc.idaho.gov/sites/all/libraries/superfish/supersubs.js?o345r4"></script>
+<script type="text/javascript" src="http://www.isc.idaho.gov/sites/all/modules/superfish/superfish.js?o345r4"></script>
+<script type="text/javascript" src="http://www.isc.idaho.gov/sites/all/themes/appeals/js/bootstrap.js?o345r4"></script>
+<script type="text/javascript">
+<!--//--><![CDATA[//><!--
+jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","ajaxPageState":{"theme":"appeals","theme_token":"2x4XrFm2fqE68m-5MvEGuXS7a3y4J3GT27mCkq0nXrI","js":{"sites\/all\/modules\/jquery_update\/replace\/jquery\/1.10\/jquery.min.js":1,"0":1,"sites\/all\/modules\/jquery_update\/replace\/jquery-migrate\/1.2.1\/jquery-migrate.min.js":1,"misc\/jquery.once.js":1,"misc\/drupal.js":1,"sites\/all\/libraries\/superfish\/jquery.hoverIntent.minified.js":1,"sites\/all\/libraries\/superfish\/sfsmallscreen.js":1,"sites\/all\/libraries\/superfish\/superfish.js":1,"sites\/all\/libraries\/superfish\/supersubs.js":1,"sites\/all\/modules\/superfish\/superfish.js":1,"sites\/all\/themes\/appeals\/js\/bootstrap.js":1},"css":{"modules\/system\/system.base.css":1,"modules\/system\/system.menus.css":1,"modules\/system\/system.messages.css":1,"modules\/system\/system.theme.css":1,"modules\/aggregator\/aggregator.css":1,"modules\/comment\/comment.css":1,"sites\/all\/modules\/date\/date_api\/date.css":1,"sites\/all\/modules\/date\/date_popup\/themes\/datepicker.1.7.css":1,"modules\/field\/theme\/field.css":1,"modules\/node\/node.css":1,"modules\/search\/search.css":1,"modules\/user\/user.css":1,"sites\/all\/modules\/views\/css\/views.css":1,"sites\/all\/modules\/ctools\/css\/ctools.css":1,"sites\/all\/modules\/print\/css\/printlinks.css":1,"sites\/all\/libraries\/superfish\/css\/superfish.css":1,"sites\/all\/libraries\/superfish\/style\/default.css":1,"sites\/all\/themes\/appeals\/styles\/bootstrap.css":1,"sites\/all\/themes\/appeals\/styles\/style.css":1,"sites\/all\/themes\/appeals\/styles\/local.css":1}},"urlIsAjaxTrusted":{"\/appeals-court\/coa_criminal":true},"superfish":{"3":{"id":"3","sf":{"delay":"200","animation":{"opacity":"show"},"speed":"\u0027fast\u0027","autoArrows":true,"dropShadows":true,"disableHI":false},"plugins":{"smallscreen":{"mode":"window_width","breakpoint":985,"addSelected":false,"menuClasses":false,"hyperlinkClasses":false,"title":"Supreme Court Appeals Main Menu"},"supposition":false,"bgiframe":false,"supersubs":{"minWidth":"10","maxWidth":"30","extraWidth":1}}}}});
+//--><!]]>
+</script>
+</head>
+<body class="html not-front not-logged-in no-sidebars page-node page-node- page-node-1802 node-type-page" >
+  <div id="skip-link">
+    <a href="#main-content" class="element-invisible element-focusable">Skip to main content</a>
+  </div>
+    <script type="text/javascript">
+    jQuery.noConflict();
+
+    jQuery(document).ready(function() {
+        jQuery('ul#accordion_related a.heading').click(function() {
+            jQuery(this).css('outline','none');
+            if(jQuery(this).parent().hasClass('current')) {
+                jQuery(this).siblings('ul').slideUp('slow',function() {
+                    jQuery(this).parent().removeClass('current');
+                });
+            } else {
+                jQuery('ul#accordion_related li.current ul').slideUp('slow',function() {
+                    jQuery(this).parent().removeClass('current');
+                });
+                jQuery(this).siblings('ul').slideToggle('slow',function() {
+                    jQuery(this).parent().toggleClass('current');
+                });
+            }
+            return false;
+        });
+    });
+
+</script>
+<div class="top-menu clearfix">
+
+        <div class="topmenuInner">
+        <!-- >>>>>>>> REMOVE THIS IF YOU WANT TO GET RID OF TOP LINKS (RSS, LOGIN, REGISTER | PROFILE) start-->
+        <div class="searchbox-region hidden-xs" >  <div class="region region-searchbox-region">
+      <div class="block block-search clearfix" id="block-search-form">
+       <div class="content clearfix"><form action="/appeals-court/coa_criminal" method="post" id="search-block-form" accept-charset="UTF-8"><div><div class="container-inline">
+      <h2 class="element-invisible">Search form</h2>
+    <div class="form-item form-type-textfield form-item-search-block-form">
+  <label class="element-invisible" for="edit-search-block-form--2">Search </label>
+ <input title="Enter the terms you wish to search for." type="text" id="edit-search-block-form--2" name="search_block_form" value="" size="15" maxlength="128" class="form-text" />
+</div>
+<div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Search" class="form-submit" /></div><input type="hidden" name="form_build_id" value="form-O4E3hljcN9qg-NawaTCWjkCDnTMrsksLuj0BDFKrbIY" />
+<input type="hidden" name="form_id" value="search_block_form" />
+</div>
+</div></form></div>
+ </div>
+  </div>
+</div>        <!-- >>>>>>>> REMOVE THIS IF YOU WANT TO GET RID OF TOP LINKS (RSS, LOGIN, REGISTER | PROFILE) start-->
+
+        <div id="top-links">
+            <ul class="top-links-ul">
+
+                                <li><a href="/">Supreme Court Home</a>&nbsp;&nbsp;|</li>
+                <!--<li><a href="#">Sitemap</a>&nbsp;&nbsp;|</li>-->
+                <li><a href="http://www.idaho.gov/">State of Idaho</a>&nbsp;&nbsp;|</li>
+                <li><a href="https://idcourts.perfectsoftware.net/ess/site/IDCourts/default.aspx" target="_blank">ESS</a></li>
+            </ul>
+        </div>
+    </div>
+   <!-- <<<<<<<< REMOVE THIS IF YOU WANT TO GET RID OF TOP LINKS (RSS, LOGIN, REGISTER) end -->
+
+</div>
+
+<!--  make-it-center -->
+<div class="make-it-center">
+    <!-- logo-container -->
+    <div id="logo-container">
+        <div id="money-bg" class="clearfix">
+            <div id="logo">
+
+                                    <div id="logo-picture">
+                        <a href="/" title="Home"><img src="http://www.isc.idaho.gov/sites/all/themes/appeals/logo.png" alt="Home" /></a>
+                    </div>
+
+            </div>
+            <div id="heading">
+            	<h1>
+					<a href="/" title="Home">
+						<span class="heading-sm">STATE OF IDAHO JUDICIAL BRANCH</span><br />
+						<span class="heading-md">Supreme Court Appeals</span>
+					</a>
+				</h1>
+            </div>
+
+			<div id="toggle" class="toggle visible-xs">
+			  <button type="button" class="search-toggle" data-toggle="collapse" data-target="#search-collapse-1">
+				  <span class="sr-only">Toggle search</span>
+				  <span class="glyphicon glyphicon-search"></span>
+			  </button>
+			</div>
+        </div>
+    </div>
+    <!-- /logo-container -->
+
+
+    <!-- primary menu -->
+
+    <div class="rws-primary-menu clearfix">
+          <div class="region region-primary-menu">
+      <div class="block block-superfish clearfix" id="block-superfish-3">
+   <h2 class="title">Appeals (Menu)</h2>    <div class="content clearfix"><ul id="superfish-3" class="menu sf-menu sf-menu-main-menu-supreme sf-horizontal sf-style-default sf-total-items-6 sf-parent-items-2 sf-single-items-4"><li id="menu-752-3" class="first odd sf-item-1 sf-depth-1 sf-total-children-4 sf-parent-children-0 sf-single-children-4 menuparent"><a href="/appeals-court/handbook" title="" class="sf-depth-1 menuparent">Pro Se Appellate Information</a><ul><li id="menu-787-3" class="first odd sf-item-1 sf-depth-2 sf-no-children"><a href="/appeals-court/handbook" class="sf-depth-2">Appellate Handbook</a></li><li id="menu-788-3" class="middle even sf-item-2 sf-depth-2 sf-no-children"><a href="/appeals-court/checkists" class="sf-depth-2">Deadlines, Fees, Checklists</a></li><li id="menu-789-3" class="middle odd sf-item-3 sf-depth-2 sf-no-children"><a href="/appeals-court/faqs" class="sf-depth-2">FAQs</a></li><li id="menu-790-3" class="last even sf-item-4 sf-depth-2 sf-no-children"><a href="/appeals-court/glossary" class="sf-depth-2">Glossary</a></li></ul></li><li id="menu-753-3" class="middle even sf-item-2 sf-depth-1 sf-no-children"><a href="/appeals-court/isc-calendar" class="sf-depth-1">Supreme Court Calendar</a></li><li id="menu-754-3" class="middle odd sf-item-3 sf-depth-1 sf-no-children"><a href="/appeals-court/coa-calendar" class="sf-depth-1">Court of Appeals Calendar</a></li><li id="menu-755-3" class="active-trail middle even sf-item-4 sf-depth-1 sf-total-children-6 sf-parent-children-0 sf-single-children-6 menuparent"><a href="/appeals-court/opinions" title="" class="sf-depth-1 menuparent">Opinions &amp; Hearings</a><ul><li id="menu-791-3" class="first odd sf-item-1 sf-depth-2 sf-no-children"><a href="/appeals-court/isc_civil" class="sf-depth-2">Supreme Court Civil Opinions</a></li><li id="menu-792-3" class="middle even sf-item-2 sf-depth-2 sf-no-children"><a href="/appeals-court/isc_criminal" class="sf-depth-2">Supreme Court Criminal Opinions</a></li><li id="menu-793-3" class="middle odd sf-item-3 sf-depth-2 sf-no-children"><a href="/appeals-court/coa_civil" class="sf-depth-2">Court of Appeals Civil Opinions</a></li><li id="menu-794-3" class="active-trail middle even sf-item-4 sf-depth-2 sf-no-children"><a href="/appeals-court/coa_criminal" class="sf-depth-2 active">Court of Appeals Criminal &amp; PC Opinions</a></li><li id="menu-795-3" class="middle odd sf-item-5 sf-depth-2 sf-no-children"><a href="/appeals-court/coaunpublished" class="sf-depth-2">Court of Appeals Unpublished Opinions</a></li><li id="menu-1078-3" class="last even sf-item-6 sf-depth-2 sf-no-children"><a href="/appeals-court/archive" class="sf-depth-2">ISC Hearings Video Archive</a></li></ul></li><li id="menu-756-3" class="middle odd sf-item-5 sf-depth-1 sf-no-children"><a href="/appeals-court/links" class="sf-depth-1">Links Of Interest</a></li><li id="menu-757-3" class="last even sf-item-6 sf-depth-1 sf-no-children"><a href="/appeals-court/transcript-reports" class="sf-depth-1">Filings &amp; Transcript Reports</a></li></ul></div>
+ </div>
+  </div>
+    </div>
+    <!--  /primary menu -->
+
+
+	<div class="contentWrap">
+				<!-- responsive search -->
+		<div class="search-row">
+			<div class="visible-xs">
+			  <div id="search-collapse-1" class="collapse">
+				<div class="searchbox-region">  <div class="region region-searchbox-region">
+      <div class="region region-searchbox-region">
+      <div class="block block-search clearfix" id="block-search-form">
+       <div class="content clearfix"><form action="/appeals-court/coa_criminal" method="post" id="search-block-form" accept-charset="UTF-8"><div><div class="container-inline">
+      <h2 class="element-invisible">Search form</h2>
+    <div class="form-item form-type-textfield form-item-search-block-form">
+  <label class="element-invisible" for="edit-search-block-form--2">Search </label>
+ <input title="Enter the terms you wish to search for." type="text" id="edit-search-block-form--2" name="search_block_form" value="" size="15" maxlength="128" class="form-text" />
+</div>
+<div class="form-actions form-wrapper" id="edit-actions"><input type="submit" id="edit-submit" name="op" value="Search" class="form-submit" /></div><input type="hidden" name="form_build_id" value="form-O4E3hljcN9qg-NawaTCWjkCDnTMrsksLuj0BDFKrbIY" />
+<input type="hidden" name="form_id" value="search_block_form" />
+</div>
+</div></form></div>
+ </div>
+  </div>
+  </div>
+</div>
+			  </div>
+			</div>
+		</div>
+		<!-- end responsive search -->
+						<!-- column-2 -->
+		<div class="column-2
+			  no-right-and-left-columns
+			  			  ">
+
+
+
+			<!-- PRINTING BLOCKS BEFORE THE CONTENT (with RED headers) -->
+						<!-- PRINTING BLOCKS BEFORE THE CONTENT (with RED headers) -->
+
+
+
+
+
+
+
+
+
+
+
+
+
+			<!-- main-content-block --><div class="main-content-block">
+				  <div class="node node-page " about="/appeals-court/coa_criminal" typeof="foaf:Document">
+    <?/*php if ($picture) {
+      print $picture;
+    }*/?>
+
+
+
+
+    <div class="content clearfix">
+    <span class="print-link"></span><div class="field field-name-body field-type-text-with-summary field-label-hidden"><div class="field-items"><div class="field-item even" property="content:encoded"><div class="left-content">
+<h2>Court of Appeals - Criminal-Post Conviction Opinions</h2>
+<p style="text-align: left;"><span style="line-height: 1.53em;">The Idaho Supreme Court and Idaho Court of Appeals cited opinions are made available online as a public service. All cited opinions are posted the day of their release. West Publishing Company publishes all cited opinions in the Pacific Reporter and Idaho Reports volumes. All cited opinions are removed from this site one-year upon release.</span></p>
+<p><span style="line-height: 1.53em;">NOTICE: These opinions are subject to formal revision before publication in the preliminary print of the Pacific Reporter. Readers are requested to notify the Clerk of the Court/Reporter of Decisions, Supreme Court of Idaho, Boise, Idaho, 83720-0101, of any typographical or other formal errors, in order that corrections may be made before the preliminary print goes to press.</span></p>
+<h3><span style="color: rgb(0, 51, 102); line-height: 1.53em;">By Release Date</span><span style="line-height: 1.53em; font-size: 13px; font-weight: normal;"> </span></h3>
+<ul><li>
+<ul><li>
+<table style="width: 100%;" border="1" cellspacing="5" cellpadding="5" align="left"><tbody><tr><td style="width: 15%;"><strong>Release Date</strong></td>
+<td style="height: 40px; text-align: center;"><strong>Docket#</strong></td>
+<td style="height: 40px; text-align: center;"><strong>Case Name</strong></td>
+<td style="height: 40px; text-align: center;"><strong>Opinion</strong></td>
+<td style="width: 25%;"><strong>Notes</strong></td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Feb 25, 2016</span></p>
+</td>
+<td style="height: 40px;">42572</td>
+<td style="height: 40px;">State v. Conner Blaine Hoy</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42572.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42780.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42506.pdf"></a><a href="http://www.isc.idaho.gov/opinions/43123.pdf"></a><a href="http://www.isc.idaho.gov/opinions/43092.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42806.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p> Robbery &amp; aggravated assault</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Feb 25, 2016</span></p>
+</td>
+<td style="height: 40px;">42806</td>
+<td style="height: 40px;">State v. Brian Ellis Neal</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42806.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42780.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42506.pdf"></a><a href="http://www.isc.idaho.gov/opinions/43123.pdf"></a><a href="http://www.isc.idaho.gov/opinions/43092.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42554.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p>The State appeals from judgment granting motion to suppress.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Feb 23, 2016</span></p>
+</td>
+<td style="height: 40px;">43077</td>
+<td style="height: 40px;">State v. James W. Clark</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/43077.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42780.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42506.pdf"></a><a href="http://www.isc.idaho.gov/opinions/43123.pdf"></a><a href="http://www.isc.idaho.gov/opinions/43092.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p> Misdemeanor trespass</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Feb 18, 2016 </span></p>
+</td>
+<td style="height: 40px;">42554</td>
+<td style="height: 40px;">State v. Vernon Craig Pelland</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42554.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42780.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42506.pdf"></a><a href="http://www.isc.idaho.gov/opinions/43123.pdf"></a><a href="http://www.isc.idaho.gov/opinions/43092.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p> Grand theft by possession</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Feb 16, 2016</span></p>
+</td>
+<td style="height: 40px;">43092</td>
+<td style="height: 40px;">State v. Anthony Kyle Smith</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/43092.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42780.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42506.pdf"></a><a href="http://www.isc.idaho.gov/opinions/43123.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p>Appeal from order denying motion to suppress.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Feb 12, 2016</span></p>
+</td>
+<td style="height: 40px;">43123</td>
+<td style="height: 40px;">State v. Michael P. Martin</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/43123.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42780.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42506.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p>Appeal from order denying motion for credit for time served.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Feb 10, 2016 </span></p>
+</td>
+<td style="height: 40px;">42506</td>
+<td style="height: 40px;">Joshua McGiboney v. State</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42506.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42780.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p>POST-CONVICTION Robbery, aggravated battery, burglary, possession of a firearm</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Feb 10, 2016 </span></p>
+</td>
+<td style="height: 40px;">43263</td>
+<td style="height: 40px;">State v. Kevin Donald Cheatham</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42780.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/43263.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p>Appeal from order denying motion to amend judgment (grand theft by possession of stolen property)</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Feb 1, 2016</span></p>
+</td>
+<td style="height: 40px;">42090</td>
+<td style="height: 40px;">State v. Laura Lee Smith</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42780.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42090SUB.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p>SUBSTITUTE:  Aiding and abetting in the delivery of a controlled substance.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Jan 27, 2016</span></p>
+</td>
+<td style="height: 40px;">42780</td>
+<td style="height: 40px;">Alik G. Takhsilov v. State</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42780.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p>POST-CONVICTION Robbery; burglary</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Jan 27, 2016 </span></p>
+</td>
+<td style="height: 40px;">42769</td>
+<td style="height: 40px;">State v. Dennis James Garner</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42769.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p> Battery on a correctional officer</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Jan 14, 2016</span></p>
+</td>
+<td style="height: 40px;">43055</td>
+<td style="height: 40px;">State v. John Scott Meier</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/43055.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p>Appeal from denial of Rule 35 Motion Re sentence for possession of sexually exploitative material</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Jan 8, 2016 </span></p>
+</td>
+<td style="height: 40px;">42321</td>
+<td style="height: 40px;">State v. John Patrick Linze, Jr.</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42321.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42637.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p>Appeal from denial of motion to suppress</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Jan 7, 2016</span></p>
+</td>
+<td style="height: 40px;">42637</td>
+<td style="height: 40px;">State v. Natasha Lynn Bly</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42637.pdf">Opinion</a></p>
+</td>
+<td style="width: 25%;">
+<p>Appeal from denial of motion to suppress</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Jan 6, 2016</span></p>
+</td>
+<td style="height: 40px;">42790</td>
+<td style="height: 40px;">State v. Lori Elizabeth Lovely</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42790X.pdf">Opinion</a></p>
+</td>
+<td style="width: 25%;">
+<p>Appeal from denial of motion to suppress</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Dec 31, 2015</span></p>
+</td>
+<td style="height: 40px;">43388</td>
+<td style="height: 40px;">State v. James Butler Ramsey</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/43388.pdf">Opinion</a></p>
+</td>
+<td style="width: 25%;">
+<p>Appeal from Order denying Rule 35 Motion to correct illegal sentence for robbery, grand theft and aggravated assault.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Dec 31, 2015</span></p>
+</td>
+<td style="height: 40px;">42362</td>
+<td style="height: 40px;">State v. Jose Antonio Ruiz</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42848.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42362.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41730.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42498.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p>Lewd conduct with a minor; sexual abuse of a child</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Dec 31, 2015</span></p>
+</td>
+<td style="height: 40px;">41834</td>
+<td style="height: 40px;">Tyrell Ramsey v. State</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42848.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41834SUB.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41730.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42498.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p>SUBSTITUTE OPINION.  POST-CONVICTION (rape and battery)</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Dec 23, 2015 </span></p>
+</td>
+<td style="height: 40px;">42848</td>
+<td style="height: 40px;">State v. Brian W. Pierce</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42848.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41730.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42498.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p>State appeals district court vacating judgment of conviction for violating a domestic violence protection order.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Dec 15, 2015 </span></p>
+</td>
+<td style="height: 40px;">42340</td>
+<td style="height: 40px;">Gary W. Mallory, II v. State</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42340.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41730.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42498.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p> POST-CONVICTION (murder)</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Dec 10, 2015 </span></p>
+</td>
+<td style="height: 40px;">42436</td>
+<td style="height: 40px;">State v. Emil Mercado</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42498.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42436.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41730.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p> Lewd conduct with a minor.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Dec 9, 2015 </span></p>
+</td>
+<td style="height: 40px;">42363</td>
+<td style="height: 40px;">State v. Keith L. Case</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42498.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42363.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41730.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p> Motion to suppress</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Dec 8, 2015</span></p>
+</td>
+<td style="height: 40px;">42335</td>
+<td style="height: 40px;">State v. Scott Lewis Ostler</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42498.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42335.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41730.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p>Lewd conduct with a minor.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Dec 4, 2015</span></p>
+</td>
+<td style="height: 40px;">41916</td>
+<td style="height: 40px;">State v. William Dee Van Komen, Jr.</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42498.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41916.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41730.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p>Appeal from order relinquishing jurisdiction; possession of a controlled substance.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Dec 4, 2015</span></p>
+</td>
+<td style="height: 40px;">42098</td>
+<td style="height: 40px;">State v. Marcos Apollo Jimenez</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42098X.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41730.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42498.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p> Sexual battery of a minor</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Nov 20, 2015</span></p>
+</td>
+<td style="height: 40px;">42498</td>
+<td style="height: 40px;">Mitchell James Bias v. State</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42498.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41730.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p>POST-CONVICTION: Conspiracy to commit robbery and burglary.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Nov 17, 2015 </span></p>
+</td>
+<td style="height: 40px;">41730</td>
+<td style="height: 40px;">State v. Arnold Dean Anderson</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/41730.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p>Possession of controlled substance; denial of motion to suppress and denial of Rule 35 motion to reduce sentence.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Nov 10, 2015</span></p>
+</td>
+<td style="height: 40px;">42680</td>
+<td style="height: 40px;">State v. Thomas C. Kelley</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42680.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42095.pdf"> </a></p>
+</td>
+<td style="width: 25%;">
+<p> Trafficking - marijuana</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Nov 6, 2015</span></p>
+</td>
+<td style="height: 40px;">42655</td>
+<td style="height: 40px;">State v. Michel J. Walker</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42095.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42655.pdf">Opinion</a></p>
+</td>
+<td style="width: 25%;">
+<p>Appeal from order granting State's motion to reconsider reduction of sentence.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Nov 4, 2015</span></p>
+</td>
+<td style="height: 40px;">42749</td>
+<td style="height: 40px;">State v. Jacob Steven Davis</td>
+<td style="height: 40px;">
+<p><a href="http://www.isc.idaho.gov/opinions/42095.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42749.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41740.pdf"></a></p>
+</td>
+<td style="width: 25%;">
+<p> Motion to suppress.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Nov 4, 2015</span></p>
+</td>
+<td style="height: 40px;">42799</td>
+<td style="height: 40px;">State v. Rey Alfredo Ornelas</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42095.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42799.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41740.pdf"></a></td>
+<td style="width: 25%;">
+<p>Appeal from the decision denying Batson challenge.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Nov 3, 2015</span></p>
+</td>
+<td style="height: 40px;">42870</td>
+<td style="height: 40px;">State v. Nicholas Tate Vance</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42095.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42870.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41740.pdf"></a></td>
+<td style="width: 25%;">
+<p> Burglary</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Nov 2, 2015</span></p>
+</td>
+<td style="height: 40px;">42095</td>
+<td style="height: 40px;">Wally Kay Schultz v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42095X.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41740.pdf"></a></td>
+<td style="width: 25%;">
+<p> POST-CONVICTION (battery)</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Oct 30, 2015</span></p>
+</td>
+<td style="height: 40px;">42636</td>
+<td style="height: 40px;">State v. Wayne Ray Floyd</td>
+<td style="height: 40px;"> <a href="http://www.isc.idaho.gov/opinions/42636.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41740.pdf"> </a></td>
+<td style="width: 25%;">
+<p> Possession of controlled substance; motion to suppress</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Oct 29, 2015</span></p>
+</td>
+<td style="height: 40px;">42532</td>
+<td style="height: 40px;">State v. Michael Brian Wilson</td>
+<td style="height: 40px;"><a style="text-decoration: underline;" href="http://www.isc.idaho.gov/opinions/42532X.pdf">Opinion</a></td>
+<td style="width: 25%;">
+<p>aggravated assault with intent to promote gang activity</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">Oct 21, 2015</span></p>
+</td>
+<td style="height: 40px;">40916</td>
+<td style="height: 40px;">State v. Robert Dean Hall</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40916.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41740.pdf"> </a></td>
+<td style="width: 25%;">
+<p>Second-degree murder </p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Oct 20, 2015</span></p>
+</td>
+<td style="height: 40px;">42525</td>
+<td style="height: 40px;">State v. Joseph R. Rockstahl</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41740.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41740.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42525.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"></a></td>
+<td style="width: 25%;">
+<p> Disturbing the peace; exhibiting a deadly weapon</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Oct 14, 2015</span></p>
+</td>
+<td style="height: 40px;">40999</td>
+<td style="height: 40px;">State v. Doris Nepa Hays</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41740.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/40999.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"></a></td>
+<td style="width: 25%;">
+<p>State appeals district court order granting motion to suppress.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Oct 7, 2015</span></p>
+</td>
+<td style="height: 40px;">42242</td>
+<td style="height: 40px;">Christopher A. Pentico v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41740.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42242.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"></a></td>
+<td style="width: 25%;">
+<p> POST-CONVICTION (tresspass)</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Oct 2, 2015</span></p>
+</td>
+<td style="height: 40px;">42155</td>
+<td style="height: 40px;">State v. Juan Roberto Jimenez</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41740.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42155.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"></a></td>
+<td style="width: 25%;">
+<p> Aggravated battery</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Oct 1, 2015</span></p>
+</td>
+<td style="height: 40px;">41740</td>
+<td style="height: 40px;">Peter Trejo Mora v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41740.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42198.pdf"> </a></td>
+<td style="width: 25%;">
+<p> POST-CONVICTION (rape)</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Sept 24, 2015</span></p>
+</td>
+<td style="height: 40px;">42682</td>
+<td style="height: 40px;">Jonna Lynn Bobeck v. Transportation</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42198.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42682.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"> </a></td>
+<td style="width: 25%;">
+<p> Driver's license suspension</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Sept 16, 2015</span></p>
+</td>
+<td style="height: 40px;">42198</td>
+<td style="height: 40px;">State v. Jose Luis Villavicencio</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42198X.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42691.pdf"> </a></td>
+<td style="width: 25%;">
+<p>State appeals amended judgment modifying probation terms. </p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Sept 8, 2015</span></p>
+</td>
+<td style="height: 40px;">42691</td>
+<td style="height: 40px;">State v. Jon Steven Huffaker</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42691.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42090.pdf"> </a></td>
+<td style="width: 25%;">
+<p>State appeals order suppressing oral and written statements. </p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> Sept 3, 2015</span></p>
+</td>
+<td style="height: 40px;">42447</td>
+<td style="height: 40px;">State v. Stephen P. Rozajewski</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42090.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42447X.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"></a></td>
+<td style="width: 25%;">
+<p> Unlawful possession of a firearm.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> August 26, 2015</span></p>
+</td>
+<td style="height: 40px;">42097</td>
+<td style="height: 40px;">State v. Freddie Anthony Naranjo</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42097.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42277.pdf"> </a></td>
+<td style="width: 25%;">
+<p> Motion to suppress.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> August 24, 2015</span></p>
+</td>
+<td style="height: 40px;">41942</td>
+<td style="height: 40px;">Cullen R. Sims v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42277.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41942.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"></a></td>
+<td style="width: 25%;">
+<p>Appeal from dismissal of motion to suppress blood test results.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">August 17, 2015</span></p>
+</td>
+<td style="height: 40px;">42277</td>
+<td style="height: 40px;">State v. Kerry Allen Howell</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42277.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42787.pdf"> </a></td>
+<td style="width: 25%;">
+<p> Burglary</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">August 14, 2015</span></p>
+</td>
+<td style="height: 40px;">42787</td>
+<td style="height: 40px;">State v. Scott Andrew Kinch</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42787.pdf">Opinion</a></td>
+<td style="width: 25%;">
+<p>Denial of Motion to Suppress</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">August 14, 2015</span></p>
+</td>
+<td style="height: 40px;">42153</td>
+<td style="height: 40px;">Richard Myers Caldwell V. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42153.pdf">Opinion</a></td>
+<td style="width: 25%;">
+<p>POST-CONVICTION.  Ineffective counsel</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> July 30, 2015</span></p>
+</td>
+<td style="height: 40px;">42699</td>
+<td style="height: 40px;">State v. Karlie Lynn Meyer</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42699.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41831.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41902.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42160.pdf"> </a></td>
+<td style="width: 25%;">
+<p>Possession of methamphetamine.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> July 22, 2015</span></p>
+</td>
+<td style="height: 40px;">42377</td>
+<td style="height: 40px;">State v. Joseph Alan Knight (OPINION VACATED. SEE ATTACHED ORDER)</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42160.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/43642ORDER.pdf">ORDER</a></td>
+<td style="width: 25%;">
+<p>Possession of controlled substance. </p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> July 21, 2015</span></p>
+</td>
+<td style="height: 40px;">42160</td>
+<td style="height: 40px;">Diego Peregrina v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42160.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41831.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41902.pdf"> </a></td>
+<td style="width: 25%;">
+<p>POST-CONVICTION.  Aggravated battery. </p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> July 17, 2015</span></p>
+</td>
+<td style="height: 40px;">41902</td>
+<td style="height: 40px;">State v. Shayne Ray Burgess</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41902.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41831.pdf"> </a></td>
+<td style="width: 25%;">
+<p> Aggravated assault.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> July 14, 2015</span></p>
+</td>
+<td style="height: 40px;">40767</td>
+<td style="height: 40px;">State v. Terry Lin Smith</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41831.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/40767.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a></td>
+<td style="width: 25%;">
+<p> Lewd conduct with minor under sixteen.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> July 9, 2015</span></p>
+</td>
+<td style="height: 40px;">42405</td>
+<td style="height: 40px;">State v. Scott Alan Moore</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41831.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42405.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a></td>
+<td style="width: 25%;">
+<p>Appeal from denial of motion to reduce felony to a misdemeanor.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> July 9, 2015</span></p>
+</td>
+<td style="height: 40px;">41671</td>
+<td style="height: 40px;">State v. Edward Ray Christensen</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41831.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41671.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a></td>
+<td style="width: 25%;">
+<p>Motion to suppress possession of controlled substance.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> July 7, 2015</span></p>
+</td>
+<td style="height: 40px;">42115</td>
+<td style="height: 40px;">State v. Robert Michael Williston</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41831.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42115.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a></td>
+<td style="width: 25%;">
+<p> Attempted strangulation.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> July 7, 2015</span></p>
+</td>
+<td style="height: 40px;">42022</td>
+<td style="height: 40px;">State v. Tristum Beeks, II</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41831.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42022.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a></td>
+<td style="width: 25%;">
+<p> No-contact order.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> July 6, 2015</span></p>
+</td>
+<td style="height: 40px;">41831</td>
+<td style="height: 40px;">State v. Ashli Marie Easterday</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41831.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a></td>
+<td style="width: 25%;">
+<p>Motion to suppress possession of controlled substance. </p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> June 24, 2015</span></p>
+</td>
+<td style="height: 40px;">42229</td>
+<td style="height: 40px;">State v. Jason Ephriam Rowland</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42229.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a></td>
+<td style="width: 25%;">
+<p>Motion to suppress possession of controlled substance.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> June 24, 2015</span></p>
+</td>
+<td style="height: 40px;">42420</td>
+<td style="height: 40px;">State v. Jacob Taylor Rainier</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42397.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42420X.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"></a></td>
+<td style="width: 25%;">
+<p> Possession of marijuana with intent to deliver.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> June 19, 2015</span></p>
+</td>
+<td style="height: 40px;">42397</td>
+<td style="height: 40px;">State v. Kurtis Thomas Kelly</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42397.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"> </a></td>
+<td style="width: 25%;">
+<p> Battery on a law enforcement officer</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> June 15, 2015</span></p>
+</td>
+<td style="height: 40px;">41661</td>
+<td style="height: 40px;">State v. Kenneth Randall Smith</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42169.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41661X.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a></td>
+<td style="width: 25%;">
+<p>Aggravated assault; aggravated battery; DUI; possession of methamphetamine.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">June 15, 2015</span></p>
+</td>
+<td style="height: 40px;">42070</td>
+<td style="height: 40px;">State v. Michael Douglas White</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42169.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42169.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/42070.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"></a></td>
+<td style="width: 25%;">
+<p> Appeal from order revoking probation</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">May 29, 2015</span></p>
+</td>
+<td style="height: 40px;">41981</td>
+<td style="height: 40px;">State v. Heather Lynn Heard</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42169.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41981.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"> </a></td>
+<td style="width: 25%;">
+<p>Appeal from denial of suppression motion</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> May 28, 2015</span></p>
+</td>
+<td style="height: 40px;">42169</td>
+<td style="height: 40px;">State v. Dona Nichoeal Westlake</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42169.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41995.pdf"> </a></td>
+<td style="width: 25%;">
+<p>State's appeal from order granting suppression motion</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;"> May 27, 2015</span></p>
+</td>
+<td style="height: 40px;">41995</td>
+<td style="height: 40px;">Juan Manuel Arellano v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41995.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41790.pdf"> </a></td>
+<td style="width: 25%;">
+<p> POST-CONVICTION - Ineffective assistance of defense counsel claim</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">May 22, 2015</span></p>
+</td>
+<td style="height: 40px;">41790</td>
+<td style="height: 40px;">State v. Russell Glenn Davis</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41790.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"> </a></td>
+<td style="width: 25%;">
+<p>Possession of controlled substance with intent to deliver.  </p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">May 19, 2015</span></p>
+</td>
+<td style="height: 40px;">41821-41822</td>
+<td style="height: 40px;">State v. Leroy S. Wilske</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41821.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"></a><a href="http://www.isc.idaho.gov/opinions/40759.pdf"> </a></td>
+<td style="width: 25%;">
+<p> DUI (alcohol); possession of controlled substance; possession of drug paraphernalia.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">May 15, 2015</span></p>
+</td>
+<td style="height: 40px;">40759</td>
+<td style="height: 40px;">State v. Justin Lee Wilson</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40759X.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"></a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"> </a></td>
+<td style="width: 25%;">
+<p> Appeal from denial of motions to exclude witness &amp; to continue trial. (DUI)</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">May 15, 2015</span></p>
+</td>
+<td style="height: 40px;">42103</td>
+<td style="height: 40px;">State v. Domingo Jesus Diaz</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42103SUB.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41677SUB.pdf"> </a></td>
+<td style="width: 25%;">
+<p> SUBSTITUTE OPINON - Battery and assault with the intent to commit rape. The Court's prior OPINION dated May 6, 2015 is WITHDRAWN.</p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">May 13, 2015 </span></p>
+</td>
+<td style="height: 40px;">41677</td>
+<td style="height: 40px;">Richard Joseph Wagner v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41677X.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"> </a></td>
+<td style="width: 25%;">
+<p>Lewd conduct with a child under 16.  The Court's prior UNPUBLISHED Opinion issued March 4, 2015 is WITHDRAWN. </p>
+</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">May 13, 2015</span></p>
+</td>
+<td style="height: 40px;">41675</td>
+<td style="height: 40px;">State v. Corey Steven Kubat</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41675.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/42103.pdf"> </a></td>
+<td style="width: 25%;">Possession of controlled substance</td>
+</tr><tr><td style="width: 15%;">
+<p><span style="line-height: 1.53em;">May 4, 2015</span></p>
+</td>
+<td style="height: 40px;">41549</td>
+<td style="height: 40px;">State v. John Joseph Fairchild</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41549.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/41063.pdf"></a></td>
+<td style="width: 25%;">Grand theft</td>
+</tr><tr><td style="width: 15%;">Apr 27, 2015</td>
+<td style="height: 40px;">41414</td>
+<td style="height: 40px;">Robert Terry Johnson v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41414.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/41063.pdf"> </a></td>
+<td style="width: 25%;">Post-Conviction. First-degree murder</td>
+</tr><tr><td style="width: 15%;">Apr 8, 2015</td>
+<td style="height: 40px;">41063</td>
+<td style="height: 40px;">State v. Brant Lee Eversole</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41063.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI; motion to suppress (warrantless blood draw)</td>
+</tr><tr><td style="width: 15%;">Apr 7, 2015</td>
+<td style="height: 40px;">41913</td>
+<td style="height: 40px;">State v. Wade Allen Tomlinson</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41913.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI  (breath alcohol test results)</td>
+</tr><tr><td style="width: 15%;">Apr 6, 2015</td>
+<td style="height: 40px;">42202</td>
+<td style="height: 40px;">State v. Jodie Marie Edwards</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42202X.pdf">Opinion</a></td>
+<td style="width: 25%;">Possession of a controlled substance</td>
+</tr><tr><td style="width: 15%;">Apr 2, 2015</td>
+<td style="height: 40px;">41603</td>
+<td style="height: 40px;">State v. Brian Neil Pratt</td>
+<td style="height: 40px;"><a style="text-decoration: underline;" href="http://www.isc.idaho.gov/opinions/41603.pdf">Opinion</a></td>
+<td style="width: 25%;">Delivery &amp; trafficking of a controlled substance</td>
+</tr><tr><td style="width: 15%;">Mar 30, 2015</td>
+<td style="height: 40px;">41497</td>
+<td style="height: 40px;">State v. Gerald K. Umphenour</td>
+<td style="height: 40px;"><a style="text-decoration: underline;" href="http://www.isc.idaho.gov/opinions/41497opinion.pdf">Opinion</a></td>
+<td style="width: 25%;">Possession - Methamphetamine</td>
+</tr><tr><td style="width: 15%;">Mar 13, 2015</td>
+<td style="height: 40px;">41824</td>
+<td style="height: 40px;">State v. Kelsey Rose Hopkins</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41539.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41824X.pdf">Opinion</a></td>
+<td style="width: 25%;">SUBSTITUTE OPINION - Malicious injury to property</td>
+</tr><tr><td style="width: 15%;">Feb 25, 2015</td>
+<td style="height: 40px;">41832</td>
+<td style="height: 40px;">State v. Victoria Bea Morin</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41539.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41832X.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/41539.pdf"></a></td>
+<td style="width: 25%;">Driving under the influence of drugs</td>
+</tr><tr><td style="width: 15%;">Feb 25, 2015</td>
+<td style="height: 40px;">41594</td>
+<td style="height: 40px;">State v. Angela Marie Boehm</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41539.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41594.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/41539.pdf"></a></td>
+<td style="width: 25%;">DUI without privileges</td>
+</tr><tr><td style="width: 15%;">Feb 18, 2015</td>
+<td style="height: 40px;">41933</td>
+<td style="height: 40px;">State v. Richard Glenn Morris</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41539.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/41933.pdf">Opinion</a><a href="http://www.isc.idaho.gov/opinions/41539.pdf"> </a></td>
+<td style="width: 25%;">Motion to suppress</td>
+</tr><tr><td style="width: 15%;">Feb 17, 2015</td>
+<td style="height: 40px;">40038</td>
+<td style="height: 40px;">State v. Matthew James Gonzales</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41539.pdf"> </a><a href="http://www.isc.idaho.gov/opinions/40038X.pdf">Opinion</a></td>
+<td style="width: 25%;">Motion to withdraw guilty plea - folony injury to a child</td>
+</tr><tr><td style="width: 15%;">Feb 13, 2015</td>
+<td style="height: 40px;">41539</td>
+<td style="height: 40px;">State v. Dwayne Allan Bradley</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41539.pdf">Opinion</a></td>
+<td style="width: 25%;">Trafficking - methamphetamine</td>
+</tr><tr><td style="width: 15%;">Feb 12, 2015</td>
+<td style="height: 40px;">41458</td>
+<td style="height: 40px;">State v. Dustin Thomas Armstrong</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41458.pdf">Opinion</a></td>
+<td style="width: 25%;">Motion to suppress</td>
+</tr><tr><td style="width: 15%;">Feb 11, 2015</td>
+<td style="height: 40px;">41890</td>
+<td style="height: 40px;">Haris Keserovic v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41890.pdf">Opinion</a></td>
+<td style="width: 25%;">Post-Conviction.  A plea of guilty to an aggravated felony resulted in deportation. State appeals from reversal of grant for summary dismissal of petition for PC relief</td>
+</tr><tr><td style="width: 15%;">Jan 15, 2015</td>
+<td style="height: 40px;">41288</td>
+<td style="height: 40px;">State v. Russell Allen Passons</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41288X.pdf">Opinion</a></td>
+<td style="width: 25%;">Aggravated assault &amp; burglary</td>
+</tr><tr><td style="width: 15%;">Jan 13, 2015</td>
+<td style="height: 40px;">41240</td>
+<td style="height: 40px;">Dennis Raymond Heilman v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41240.pdf">Opinion</a></td>
+<td style="width: 25%;">Appeal from summary dismissal of successive petition for post-conviction relief.  - Rape / aggravated assault</td>
+</tr><tr><td style="width: 15%;">Jan 8, 2015</td>
+<td style="height: 40px;">42024</td>
+<td style="height: 40px;">State v. Michelle Alece Mace</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/42024.pdf">Opinion</a></td>
+<td style="width: 25%;">Appeal from order rescinding credit for time served</td>
+</tr><tr><td style="width: 15%;">Dec 23, 2014</td>
+<td style="height: 40px;">41772/41773</td>
+<td style="height: 40px;">Tarango DeForest Padilla v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41772.pdf">Opinion</a></td>
+<td style="width: 25%;">Post-Conviction - Ineffective assistance</td>
+</tr><tr><td style="width: 15%;">Dec 19, 2014</td>
+<td style="height: 40px;">41462</td>
+<td style="height: 40px;">State v. Jonathan A. Collins</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41462.pdf">Opinion</a></td>
+<td style="width: 25%;">Lewd conduct with minor under sixteen</td>
+</tr><tr><td style="width: 15%;">Dec 19, 2014</td>
+<td style="height: 40px;">41236</td>
+<td style="height: 40px;">State v. James D. Kirk</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41236.pdf">Opinion</a></td>
+<td style="width: 25%;">Lewd conduct with minor under sixteen</td>
+</tr><tr><td style="width: 15%;">Dec 17, 2014</td>
+<td style="height: 40px;">41862</td>
+<td style="height: 40px;">State v. Murray Casey Carter</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41862.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI; felony eluding</td>
+</tr><tr><td style="width: 15%;">Dec 16, 2014</td>
+<td style="height: 40px;">41762</td>
+<td style="height: 40px;">State v. Gaylord Jay Colvin</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41762.pdf">Opinion</a></td>
+<td style="width: 25%;">State appeals from district court's reversal of magistrate's order denying motion to suppress</td>
+</tr><tr><td style="width: 15%;">Dec 10, 2014</td>
+<td style="height: 40px;">41997-41998</td>
+<td style="height: 40px;">State v. John Huey Daniels</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41997.pdf">Opinion</a></td>
+<td style="width: 25%;">State appeals from district court's dismissal of appeals in the decision to dismiss the complaint charging destruction of insured property</td>
+</tr><tr><td style="width: 15%;">Dec 4, 2014</td>
+<td style="height: 40px;">41892</td>
+<td style="height: 40px;">State v. Shepherd Reale</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41892.pdf">Opinion</a></td>
+<td style="width: 25%;">Sexual abuse of a child under sixteen; restitution order</td>
+</tr><tr><td style="width: 15%;">Dec 4, 2014</td>
+<td style="height: 40px;">41015</td>
+<td style="height: 40px;">State v. John M. Barber</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41015.pdf">Opinion</a></td>
+<td style="width: 25%;">Possession of marijuana</td>
+</tr><tr><td style="width: 15%;">Dec 3, 2014</td>
+<td style="height: 40px;">40855</td>
+<td style="height: 40px;">State v. Tami Marie Southwick</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40855.pdf">Opinion</a></td>
+<td style="width: 25%;">Possession of methamphetamine</td>
+</tr><tr><td style="width: 15%;">Dec 3, 2014</td>
+<td style="height: 40px;">40895</td>
+<td style="height: 40px;">State v. Kirk Julliard Gosch</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40895.pdf">Opinion</a></td>
+<td style="width: 25%;">Manufacturing of, possession of and intent to deliver marijuana</td>
+</tr><tr><td style="width: 15%;">Nov 25, 2014</td>
+<td style="height: 40px;">40733</td>
+<td style="height: 40px;">State v. Arthur Gene Schmierer</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40733.pdf">Opinion</a></td>
+<td style="width: 25%;">Enticing children over the internet</td>
+</tr><tr><td style="width: 15%;">Nov 20, 2014</td>
+<td style="height: 40px;">39622</td>
+<td style="height: 40px;">State v. Jonathan Earl Folk</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/39622X.pdf">Opinion</a></td>
+<td style="width: 25%;">Lewd conduct with child under sixteen</td>
+</tr><tr><td style="width: 15%;">Nov 12, 2014</td>
+<td style="height: 40px;">41173</td>
+<td style="height: 40px;">State v. Robert Louis Stevenson</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41173.pdf">Opinion</a></td>
+<td style="width: 25%;">Order denying motion for credit for time served</td>
+</tr><tr><td style="width: 15%;">Nov 6, 2014</td>
+<td style="height: 40px;">41221</td>
+<td style="height: 40px;">State v. Jay Alton Roach</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41221.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI - Order excluding expert testimony</td>
+</tr><tr><td style="width: 15%;">Nov 6, 2014</td>
+<td style="height: 40px;">40930</td>
+<td style="height: 40px;">State v. William Jack Bias</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40930.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI</td>
+</tr><tr><td style="width: 15%;">Nov 3, 2014</td>
+<td style="height: 40px;">40091</td>
+<td style="height: 40px;">State v. Richard Allen Larson</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40091X.pdf">Opinion</a></td>
+<td style="width: 25%;">SUBSTITUTE OPINION. Aggravated Assault.  Prior Opinion of 8/15/14 is WITHDRAWN.</td>
+</tr><tr><td style="width: 15%;">October 31, 2014</td>
+<td style="height: 40px;">41365</td>
+<td style="height: 40px;">State v. Jeffrey J. Hughes</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41365.pdf">Opinion</a></td>
+<td style="width: 25%;">State appeals dismissal of two felony counts - taking wildlife</td>
+</tr><tr><td style="width: 15%;">October 30, 2014</td>
+<td style="height: 40px;">41533</td>
+<td style="height: 40px;">State v. Junior Larry Hillbroom</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41533.pdf">Opinion</a></td>
+<td style="width: 25%;">No contact order</td>
+</tr><tr><td style="width: 15%;">October 22, 2014</td>
+<td style="height: 40px;">40915/41205</td>
+<td style="height: 40px;">State v. Aaron Louis Bitkoff</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40915.pdf">Opinion</a></td>
+<td style="width: 25%;">Credit for time served</td>
+</tr><tr><td style="width: 15%;">October 22, 2014</td>
+<td style="height: 40px;">40751</td>
+<td style="height: 40px;">Ernesto Garza Lopez</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40751.pdf">Opinion</a></td>
+<td style="width: 25%;">Post Conviction - Felony domestic batery</td>
+</tr><tr><td style="width: 15%;">October 22, 2014</td>
+<td style="height: 40px;">40824</td>
+<td style="height: 40px;">Michael Parvin v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40824.pdf">Opinion</a></td>
+<td style="width: 25%;">Post Conviction - Lewd conduct with a child under sixteen</td>
+</tr><tr><td style="width: 15%;">October 20, 2014</td>
+<td style="height: 40px;">41923</td>
+<td style="height: 40px;">State v. Christopher D. Griffith</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41923.pdf">Opinion</a></td>
+<td style="width: 25%;">Motion to correct illegal sentence - First Degree Murder</td>
+</tr><tr style="display: none;"><td style="width: 15%;"> </td>
+<td style="height: 40px;"> </td>
+<td style="height: 40px;"> </td>
+<td style="height: 40px;"> </td>
+<td style="width: 25%;"> </td>
+</tr><tr><td style="width: 15%;">October 15, 2014</td>
+<td style="height: 40px;">41534</td>
+<td style="height: 40px;">State v. Nathan David Neal</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41534.pdf">Opinion</a></td>
+<td style="width: 25%;">Order suppressing evidence</td>
+</tr><tr><td style="width: 15%;">October 10, 2014</td>
+<td style="height: 40px;">40769</td>
+<td style="height: 40px;">Larry Severson v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40769.pdf">Opinion</a></td>
+<td style="width: 25%;">First Degree Murder</td>
+</tr><tr><td style="width: 15%;">October 8, 2014</td>
+<td style="height: 40px;">41431</td>
+<td style="height: 40px;">State v. Justin Lee Pedersen</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41431.pdf">Opinion</a></td>
+<td style="width: 25%;">Motion to suppress</td>
+</tr><tr><td style="width: 15%;">October 8, 2014</td>
+<td style="height: 40px;">40661/40828</td>
+<td style="height: 40px;">Gregory Joseph Nelson v. State</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/40661.pdf">Opinion</a></td>
+<td style="width: 25%;">Kidnapping; lewd conduct with a minor</td>
+</tr><tr><td style="width: 15%;">October 8, 2014</td>
+<td style="height: 40px;">41241</td>
+<td style="height: 40px;">State v. Richard L. Beck</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41241.pdf">Opinion</a></td>
+<td style="width: 25%;">Motion to suppress</td>
+</tr><tr><td style="width: 15%;">October 2, 2014</td>
+<td style="height: 40px;">41535</td>
+<td style="height: 40px;">State v. Alfredo Lopez Rocha</td>
+<td style="height: 40px;"><a href="http://www.isc.idaho.gov/opinions/41535fix.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI</td>
+</tr><tr><td style="width: 15%;">Sept 29, 2014</td>
+<td style="height: 40px;">40682</td>
+<td style="height: 40px;">State v. Anthony Edward Ortega</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40682.pdf">Opinion</a></td>
+<td style="width: 25%;">Felony injury to a child</td>
+</tr><tr><td style="width: 15%;">Sept 24, 2014</td>
+<td style="height: 40px;">41541</td>
+<td style="height: 40px;">State v. Troy Cameron Young</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41541.pdf">Opinion</a></td>
+<td style="width: 25%;">Domestic battery in the presence of a child</td>
+</tr><tr><td style="width: 15%;">Sept 24, 2014</td>
+<td style="height: 40px;">41660</td>
+<td style="height: 40px;">State v. Jeffrey Alan Denny</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41660.pdf">Opinion</a></td>
+<td style="width: 25%;">Credit for time served</td>
+</tr><tr><td style="width: 15%;">Sept 24, 2014</td>
+<td style="height: 40px;">41046</td>
+<td style="height: 40px;">State v. Matthew O. Brooks</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41046.pdf">Opinion</a></td>
+<td style="width: 25%;">Possession of controlled substance</td>
+</tr><tr><td style="width: 15%;">Sept 24, 2014</td>
+<td style="height: 40px;">40662</td>
+<td style="height: 40px;">State v. Justin B. Miller</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40662X.pdf">Opinion</a></td>
+<td style="width: 25%;">Aggravated assault &amp; battery</td>
+</tr><tr><td style="width: 15%;">Sept 18, 2014</td>
+<td style="height: 40px;">41489</td>
+<td style="height: 40px;">State v. Big Dawg</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41489.pdf">Opinion</a></td>
+<td style="width: 25%;">Bail Bonds appeals partial exoneration</td>
+</tr><tr><td style="width: 15%;">Sept 8, 2014</td>
+<td style="height: 40px;">39745</td>
+<td style="height: 40px;">Daniel Lee Dixon v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39745.pdf">Opinion</a></td>
+<td style="width: 25%;">Post Conviction - Lewd conduct with a minor under sixteen</td>
+</tr><tr><td style="width: 15%;">Sept 2, 2014</td>
+<td style="height: 40px;">41358</td>
+<td style="height: 40px;">State v. Marvin Orellana-Castro</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/CASTRO.pdf">Opinion</a></td>
+<td style="width: 25%;">Lewd conduct and sexual abuse of a minor</td>
+</tr><tr><td style="width: 15%;">Sept 2, 2014</td>
+<td style="height: 40px;">41449</td>
+<td style="height: 40px;">Sean M. Cook v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/COOK.pdf">Opinion</a></td>
+<td style="width: 25%;">State appeals judgment granting Post Conviction relief</td>
+</tr><tr><td style="width: 15%;">Aug 22, 2014</td>
+<td style="height: 40px;">41114</td>
+<td style="height: 40px;">State v. Andrew Taylor</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41114.pdf">Opinion</a></td>
+<td style="width: 25%;">Possession - Meth</td>
+</tr><tr><td style="width: 15%;">Aug 22, 2014</td>
+<td style="height: 40px;">41147</td>
+<td style="height: 40px;">State v. Connor G. Spies</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41147.pdf">Opinion</a></td>
+<td style="width: 25%;">Motion to suppress - Possession</td>
+</tr><tr><td style="width: 15%;">Aug 22, 2014</td>
+<td style="height: 40px;">40777</td>
+<td style="height: 40px;">Popoca-Garcia v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40777SUB.pdf">Opinion</a></td>
+<td style="width: 25%;">Substitute Opinion - Appeal from denial of Post Conviction petition for relief from plea resulting in deportation.</td>
+</tr><tr><td style="width: 15%;">Aug 20, 2014</td>
+<td style="height: 40px;">39672</td>
+<td style="height: 40px;">State v. Gutierrez-Medina</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39672.pdf">Opinion</a></td>
+<td style="width: 25%;">Post Conviction - Delivery of controlled substance</td>
+</tr><tr><td style="width: 15%;">Aug 20, 2014</td>
+<td style="height: 40px;">41161</td>
+<td style="height: 40px;">State v. Doe (13-14)</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41161.pdf">Opinion</a></td>
+<td style="width: 25%;">Juvenile - Malicious injury to proerty</td>
+</tr><tr><td style="width: 15%;">Aug 13, 2014</td>
+<td style="height: 40px;">41499</td>
+<td style="height: 40px;">James Dee Olsen v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41499.pdf">Opinion</a></td>
+<td style="width: 25%;">Post Conviction - DUI</td>
+</tr><tr><td style="width: 15%;">Aug 12, 2014</td>
+<td style="height: 40px;">41378</td>
+<td style="height: 40px;">State v. Michael Jay Freitas</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41378.pdf">Opinion</a></td>
+<td style="width: 25%;">Transferring water in violation of city ordinance</td>
+</tr><tr><td style="width: 15%;">July 30, 2014</td>
+<td style="height: 40px;">40291</td>
+<td style="height: 40px;">State v. Benjamin Patrick Dugan</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40291.pdf">Opinion</a></td>
+<td style="width: 25%;">Injuring jails</td>
+</tr><tr><td style="width: 15%;">July 24, 2014</td>
+<td style="height: 40px;">39876</td>
+<td style="height: 40px;">State v. Rey Alfredo Ornelas</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39876.pdf">Opinion</a></td>
+<td style="width: 25%;">Lewd conduct with minor child</td>
+</tr><tr><td style="width: 15%;">July 24, 2014</td>
+<td style="height: 40px;">41428</td>
+<td style="height: 40px;">State v. Desiree B. Eliasen</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41428.pdf">Opinion</a></td>
+<td style="width: 25%;">Second degree stalking</td>
+</tr><tr><td style="width: 15%;">July 24, 2014</td>
+<td style="height: 40px;">40475</td>
+<td style="height: 40px;">State v. George Alan Kapelle</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40475SUB.pdf">Opinion</a></td>
+<td style="width: 25%;">
+<p>This is a Substitute Opinion.  Denial of motion to suppress</p>
+</td>
+</tr><tr><td style="width: 15%;">July 18, 2014</td>
+<td style="height: 40px;">40963</td>
+<td style="height: 40px;">Harvey L. Mahler v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/Mahlerfix.pdf">Opinion</a></td>
+<td style="width: 25%;">Post Conviction - Lewd conduct with a minor</td>
+</tr><tr><td style="width: 15%;">July 18, 2014</td>
+<td style="height: 40px;">41235</td>
+<td style="height: 40px;">Lee Edd Green, Jr. v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41235.pdf">Opinion</a></td>
+<td style="width: 25%;">Post Conviction - Lewd conduct with a minor</td>
+</tr><tr><td style="width: 15%;">July 10, 2014</td>
+<td style="height: 40px;">41402</td>
+<td style="height: 40px;">State v. Dennis Earl Hiebert</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41402.pdf">Opinion</a></td>
+<td style="width: 25%;">Possession of controlled substance</td>
+</tr><tr><td style="width: 15%;">July 10, 2014</td>
+<td style="height: 40px;">41165</td>
+<td style="height: 40px;">State v. Lloyd Hardin McNeil</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41165.pdf">Opinion</a></td>
+<td style="width: 25%;">Order of restitution</td>
+</tr><tr><td style="width: 15%;">July 9, 2014</td>
+<td style="height: 40px;">41270</td>
+<td style="height: 40px;">State v. Christopher T. Weaver</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41270.pdf">Opinion</a></td>
+<td style="width: 25%;">Order of restitution</td>
+</tr><tr><td style="width: 15%;">July 3, 2014</td>
+<td style="height: 40px;">41325</td>
+<td style="height: 40px;">State v. Heidi H. Swenson</td>
+<td style="height: 40px;"> -<a href="http://www.isc.idaho.gov/opinions/41325.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI-Administration of breath test</td>
+</tr><tr><td style="width: 15%;">July 2, 2014</td>
+<td style="height: 40px;">40924</td>
+<td style="height: 40px;">Marc Edward Klein v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40924fix2.pdf">Opinion</a></td>
+<td style="width: 25%;">Post Conviction - Vehicular manslaughter</td>
+</tr><tr><td style="width: 15%;">June 30, 2014</td>
+<td style="height: 40px;">39161</td>
+<td style="height: 40px;">State v. Arlyn V. Orr</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39161.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI</td>
+</tr><tr><td style="width: 15%;">June 13, 2014</td>
+<td style="height: 40px;">39847</td>
+<td style="height: 40px;">State v. Martin Edmo Ish</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39847PUB.pdf">Opinion</a></td>
+<td style="width: 25%;">Controlled Sub.</td>
+</tr><tr><td style="width: 15%;">May 30, 2014</td>
+<td style="height: 40px;">40720</td>
+<td style="height: 40px;">State v. Shawn O'Shay Davis, II</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40720opinion.pdf">Opinion</a></td>
+<td style="width: 25%;">Grand Theft</td>
+</tr><tr><td style="width: 15%;">May 23, 2014</td>
+<td style="height: 40px;">41168</td>
+<td style="height: 40px;">State v. Johnson</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41168.pdf.pdf">Opinion</a></td>
+<td style="width: 25%;">State's Appeal of Acquittal</td>
+</tr><tr><td style="width: 15%;">May 22, 2014</td>
+<td style="height: 40px;">40419</td>
+<td style="height: 40px;">State v. Allen Keith Clontz</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40419.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI</td>
+</tr><tr><td style="width: 15%;">May 20, 2014</td>
+<td style="height: 40px;">41158</td>
+<td style="height: 40px;">State v. Jose Perez-Jungo</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41158.pdf">Opinion</a></td>
+<td style="width: 25%;">Controlled Sub.</td>
+</tr><tr><td style="width: 15%;">May 19, 2014</td>
+<td style="height: 40px;">40941</td>
+<td style="height: 40px;">State v. Kenny Struhs</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40941.pdf">Opinion</a></td>
+<td style="width: 25%;">Vehicular Manslaughter</td>
+</tr><tr><td style="width: 15%;">May 12, 2014</td>
+<td style="height: 40px;">40696</td>
+<td style="height: 40px;">State v. Allen</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40696.pdf">Opinion</a></td>
+<td style="width: 25%;">Motions for Relief and to Seal</td>
+</tr><tr><td style="width: 15%;">May 12, 2014</td>
+<td style="height: 40px;">40175</td>
+<td style="height: 40px;">State v. Ruggiero</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/RuggSUB.pdf">Opinion</a></td>
+<td style="width: 25%;">State Appeals Dismissal SUB</td>
+</tr><tr><td style="width: 15%;">May 7, 2014</td>
+<td style="height: 40px;">41212</td>
+<td style="height: 40px;">State v. Stephen D. L'Abbe</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/41212fix.pdf">Opinion</a></td>
+<td style="width: 25%;">Speeding</td>
+</tr><tr><td style="width: 15%;">May 6, 2014</td>
+<td style="height: 40px;">40950</td>
+<td style="height: 40px;">State v. Mark C. Hunter</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40950.pdf">Opinion</a></td>
+<td style="width: 25%;">Motion to Suppress - DUI</td>
+</tr><tr><td style="width: 15%;">Apr 30, 2014</td>
+<td style="height: 40px;">40026 </td>
+<td style="height: 40px;">State v. Hamlin </td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40026.pdf">Opinion</a></td>
+<td style="width: 25%;"> Sexual Abuse - Vulnerable</td>
+</tr><tr><td style="width: 15%;">Apr 25, 2014</td>
+<td style="height: 40px;">39207</td>
+<td style="height: 40px;">Woodrow Grant v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39207.pdf">Opinion</a></td>
+<td style="width: 25%;">Post Conviction - Battery</td>
+</tr><tr><td style="width: 15%;">Apr 22, 2014</td>
+<td style="height: 40px;">39684</td>
+<td style="height: 40px;">State v. Frank D. Marks</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39684.pdf">Opinion</a></td>
+<td style="width: 25%;">Lewd Conduct</td>
+</tr><tr><td style="width: 15%;">Apr 18, 2014</td>
+<td style="height: 40px;">40985</td>
+<td style="height: 40px;">State v. Kevin Michael Nicolescu</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40985.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI</td>
+</tr><tr><td style="width: 15%;">Apr 17, 2014</td>
+<td style="height: 40px;">40423</td>
+<td style="height: 40px;">State v. Santos Tena</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40423.pdf">Opinion</a></td>
+<td style="width: 25%;">Controlled Sub.</td>
+</tr><tr><td style="width: 15%;">Apr 1, 2014</td>
+<td style="height: 40px;">40995</td>
+<td style="height: 40px;">State v. Nikolas Sherman</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40995.pdf">Opinion</a></td>
+<td style="width: 25%;">Controlled Sub.</td>
+</tr><tr><td style="width: 15%;">Mar 28, 2014</td>
+<td style="height: 40px;">40222 </td>
+<td style="height: 40px;"> State v. Wayne D. Anderson</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40222.pdf">Opinion</a></td>
+<td style="width: 25%;"> Lewd Conduct</td>
+</tr><tr><td style="width: 15%;">Mar 27, 2014</td>
+<td style="height: 40px;">39547</td>
+<td style="height: 40px;">Miguel C. Joyner v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39547.pdf">Opinion</a></td>
+<td style="width: 25%;">No Contact (PC)</td>
+</tr><tr><td style="width: 15%;">Mar 26, 2014</td>
+<td style="height: 40px;">39529</td>
+<td style="height: 40px;">State v. Valentin Calvillo</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39529.pdf">Opinion</a></td>
+<td style="width: 25%;">Lewd Conduct</td>
+</tr><tr><td style="width: 15%;">Mar 26, 2014</td>
+<td style="height: 40px;">40811</td>
+<td style="height: 40px;">Cecil G. Daniels v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40811.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI</td>
+</tr><tr><td style="width: 15%;">Mar 25, 2014</td>
+<td style="height: 40px;">40544</td>
+<td style="height: 40px;">State v. Robert Javier Garcia, Jr.</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40544.pdf">Opinion</a></td>
+<td style="width: 25%;"> </td>
+</tr><tr><td style="width: 15%;">Mar 17, 2014</td>
+<td style="height: 40px;">40471/40472</td>
+<td style="height: 40px;">Kent Hall v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40471.2.pdf">Opinion</a></td>
+<td style="width: 25%;">Post-Conviction - Possession</td>
+</tr><tr><td style="width: 15%;">Mar 10, 2014</td>
+<td style="height: 40px;">40506</td>
+<td style="height: 40px;">State v. Jacob M. Torrez</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40506.pdf">Opinion</a></td>
+<td style="width: 25%;">Aggravated DUI</td>
+</tr><tr><td style="width: 15%;">Feb 28, 2014  </td>
+<td style="height: 40px;">40223/40224  </td>
+<td style="height: 40px;">  State v. Rafael Galvan</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40223.pdf">Opinion</a></td>
+<td style="width: 25%;">  Stalking</td>
+</tr><tr><td style="width: 15%;">Feb 28, 2014 </td>
+<td style="height: 40px;">40718 </td>
+<td style="height: 40px;"> State v. Gregory Scott McAmis</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40718.pdf">Opinion</a></td>
+<td style="width: 25%;"> Grand Theft</td>
+</tr><tr><td style="width: 15%;">Feb 24, 2014 </td>
+<td style="height: 40px;"> 38123</td>
+<td style="height: 40px;">State v. Timothy Nichols </td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/38123.pdf.pdf">Opinion</a></td>
+<td style="width: 25%;">Statutory Rape </td>
+</tr><tr><td style="width: 15%;">Feb 21, 2014 </td>
+<td style="height: 40px;"> 40289</td>
+<td style="height: 40px;">State v. Derek Edward Moad </td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40289.pdf">Opinion</a></td>
+<td style="width: 25%;"> Male Rape</td>
+</tr><tr><td style="width: 15%;">Feb 20, 2014</td>
+<td style="height: 40px;">40503</td>
+<td style="height: 40px;">State v. Pierre J. Saviers</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40503.pdf">Opinion</a></td>
+<td style="width: 25%;">No-Contact</td>
+</tr><tr><td style="width: 15%;">Feb 11, 2014</td>
+<td style="height: 40px;">40416</td>
+<td style="height: 40px;">State v. Bryce S. Mendel</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40416.pdf">Opinion</a></td>
+<td style="width: 25%;">Controlled Sub</td>
+</tr><tr><td style="width: 15%;">Feb 11, 2014</td>
+<td style="height: 40px;">40428</td>
+<td style="height: 40px;">State v. Morgan C. Alley</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40428.pdf">Opinion</a></td>
+<td style="width: 25%;">Controlled Sub</td>
+</tr><tr><td style="width: 15%;">Feb 10, 2014</td>
+<td style="height: 40px;">40241</td>
+<td style="height: 40px;">State v. Rhonda Trusdall</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40241.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI</td>
+</tr><tr><td style="width: 15%;">Feb 10, 2014</td>
+<td style="height: 40px;">39933</td>
+<td style="height: 40px;">State v. Brandon Eddins</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39933.pdf">Opinion</a></td>
+<td style="width: 25%;">Assault</td>
+</tr><tr><td style="width: 15%;">Feb 5, 2014</td>
+<td style="height: 40px;">40673</td>
+<td style="height: 40px;">State v. Albert Ray Moore</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/Moore.pdf">Opinion</a></td>
+<td style="width: 25%;">Credit for Time Served</td>
+</tr><tr><td style="width: 15%;">Feb 4, 2014</td>
+<td style="height: 40px;">39811</td>
+<td style="height: 40px;">State v. Martin C. Cardoza</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39811FIX.pdf">Opinion</a></td>
+<td style="width: 25%;">Trafficking</td>
+</tr><tr><td style="width: 15%;">Feb 4, 2014</td>
+<td style="height: 40px;">39255/40628</td>
+<td style="height: 40px;">State v. Lee Odell Fair</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39255.pdf">Opinion</a></td>
+<td style="width: 25%;">Assault</td>
+</tr><tr><td style="width: 15%;">  Jan 24, 2014</td>
+<td style="height: 40px;"> 40616 </td>
+<td style="height: 40px;">  State v. Charles A. Vaughn, Jr.</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40616.pdf">Opinion</a></td>
+<td style="width: 25%;">No Contact  </td>
+</tr><tr><td style="width: 15%;">Jan 17, 2014 </td>
+<td style="height: 40px;"> 39219</td>
+<td style="height: 40px;"> State v. Kristi L. Hurles</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/HURLES011714.pdf">Opinion</a></td>
+<td style="width: 25%;"> Grand Theft</td>
+</tr><tr><td style="width: 15%;">Jan 10, 2014 </td>
+<td style="height: 40px;"> 40477</td>
+<td style="height: 40px;"> State v. Teddy Edghill</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/Edgehill%20Substitute.pdf">Opinion</a></td>
+<td style="width: 25%;">[SUBSTITUTE] </td>
+</tr><tr><td style="width: 15%;">Jan 10, 2014 </td>
+<td style="height: 40px;"> 40634</td>
+<td style="height: 40px;"> State v. Jacob Jerome Buck</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40634.pdf">Opinion</a></td>
+<td style="width: 25%;"> Possession</td>
+</tr><tr><td style="width: 15%;">Jan 6, 2014</td>
+<td style="height: 40px;">40359</td>
+<td style="height: 40px;">State v. Joseph Thomas Iverson</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40359.pdf">Opinion</a></td>
+<td style="width: 25%;">Battery</td>
+</tr><tr><td style="width: 15%;">Dec 30, 2013 </td>
+<td style="height: 40px;">39426/39427</td>
+<td style="height: 40px;">State v. Chase Dalton Gillespie </td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/gillespieFix.pdf">Opinion</a></td>
+<td style="width: 25%;"> Sexually Exploitative</td>
+</tr><tr><td style="width: 15%;">Dec 30, 2013</td>
+<td style="height: 40px;">40353</td>
+<td style="height: 40px;">Wally Kay Schultz v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40353.pdf">Opinion</a></td>
+<td style="width: 25%;">Post-Conviction</td>
+</tr><tr><td style="width: 15%;">Dec 23, 2013</td>
+<td style="height: 40px;">39484/39485/39486</td>
+<td style="height: 40px;">State v. Shawn M. Kesling</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/Kesling.pdf">Opinion</a></td>
+<td style="width: 25%;">Order Revoking Probation</td>
+</tr><tr><td style="width: 15%;">Dec 19, 2013</td>
+<td style="height: 40px;">40239</td>
+<td style="height: 40px;">State v. Derek W. Howard</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40239.pdf">Opinion</a></td>
+<td style="width: 25%;">Motion to Suppress</td>
+</tr><tr><td style="width: 15%;">Dec 12, 2013</td>
+<td style="height: 40px;">40417</td>
+<td style="height: 40px;">Gregory S. McAmis v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40417FIX.pdf">Opinion</a></td>
+<td style="width: 25%;">Grand Theft</td>
+</tr><tr><td style="width: 15%;">Dec 10, 2013</td>
+<td style="height: 40px;">39908</td>
+<td style="height: 40px;">State v. Daniel L. Widner</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39908.pdf">Opinion</a></td>
+<td style="width: 25%;">Trafficking</td>
+</tr><tr><td style="width: 15%;">Dec 10, 2013</td>
+<td style="height: 40px;">39218</td>
+<td style="height: 40px;">Edward Stevens v. State</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39218.pdf">Opinion</a></td>
+<td style="width: 25%;">Post-Conviction</td>
+</tr><tr><td style="width: 15%;">Nov 26, 2013</td>
+<td style="height: 40px;">39903 </td>
+<td style="height: 40px;">State v. Donald Houser </td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39903houseropn.pdf">Opinion</a></td>
+<td style="width: 25%;">Assault </td>
+</tr><tr><td style="width: 15%;">Nov 21, 2013</td>
+<td style="height: 40px;">38554</td>
+<td style="height: 40px;">State v. Darren Carmouche</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/38554.pdf">Opinion</a></td>
+<td style="width: 25%;">Battery</td>
+</tr><tr><td style="width: 15%;">Nov 14, 2013</td>
+<td style="height: 40px;">39287</td>
+<td style="height: 40px;">State v. Franklin Osterhoudt</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39287.pdf">Opinion</a></td>
+<td style="width: 25%;">Rape</td>
+</tr><tr><td style="width: 15%;">Nov 14, 2013</td>
+<td style="height: 40px;">38896</td>
+<td style="height: 40px;">State v. William Franklin Wolfe</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/wolfeSUB.pdf">Opinion</a></td>
+<td style="width: 25%;">[SUBSTITUTE]  Rule 35</td>
+</tr><tr><td style="width: 15%;">Nov 12, 2013</td>
+<td style="height: 40px;">40135</td>
+<td style="height: 40px;">State v. Juan L. Juarez</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40135.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI</td>
+</tr><tr><td style="width: 15%;">Nov 8, 2013</td>
+<td style="height: 40px;">39881</td>
+<td style="height: 40px;">State v. Lloyd Hardin McNeil</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39881.pdf">Opinion</a></td>
+<td style="width: 25%;">Manslaughter</td>
+</tr><tr><td style="width: 15%;">Oct 25, 2013</td>
+<td style="height: 40px;">39954 </td>
+<td style="height: 40px;">State v. Garry K. Widmyer</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39954.pdf">Opinion</a></td>
+<td style="width: 25%;">Lewd Conduct </td>
+</tr><tr><td style="width: 15%;">Oct 25, 2013</td>
+<td style="height: 40px;">39943</td>
+<td style="height: 40px;">State v. J. Bradshaw</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39943.pdf">Opinion</a></td>
+<td style="width: 25%;">Destruction of Evidence</td>
+</tr><tr><td style="width: 15%;">Oct 22, 2013</td>
+<td style="height: 40px;">40069</td>
+<td style="height: 40px;">State v. Kori Lynn Ward</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40069.pdf">Opinion</a></td>
+<td style="width: 25%;">Order Supressing</td>
+</tr><tr><td style="width: 15%;">Oct 22, 2013</td>
+<td style="height: 40px;">39284</td>
+<td style="height: 40px;">State v. Daniel &amp; Kathleen Bergerud</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39284.pdf">Opinion</a></td>
+<td style="width: 25%;"> </td>
+</tr><tr><td style="width: 15%;">Oct 7, 2013</td>
+<td style="height: 40px;">40165</td>
+<td style="height: 40px;">State v. Ricardo Ozuna, Jr.</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40165.pdf">Opinion</a></td>
+<td style="width: 25%;">Lewd</td>
+</tr><tr><td style="width: 15%;">Sept 19, 2013</td>
+<td style="height: 40px;">39226 </td>
+<td style="height: 40px;"> State v. Mark L. Ellis</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39226.pdf">Opinion</a></td>
+<td style="width: 25%;"> Motion to Supress</td>
+</tr><tr><td style="width: 15%;">Sept 6, 2013</td>
+<td style="height: 40px;">38347</td>
+<td style="height: 40px;">State v. Keith Allan Brown</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/38347FIX.pdf">Opinion</a></td>
+<td style="width: 25%;">Manslaughter</td>
+</tr><tr><td style="width: 15%;">Sept 6, 2013</td>
+<td style="height: 40px;">39682/39683</td>
+<td style="height: 40px;">State v. Moses Olivas, Jr. </td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39682-83.pdf">Opinion</a></td>
+<td style="width: 25%;">Sex Offender</td>
+</tr><tr><td style="width: 15%;">Sept 5, 2013</td>
+<td style="height: 40px;">39891</td>
+<td style="height: 40px;">State v. Gary L. Schall</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39891.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI</td>
+</tr><tr><td style="width: 15%;">July 23, 2013</td>
+<td style="height: 40px;">38813</td>
+<td style="height: 40px;"> State v. Tankovich</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/38813amd.pdf">Opinion</a></td>
+<td style="width: 25%;"> Malicious Harrassment</td>
+</tr><tr><td style="width: 15%;">July 17, 2013</td>
+<td style="height: 40px;">36427</td>
+<td style="height: 40px;">State v. Leotis B. Branigh, III</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/36427.pdf">Opinion</a></td>
+<td style="width: 25%;">Murder</td>
+</tr><tr><td style="width: 15%;">July 12, 2013</td>
+<td style="height: 40px;">39139</td>
+<td style="height: 40px;">State v. Elias</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/39139.pdf">Opinion</a></td>
+<td style="width: 25%;">Forcible Penetration</td>
+</tr><tr><td style="width: 15%;">July 11, 2013</td>
+<td style="height: 40px;">40244</td>
+<td style="height: 40px;">State v. Tracy Lorene Davis</td>
+<td style="height: 40px;">- <a href="http://www.isc.idaho.gov/opinions/40244.pdf">Opinion</a></td>
+<td style="width: 25%;">DUI</td>
+</tr></tbody></table></li>
+</ul></li>
+</ul></div>
+</div></div></div>  </div>
+
+          <div class="links"><ul class="links inline"><li class="print_html first"><a href="/print/appeals-court/coa_criminal" title="Display a printer-friendly version of this page." class="print-page" rel="nofollow">Printer-friendly version</a></li>
+<li class="print_pdf last"><a href="/printpdf/1802" title="Display a PDF version of this page." class="print-pdf" rel="nofollow">PDF version</a></li>
+</ul></div>
+
+          </div>
+				<!-- /main-content-block --></div>
+
+
+
+
+
+			<!-- PRINTING BLOCK AFTER THE CONTENT -->
+
+
+
+
+
+
+			<!-- / column-2 --></div>
+
+				<div style="clear: both"></div>
+	</div>
+    <!--end contentWrap-->
+
+
+
+
+<div style="clear: both"></div>
+    <!-- footer -->
+    <div id="footer-wrapper">
+        <div id="footer-map"><img src="/sites/all/themes/appeals/images/mapsmall.png" alt="Arrow Right"></div>
+        <ul class="footer-menu">
+            <li><a href="http://www.isc.idaho.gov/">Home</a> |</li>
+            <li><a href="http://www.idaho.gov/">State of Idaho</a>|</li>
+            <li><a href="http://www.idaho.gov/accessibility.html">Accessibility</a>|</li>
+            <li><a href="http://www.idaho.gov/privacy.html">Privacy & Security </a>|</li>
+            <!-- <li><a href="">Contact Webmaster </a>|</li> -->
+            <li><a href="http://www.icondesignusa.com" target="_blank">ICON Design.</a></li>
+        </ul>
+		<div style="clear: both"></div>
+    </div>
+    <!-- /footer -->
+
+</div>
+<!-- / make-it-center -->
+
+  </body>
+</html>

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 import glob


### PR DESCRIPTION
Unlike the idaho_civil resource page, the idahoctapp_criminal resource page uses 'ORDER' instead of 'Order' as the anchor text for order case PDF links.  I suspect this is just a one-off incident, but I've gone ahead and added a test example of the html that was breaking the idahoctapp_criminal scraper.