### PR TITLE
Fixing colo, fladistctapp_2, wash. Improving nyappdiv_3rd.

### DIFF
--- a/opinions/united_states/state/wash.py
+++ b/opinions/united_states/state/wash.py
@@ -1,6 +1,8 @@
-from juriscraper.OpinionSite import OpinionSite
-from datetime import datetime, timedelta, date
+from datetime import timedelta, date
 from dateutil.rrule import rrule, MONTHLY
+
+from juriscraper.OpinionSite import OpinionSite
+from juriscraper.lib.string_utils import convert_date_string
 
 
 class Site(OpinionSite):
@@ -42,10 +44,7 @@ class Site(OpinionSite):
 
     def _get_case_dates(self):
         path = "{base}/td[1]/text()".format(base=self.base)
-        dates = []
-        for date_string in self.html.xpath(path):
-            dates.append(datetime.strptime(date_string.strip(), '%b. %d, %Y').date())
-        return dates
+        return [convert_date_string(date.strip()) for date in self.html.xpath(path) if date.strip()]
 
     def _get_download_urls(self):
         path = "{base}/td[2]/a[2]/@href".format(base=self.base)

--- a/tests/examples/opinions/united_states/coloctapp_example_2.html
+++ b/tests/examples/opinions/united_states/coloctapp_example_2.html
@@ -1,0 +1,654 @@
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN">
+
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+
+	<meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7" />
+	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+
+
+
+				<title>March 10, 2016 - Colorado Court of Appeals Opinions</title>
+
+			<meta name="description" content="" />
+			<meta name="keywords" content="" />
+		<link href="/wrapper/styles.css" rel="stylesheet" type="text/css" />
+<link rel="stylesheet" href="/wrapper/styles1024.css" type="text/css" title="1024 x 768" />
+
+
+
+    <script src="/jquery/jquery-1.6.2.js" type="text/javascript"></script>
+
+	<script type="text/javascript" src="/resources/event_listeners.js"></script>
+	<script type="text/javascript" src="/resources/screenresolution.js"></script>
+
+	<script type="text/javascript" src="/resources/jquery.corner.js"></script>
+
+
+<script type="text/javascript" src="/global/scripts/generalLib.cfm"></script>
+
+
+
+
+		<style>
+			@media print {
+
+				#wrapper, #content-wrapper, #centercol {
+					width:99%;
+				}
+									}
+
+			}
+		</style>
+        <style type="text/css">
+			#bodyBox{
+				min-width: 782px;
+			}
+		</style>
+	<!--[if IE 6]>
+		<style>
+			@media print {
+				#wrapper, #content-wrapper, #centercol {
+					width:67%;
+				}
+
+			}
+
+		</style>
+	<![endif]-->
+
+
+	<link type="text/css" rel="stylesheet" href='/repository/searchCss.css' />
+</head>
+<body >
+
+
+
+
+<table id="wrapper"  border="0" align="center" cellpadding="0" cellspacing="0">
+  <tr>
+    <td><table width="100%" border="0" cellspacing="0" cellpadding="0" id="header">
+        <tr>
+          <td width="62%" rowspan="2" align="left" valign="bottom" id="logo"><a href="/"><img src="/wrapper/images/logo_CBA.gif" alt="The Colorado and Denver Bar Association" width="209" height="46" border="0" /></a></td>
+          <td width="37%" align="center"><a href="/">CBA Home</a> | <a href="/index.cfm/ID/20023/">CLE Home</a> | <a href="/index.cfm/ID/21403/dpadm/Staff-Directory/">Contact Us</a> | <a href="/cle/cobarcart.cfm"><img src="/image/carticononblue.jpg" border=0>Cart -  <span id="numCarts0">empty</span> </a> <br>
+</td>
+        </tr>
+        <tr>
+          <td valign="bottom" align="right" style="padding-right:10px;">
+		  	<div id="tab">
+
+			<a href="/cle/login.cfm?id=20052&returnto=/opinions/opinionlist.cfm?casedate=3/10/2016&courtid=1">Log On</a>
+
+
+    <a href="/infomgmt.cfm?id=20052">My Cobar</a>
+
+	<script>
+	function checkFormFrame(){
+			 if(! document.getElementById('formFrame')){
+                    var frmFrm = document.createElement("iframe");
+                    frmFrm.id="formFrame";
+					frmFrm.name="formFrame";
+                    frmFrm.height = 0;
+                    frmFrm.width = 0;
+                    frmFrm.style.visibility = "hidden";
+                    document.body.appendChild(frmFrm);
+                    if(document.all)
+                        document.getElementById('formFrame').attachEvent('onload',function(){iframeFinished('')});
+                    else
+                        document.getElementById('formFrame').addEventListener('load',function(){iframeFinished('')},false);
+                }
+				return true;
+			}
+				</script>
+
+			</div>          </td>
+        </tr>
+      </table></td>
+  </tr>
+
+
+  <tr>
+    <td valign="top">
+	<table width="100%" border="0" cellspacing="0" cellpadding="0" id="content-wrapper">
+        <tr>
+          <td id="leftBorder"></td>
+          <td colspan="2" id="headBar">
+			<div class="imgWrap" style="background-image:url()" id="item1"></div>
+
+
+			<div style="float:right; background-color:#FFFFFF; height:70px">
+				<h2>
+				Search
+				</h2>
+
+				<div class="plaidBox" style="height:52px;">
+					<div class="content">
+					<form name="search" action="/search/" method="get" style="margin:0;">
+
+						<input name="q" type="text" style="width:135px;" value=""/>
+
+						<input type="hidden" name="categories" value='product,TCL,opinion,webpage,Publication,CLE Online,Video On-Demand,Course Material,CD Homestudy,MP3 Download,event,Webcast,seminar,teleseminar,Video Replay' />
+						<input name="GO" type="submit" value="GO" class="smButton" /><br />
+
+
+						<input type="hidden" name="searchmode" value="CBA">
+
+					</form>
+					</div>
+				</div>
+			</div>
+
+		  </td>
+          <td id="rightBorder"></td>
+        </tr>
+        <tr>
+          <td id="leftBorder"></td>
+          <td id="leftCol" style="padding-left: 5px;">
+		  <div id="navBox">
+		  	<div id="tab"> <a href="/" class="active">CBA</a> <a href="/index.cfm/ID/20023/">CLE</a> </div>
+				<br />
+
+              <div class="greyBox" style="width: 145px;">
+			    <div id="links">
+
+
+<style type="text/css">
+
+/*Credits: Dynamic Drive CSS Library */
+/*URL: http://www.dynamicdrive.com/style/ */
+
+.suckerdiv, #suckertree1 {
+padding: 0;
+
+line-height: 15px;
+/* Set line-height because I think it looks better like this ;^) */
+/*letter-spacing: .04em;*/
+/* Set letter-spacing so text don't jump as much when it turns bold on hover */
+}
+
+.suckerdiv ul{
+list-style-type: none;
+padding-left: 0px;
+margin: 0px;
+background-color:#EBEBEB;
+
+}
+
+.suckerdiv li{
+
+}
+
+.suckerdiv a{
+text-decoration: none;
+}
+
+.suckerdiv a:hover
+{
+
+
+/*background-image:url(/wrapper/images/arrow.gif);
+background-repeat:no-repeat;
+background-position:left 0px top 3px;*/
+
+
+/*font-weight: bold;*/
+/*letter-spacing: 0;*/
+/* Set letter-spacing back to 0 so text don't jump as much when it turns to bold on hover (Still jumps some though) */
+}
+
+
+.suckerdiv ul {
+
+}
+
+.suckerdiv ul li {
+padding-left:8px;
+}
+
+/*Sub level menu items */
+.suckerdiv ul li ul{
+ background-color:#DFDFDF;
+
+/*display:none;*/
+
+}
+
+/*Sub level menu items */
+.suckerdiv ul li ul li{
+border-bottom:#CCCCCC 1px solid;
+border-left:#CCCCCC 1px solid;
+}
+
+/*Sub level menu items */
+.suckerdiv ul li ul li ul{
+
+	 background-color:#F4F4F4;
+
+
+}
+
+
+/*Third Level menu items */
+.suckerdiv ul li ul li ul li{
+
+}
+
+/*Third Level menu items */
+.suckerdiv ul li ul li ul li ul{
+ background-color:#ffffff;
+
+}
+
+/*Third Level menu items */
+.suckerdiv ul li ul li ul li ul li ul{
+ background-color:#ffffff;
+
+}
+
+/* menu links style */
+.suckerdiv ul li a{
+
+}
+
+.suckerdiv ul li a:visited{
+
+}
+
+.suckerdiv ul li a:hover{
+
+}
+
+
+
+</style>
+
+
+
+
+ 	<div class="suckerdiv">
+		<ul id="suckertree1">
+
+		<li id="LI22086"> <a href="/index.cfm/ID/22086/DPCOM/About-Us/" id="A22086" >About Us</a><br />
+
+			</li>
+
+		<li id="LI20125"> <a href="/index.cfm/ID/20125/DPMEM/Membership-/" id="A20125" >Membership </a><br />
+
+			</li>
+
+		<li id="LI20002"> <a href="/index.cfm/ID/20002/CLPE/For-Lawyers/" id="A20002" >For Lawyers</a><br />
+
+					<ul>
+
+		<li id="LI23046"> <a href="/index.cfm/ID/23046/DPWAJ/Representing-the-Moderate-Income-Client/" id="A23046" >Representing the Moderate Income Client</a><br />
+
+			</li>
+
+		<li id="LI22803"> <a href="/index.cfm/ID/22803/DPMEM/STRATUM/" id="A22803" >STRATUM</a><br />
+
+			</li>
+
+		<li id="LI21965"> <a href="/index.cfm/ID/21965/DPMEM/Colorado-Mentoring-Program/" id="A21965" >Colorado Mentoring Program</a><br />
+
+			</li>
+
+		<li id="LI22090"> <a href="http://www.coltaf.org/" id="A22090" >COLTAF</a><br />
+
+			</li>
+
+		<li id="LI1749"> <a href="/index.cfm/ID/1749/DCCO/Casemaker/" id="A1749" >Casemaker</a><br />
+
+			</li>
+
+		<li id="LI20017"> <a href="/index.cfm/ID/20017/dptcl/The-Colorado-Lawyer/" id="A20017" >The Colorado Lawyer</a><br />
+
+			</li>
+
+		<li id="LI20062"> <a href="/ors.cfm?ID=20062" id="A20062" >Opinions/ Rules/ Statutes</a><br />
+
+			</li>
+
+		<li id="LI20016"> <a href="/index.cfm/ID/20016/CONTENT/By-Practice-Area/" id="A20016" >By Practice Area</a><br />
+
+			</li>
+
+		<li id="LI20124"> <a href="/index.cfm/ID/20124/DPLPM/Practice-Management/" id="A20124" >Practice Management</a><br />
+
+			</li>
+
+		<li id="LI20037"> <a href="/directory/index.cfm?ID=20037" id="A20037" >Find A Lawyer</a><br />
+
+			</li>
+
+		<li id="LI20039"> <a href="http://www.courts.state.co.us/" id="A20039" target="_blank">Colorado Courts Website</a><br />
+
+			</li>
+
+		<li id="LI20024"> <a href="/index.cfm/ID/20023/" id="A20024" >Continuing Legal Education</a><br />
+
+			</li>
+
+		<li id="LI20025"> <a href="/index.cfm/ID/20202/CETH/Ethics-Committee/" id="A20025" >Ethics</a><br />
+
+			</li>
+
+		<li id="LI20979"> <a href="/index.cfm/ID/20979/CLPE/Professionalism-Resources/" id="A20979" >Professionalism Resources</a><br />
+
+			</li>
+
+		<li id="LI20027"> <a href="http://www.coloradosupremecourt.com/Registration/Registration.asp" id="A20027" target="_blank">Attorney Registration</a><br />
+
+			</li>
+
+		<li id="LI20028"> <a href="/index.cfm/ID/22363/CLPE/ICCES/" id="A20028" target="_blank">E-Filing</a><br />
+
+			</li>
+
+		<li id="LI20123"> <a href="/index.cfm/ID/20123/DPLEG/Legislative-Matters/" id="A20123" >Legislative Matters</a><br />
+
+			</li>
+
+		<li id="LI678"> <a href="/index.cfm/ID/678/dpmem/Employment/" id="A678" >Employment</a><br />
+
+			</li>
+
+		<li id="LI20079"> <a href="/listservs.cfm?ID=20079" id="A20079" >Listserves</a><br />
+
+			</li>
+
+		<li id="LI20011"> <a href="/group/index.cfm?category=3149&EntityID=dplpm&ID=20011" id="A20011" >Law Related Websites</a><br />
+
+			</li>
+
+		<li id="LI20015"> <a href="/litihandbook/?ID=20015" id="A20015" >Litigators Handbook</a><br />
+
+			</li>
+
+		<li id="LI20059"> <a href="/index.cfm/ID/767/Membership-Applications/" id="A20059" >Join the CBA</a><br />
+
+			</li>
+
+		<li id="LI1875"> <a href="/index.cfm/ID/1875/dpmem/Confidential-Assistance-for-Attorneys/" id="A1875" >Confidential Assistance for Attorneys</a><br />
+
+			</li>
+
+		<li id="LI2626"> <a href="/index.cfm/ID/2626/DPMEM/Help---FAQs/" id="A2626" >Help - FAQs</a><br />
+
+			</li>
+
+					</ul>
+				</li>
+
+		<li id="LI20113"> <a href="/index.cfm/ID/20113/CYLD/Young-Lawyers-Division/" id="A20113" >Young Lawyers Division</a><br />
+
+			</li>
+
+		<li id="LI20003"> <a href="/index.cfm/ID/20003/DCCO/Inside-the-Bar/" id="A20003" >Inside the Bar</a><br />
+
+			</li>
+
+		<li id="LI20005"> <a href="/index.cfm/ID/20005/DPCOM/News/Media-Resources/" id="A20005" >News/Media Resources</a><br />
+
+			</li>
+
+		<li id="LI20004"> <a href="/index.cfm/ID/20004/dpwfp/For-the-Public/" id="A20004" >For the Public</a><br />
+
+			</li>
+
+		<li id="LI20213"> <a href="/highlights.cfm?pi=FromTheCourts&ID=20213" id="A20213" >From the Courts</a><br />
+
+			</li>
+
+		<li id="LI22467"> <a href="/index.cfm/ID/22467/DPPLE/Pro-Bono/Volunteer-Opportunities/" id="A22467" >Pro Bono/Volunteer Opportunities</a><br />
+
+			</li>
+
+		<li id="LI21616"> <a href="/classified/classifiedAdList.cfm?ID=21616" id="A21616" >Employment/Classified Ads</a><br />
+
+			</li>
+
+		</ul>
+	</div>
+
+
+    <script language="javascript">
+
+
+   // Highlight current item
+  $("li#LI20062").css({fontWeight:"bold"});
+   $("li#LI20062 > ul").css({fontWeight:"normal"});
+  // Show parent ul
+ // $("li#LI20062").parent("ul").css({display:"block"});
+  // Show Grnadpa ul
+ // $("li#LI20062").parent().parent().parent("ul").css({display:"block"});
+    // Show Great Gpa ul
+ // $("li#LI20062").parent().parent().parent().parent().parent("ul").css({display:"block"});
+      // Show Great Great Gpa ul
+ // $("li#LI20062").parent().parent().parent().parent().parent().parent().parent("ul").css({display:"block"});
+  // Show one level down
+ // $("li#LI20062 > ul").css({display:"block",fontWeight:"normal"});
+     // Add Arrows
+ // $(".suckerdiv ul:nth-child(1)").children().prepend("<img src='/cms/images/bullet_arrow.gif' style='margin:0px 6px 2px 4px;'>");
+  //$(".suckerdiv ul:first-child").children().children().children().prepend("&nbsp;&nbsp;");
+// $(".suckerdiv > ul:first-child").children().children().children().prepend("&nbsp;&nbsp;");
+
+</script>
+
+
+				</div>
+			  </div>
+            </div>
+			<br clear="all">
+
+            <span id="item15"><table border="0" cellpadding="1" cellspacing="3" width="150">
+	<tbody>
+		<tr align="center">
+			<td>
+				<table width="100%">
+					<tbody>
+						<tr valign="middle">
+							<td style="padding-right: 5px; padding-top: 10px; padding-bottom: 15px;">
+								<a href="http://www.facebook.com/ColoradoBarAssociation"> <img border="0" src="http://www.cobar.org/repository/homepage/facebook.png" width="20" /></a></td>
+							<td style="padding-right: 5px; padding-top: 10px; padding-bottom: 15px;">
+								<a href="https://twitter.com/#!/COBarAssoc"><img border="0" src="http://www.cobar.org/repository/homepage/twitter.png" width="20" /></a></td>
+							<td style="padding-right: 5px; padding-top: 10px; padding-bottom: 15px;">
+								<a href="http://www.linkedin.com/groups/Colorado-Bar-Association-4318515?gid=4318515&amp;trk=hb_side_g"><img border="0" src="http://www.cobar.org/repository/homepage/LinkedIn.png" width="20" /></a></td>
+							<td style="padding-right: 5px; padding-top: 10px; padding-bottom: 15px;">
+								<a href="https://plus.google.com/u/0/b/100514911196059631658/100514911196059631658/about"> <img border="0" src="http://www.cobar.org/repository/homepage/google.png" width="20" /></a></td>
+							<td style="padding-right: 10px; padding-top: 5px; padding-bottom: 10px;">
+								<a href="http://www.youtube.com/user/coloradoanddenverbar?feature=g-user-u"> <img border="0" src="http://www.cobar.org/repository/homepage/youtube.png" /></a></td>
+						</tr>
+					</tbody>
+				</table>
+			</td>
+		</tr>
+		<tr>
+			<td style="text-align: center">
+				<a href="http://www.cobar.org/index.cfm/ID/767/dpmem/Membership-Applications/"><img alt="Not a CBA Member? Join Now!" border="0" src="/repository/join_now_image.jpg" style="padding-bottom: 5px; padding-left: 2px; padding-right: 2px; padding-top: 5px" /></a></td>
+		</tr>
+		<tr>
+			<td style="text-align: center;">
+				<a href="http://www.cobar.org/index.cfm/ID/1749/DPMEM/Casemaker/"><img src="http://www.cobar.org/repository/homepage/Casemaker.png" style="width: 150px; margin-top: 10px; margin-bottom: 10px; border-width: 0px; border-style: solid;" vspace="10" /></a></td>
+		</tr>
+		<tr>
+			<td style="text-align: center; padding-bottom: 15px;">
+				<a href="http://www.cobar.org/directory/"><img alt="Find A Lawyer Directory" src="/repository/Member Benefits/FAL_150px.gif" style="border-width: 0px; border-style: solid; width: 150px; height: 45px;" /></a></td>
+		</tr>
+		<tr>
+			<td style="text-align: center; padding-bottom: 5px;">
+				<a href="https://www.cobar.org/cvweb_legaldirectory/cgi-bin/memberdll.dll/info?wrp=mainloginwelcome.htm"><img alt="Legal Directory" src="http://www.cobar.org/repository/homepage/LDWeb_150.jpg" style="border-width: 0px; border-style: solid; width: 150px;" /></a></td>
+		</tr>
+
+		<tr>
+			<td style="text-align: center; padding-bottom: 8px;">
+				<a href="http://www.cobar.org/index.cfm/ID/22803/DPMEM/STRATUM/"><img alt="STRATUM" src="http://www.cobar.org/repository/homepage/Stratum_150w.jpg" style="border-width: 0px; border-style: solid; width: 150px;" /></a></td>
+		</tr>
+		<tr>
+			<td style="text-align: center;">
+				<a href="/page.cfm/ID/23046/" target="_blank"><img border="0" src="http://www.cobar.org/repository/homepage/ModerateIncome-button.png" style="margin-top: 5px; margin-bottom: 5px;" /></a></td>
+		</tr>
+		<tr>
+			<td style="text-align: center;">
+				<a href="http://www.cobar.org/index.cfm/ID/22467/DPPLE/Pro-Bono/Volunteer-Opportunities/#flood"><img src="http://www.cobar.org/repository/homepage/Pro-Bono-Opps-Button.jpg" style="border-width: 0px; border-style: solid; margin-top: 5px; margin-bottom: 5px;" /></a></td>
+		</tr>
+	</tbody>
+</table>
+</span> <span id="item8">
+</span>
+
+
+				  </td>
+          <td valign="top" id="centerCol">
+
+				<div id="breadCrumbs">
+
+
+		<a href="/">Home</a>  &gt;
+				<a href="/page.cfm/ID/20002/">For Lawyers</a>  &gt;
+				<a href="/ors.cfm"><u>Opinions/ Rules/ Statutes</a> </u> </div>
+
+		  <div id="bodyBox" style=" min-height:400px;">
+		    	<!--BEGINCONTENT-->
+	<!-- distemp: default -->
+
+<script language="JavaScript"> // Search, Calendar and Login rollovers
+<!--
+function MM_findObj(n, d) { //v3.0
+  var p,i,x;  if(!d) d=document; if((p=n.indexOf("?"))>0&&parent.frames.length) {
+    d=parent.frames[n.substring(p+1)].document; n=n.substring(0,p);}
+  if(!(x=d[n])&&d.all) x=d.all[n]; for (i=0;!x&&i<d.forms.length;i++) x=d.forms[i][n];
+  for(i=0;!x&&d.layers&&i<d.layers.length;i++) x=MM_findObj(n,d.layers[i].document); return x;
+}
+function MM_swapImage() { //v3.0
+  var i,j=0,x,a=MM_swapImage.arguments; document.MM_sr=new Array; for(i=0;i<(a.length-2);i+=3)
+   if ((x=MM_findObj(a[i]))!=null){document.MM_sr[j++]=x; if(!x.oSrc) x.oSrc=x.src; x.src=a[i+2];}
+}
+function MM_swapImgRestore() { //v3.0
+  var i,x,a=document.MM_sr; for(i=0;a&&i<a.length&&(x=a[i])&&x.oSrc;i++) x.src=x.oSrc;
+}
+
+function MM_preloadImages() { //v3.0
+ var d=document; if(d.images){ if(!d.MM_p) d.MM_p=new Array();
+   var i,j=d.MM_p.length,a=MM_preloadImages.arguments; for(i=0; i<a.length; i++)
+   if (a[i].indexOf("#")!=0){ d.MM_p[j]=new Image; d.MM_p[j++].src=a[i];}}
+}
+
+//-->
+</script>
+
+
+
+
+
+<div id="opinion">
+
+<p><font size="4"><b>
+<a href="index.cfm?courtid=1">Colorado Court of Appeals Opinions</a>
+<br><font size="3">March 10, 2016</font></b></font> <table align="center" cellpadding="10" cellspacing="0" bgcolor="#ffffcc"><tr><td><font size="1">The Court of Appeals summaries are written for the Colorado Bar Association by licensed attorneys Teresa Wilkins (Denver) and Paul Sachs (Steamboat Springs). Please note that the summaries of Opinions of the Colorado Court of Appeals are provided as a service by the Colorado Bar Association and are not the official language of the Court. The Colorado Bar Association cannot guarantee the accuracy or completeness of the summaries.</font></td></tr></table>
+			<P>
+			<A HREF="opinion.cfm?opinionid=10119&courtid=1"><b>2016 COA 32. No. 14CA1424. Brooks v. Raemisch.</b></A><BR>
+			<b><i></i></b><BR>
+
+
+			</P>
+
+			<P>
+			<A HREF="opinion.cfm?opinionid=10120&courtid=1"><b>2016 COA 33. Nos. 14CA1483 & 15CA0216. Rocky Mountain Exploration, Inc. v. Davis Graham & Stubbs LLP.</b></A><BR>
+			<b><i></i></b><BR>
+
+			</P>
+
+			<P>
+			<A HREF="opinion.cfm?opinionid=10121&courtid=1"><b>2016 COA 34. No. 14CA1581. Estate of Robert A. Petteys v. Farmers State Bank of Brush.</b></A><BR>
+			<b><i></i></b><BR>
+
+
+			</P>
+
+			<P>
+			<A HREF="opinion.cfm?opinionid=10122&courtid=1"><b>2016 COA 35. No. 14CA1719. People v. Mazzarelli.</b></A><BR>
+			<b><i></i></b><BR>
+
+			</P>
+
+			<P>
+			<A HREF="opinion.cfm?opinionid=10123&courtid=1"><b>2016 COA 36. No. 14CA2192. In re the Marriage of Gross.</b></A><BR>
+			<b><i></i></b><BR>
+
+			</P>
+
+			<P>
+			<A HREF="opinion.cfm?opinionid=10124&courtid=1"><b>2016 COA 37. No. 14CA2383. Department of Human Services, Colorado v. State Personnel Board.</b></A><BR>
+			<b><i></i></b><BR>
+
+
+			</P>
+
+			<P>
+			<A HREF="opinion.cfm?opinionid=10125&courtid=1"><b>2016 COA 38.Nos. 14CA2454, 14CA2455, 14CA2456 People In the Interest of E.M. and Concerning L.G.M.</b></A><BR>
+			<b><i>Nos. 14CA2454, 14CA2455, 14CA2456 & 14CA1457</i></b><BR>
+
+			</P>
+
+			<P>
+			<A HREF="opinion.cfm?opinionid=10126&courtid=1"><b>2016 COA 39. No. 14CA2502. Lindauer v. Williams Production RMT Company.</b></A><BR>
+			<b><i></i></b><BR>
+
+			</P>
+
+			<P>
+			<A HREF="opinion.cfm?opinionid=10127&courtid=1"><b>2016 COA 40. No. 15CA0109. Rowland  v. Department of Revenue.</b></A><BR>
+			<b><i></i></b><BR>
+
+			</P>
+
+			<P>
+			<A HREF="opinion.cfm?opinionid=10128&courtid=1"><b>2016 COA 41. No. 15CA0346. Foster v. Plock.</b></A><BR>
+			<b><i></i></b><BR>
+
+			</P>
+
+
+
+<p><a href="index.cfm?courtid=1">Colorado Court of Appeals Opinions</a>
+<p><A HREF="javascript:history.go(-1)">Back</A>
+
+</div>
+
+<!-- Include Global footer -->
+ <!--ENDCONTENT-->
+		  </div>		  </td>
+          <td id="rightBorder"></td>
+        </tr>
+      </table></td>
+  </tr>
+  <tr>
+    <td align="center"><div id="footer">Colorado Bar Association &nbsp;&nbsp;|&nbsp;&nbsp; 1900 Grant St, 9th Floor &nbsp;&nbsp;|&nbsp;&nbsp; Denver, CO 80203 &nbsp;&nbsp;|&nbsp;&nbsp; 303.860.1115</div></td>
+  </tr>
+</table>
+	<iframe name="formFrame" id="formFrame" width=0 height=0 src="/global/scripts/empty.htm" style="visibility: hidden;" scrolling="auto"></iframe>
+	<script type="text/javascript">
+			if(document.all)
+				document.getElementById('formFrame').attachEvent('onload',function(){iframeFinished('')});
+			else
+				document.getElementById('formFrame').addEventListener('load',function(){iframeFinished('')},false);
+	</script>
+
+
+		<script type="text/javascript">
+		var gaJsHost = (("https:" == document.location.protocol) ? "https://ssl." : "http://www.");
+		document.write(unescape("%3Cscript src='" + gaJsHost + "google-analytics.com/ga.js' type='text/javascript'%3E%3C/script%3E"));
+		</script>
+		<script type="text/javascript">
+		try {
+		var pageTracker = _gat._getTracker("UA-10428213-2");
+		pageTracker._trackPageview();
+		} catch(err) {}
+		</script>
+
+
+
+</body>
+</html>
+
+	<!-- distemp: default -->

--- a/tests/examples/opinions/united_states/fladistctapp_2_example_3.html
+++ b/tests/examples/opinions/united_states/fladistctapp_2_example_3.html
@@ -1,0 +1,222 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="../../../../Templates/dca_main_second.dwt" codeOutsideHTMLIsLocked="false" -->
+<head>
+<!-- InstanceBeginEditable name="doctitle" -->
+<title>Florida's Second District Court of Appeal's Website</title>
+<!-- InstanceEndEditable -->
+<script language="JavaScript1.2" type="text/javascript" src="/stylesheets/init_homepg.js"></script>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+  <meta http-equiv="PRAGMA" content="NO-CACHE" />
+  <meta http-equiv="Expires" content="0" />
+<!-- InstanceBeginEditable name="head" --><!-- InstanceEndEditable -->
+<link href="/stylesheets/main.css" rel="stylesheet" type="text/css" />
+<link href="/stylesheets/print.css" rel="stylesheet" type="text/css" media="print">
+</head>
+<body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onLoad="MM_preloadImages('/images/navbar_home.jpg','/images/navbar_judgeshover.jpg','/images/navbar_homehover.jpg','/images/navbar_clerkhover.jpg','/images/navbar_argumentshover.jpg','/images/navbar_dockethover.jpg','/images/navbar_opinionshover.jpg','/images/navbar_eaccesshover.jpg','/images/navbar_searchhover.jpg')">
+<script language="JavaScript" type="text/JavaScript">
+<!--
+
+
+
+function MM_preloadImages() { //v3.0
+  var d=document; if(d.images){ if(!d.MM_p) d.MM_p=new Array();
+    var i,j=d.MM_p.length,a=MM_preloadImages.arguments; for(i=0; i<a.length; i++)
+    if (a[i].indexOf("#")!=0){ d.MM_p[j]=new Image; d.MM_p[j++].src=a[i];}}
+}
+//-->
+</script>
+<link href="/New WebPage/Stylesheets/main.css" rel="stylesheet" type="text/css">
+<script type="text/JavaScript">
+<!--
+function MM_swapImgRestore() { //v3.0
+  var i,x,a=document.MM_sr; for(i=0;a&&i<a.length&&(x=a[i])&&x.oSrc;i++) x.src=x.oSrc;
+}
+
+function MM_findObj(n, d) { //v4.01
+  var p,i,x;  if(!d) d=document; if((p=n.indexOf("?"))>0&&parent.frames.length) {
+    d=parent.frames[n.substring(p+1)].document; n=n.substring(0,p);}
+  if(!(x=d[n])&&d.all) x=d.all[n]; for (i=0;!x&&i<d.forms.length;i++) x=d.forms[i][n];
+  for(i=0;!x&&d.layers&&i<d.layers.length;i++) x=MM_findObj(n,d.layers[i].document);
+  if(!x && d.getElementById) x=d.getElementById(n); return x;
+}
+
+function MM_swapImage() { //v3.0
+  var i,j=0,x,a=MM_swapImage.arguments; document.MM_sr=new Array; for(i=0;i<(a.length-2);i+=3)
+   if ((x=MM_findObj(a[i]))!=null){document.MM_sr[j++]=x; if(!x.oSrc) x.oSrc=x.src; x.src=a[i+2];}
+}
+//-->
+</script>
+<body onLoad="MM_preloadImages('/New WebPage/images/navbar_home.jpg','/New WebPage/images/navbar_judgeshover.jpg','/New WebPage/images/navbar_homehover.jpg','/New WebPage/images/navbar_clerkhover.jpg','/New WebPage/images/navbar_argumentshover.jpg','/New WebPage/images/navbar_dockethover.jpg','/New WebPage/images/navbar_opinionshover.jpg','/New WebPage/images/navbar_searchhover.jpg')">
+<table border="0" cellpadding="0" cellspacing="0" bgcolor="#375885">
+  <tr>
+
+	<td align="right" valign="top"><table width="100%"  border="0" cellpadding="0" cellspacing="0" bgcolor="#365886">
+      <tr>
+        <td background="/New WebPage/images/banner_background.jpg"><img src="http://www.2dca.org/images/banner_text_second.jpg" width="752" height="82" align="right"></td>
+      </tr>
+      <tr>
+        <td background="/New WebPage/images/banner_background.jpg">
+          <table width="98%" border="2" align="right" "cellpadding="0" cellspacing="0" bordercolor="#999999" bgcolor="#ECE9D8">
+            <tr>
+
+			  <td width="8%" bgcolor="#ECE9D8"><div align="center"><a href="/index.shtml"></a><a href="http://www.2dca.org/index2.shtml"><img src="/images/navbar_home.jpg" alt="home button" width="50" height="15" border="0" id="Image1" onMouseOver="MM_swapImage('Image1','','/New WebPage/images/navbar_home.jpg',1);MM_swapImage('Image1','','/New WebPage/images/navbar_homehover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="9%"><div align="center" class="boldbodytext"><a href="/judges.shtml"></a><a href="http://www.2dca.org/Judges/judges.shtml"><img src="/images/navbar_judges.jpg" alt="judges button" name="Image2" width="50" height="15" border="0" id="Image2" onMouseOver="MM_swapImage('Image2','','/New WebPage/images/navbar_judgeshover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="16%"><div align="center" class="boldbodytext"><a href="/clerks_office.shtml"></a><a href="http://www.2dca.org/Clerk/clerks_office.shtml"><img src="/images/navbar_clerk.jpg" alt="clerk's office button" name="Image3" width="104" height="15" border="0" id="Image3" onMouseOver="MM_swapImage('Image3','','/New WebPage/images/navbar_clerkhover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="18%" bgcolor="#ECE9D8"><div align="center" class="boldbodytext"><a href="/oralarguments.shtml"></a><a href="http://www.2dca.org/OralArgumentCalendar/calendardates.shtml"><img src="/images/navbar_arguments.jpg" alt="oral arguments button" name="Image4" width="110" height="15" border="0" id="Image4" onMouseOver="MM_swapImage('Image4','','/New WebPage/images/navbar_argumentshover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="17%" bordercolor="#999999"><div align="center" class="boldbodytext"><a href="http://jweb.flcourts.org/pls/docket/ds_docket_search%20"></a><a href="http://199.242.69.70/pls/ds/ds_docket_search"><img src="/images/navbar_docket.jpg" alt="on-line docket button" name="Image5" width="110" height="15" border="0" id="Image5" onMouseOver="MM_swapImage('Image5','','/New WebPage/images/navbar_dockethover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+              <td width="11%"><div align="center" class="boldbodytext"><a href="/New WebPage/opinions.shtml"></a><a href="http://www.2dca.org/opinions/opinions.shtml"><img src="/images/navbar_opinions.jpg" alt="opinions button" name="Image6" width="68" height="15" border="0" id="Image6" onMouseOver="MM_swapImage('Image6','','/New WebPage/images/navbar_opinionshover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="10%"><div align="center" class="boldbodytext"><a href="http://www.1dca.org/cgi-bin/mclient.cgi"></a><a href="http://www.2dca.org/search.shtml"><img src="/images/navbar_search.jpg" alt="search button" width="68" height="15" border="0" id="Image8" onMouseOver="MM_swapImage('Image8','','/New WebPage/images/navbar_searchhover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  </tr>
+          </table>          </td>
+      </tr>
+    </table>    </td>
+
+    <td width="100%"align="top" background="/New WebPage/images/banner_background.jpg"></td>
+    <td align="top">&nbsp;</td>
+  </tr>
+</table>
+
+
+<table width="754" border="0" cellpadding="0" cellspacing="0" bordercolor="#003366">
+  <tr>
+    <td width="15" valign="top"><a href="#main"><img src="../../../../images/banner_background_spacer.jpg" alt="Skip Navigation" width="4" height="15" border="0" /></a></td>
+    <td width="200" valign="top" align="left">
+
+	<style type="text/css">
+<!--
+.style1 {color: #FF0000}
+-->
+</style>
+<table  width="100%" border="0">
+  <tr>
+    <td style="padding-top:1px; padding-left:6px; padding-bottom:0px">
+<div id="menu">
+	 <ul style="margin-left:0; margin-bottom:0; padding-left:1em; padding-bottom:0px;">
+    	<li><a href="http://www.2dca.org/Clerk/clerks_office.shtml">Clerk's Office</a></li>
+        <li><a href="http://www.2dca.org/opinions/opinions.shtml">Opinions</a></li>
+        <li><a href="http://www.2dca.org/PCA/PCA.shtml">Per Curiam Affirmances</a> </li>
+        <li><a href="http://www.2dca.org/opinions/ArchivedOpinions.shtml">Archived Opinions</a></li>
+        <li><a href="/OralArgumentCalendar/calendardates.shtml">Oral Argument Calendar</a></li>
+        <li><a href="../OralArgumentCalendar/oa-streaming.shtml"> Live Oral Argument</a> </li>
+        <li><a href="http://www.2dca.org/marshal/Marshal_Office.shtml">Marshal's Office</a></li>
+        <li><a href="http://www.2dca.org/Employment/employment.shtml">Employment</a></li>
+        <hr align="center" width="95%" size="1" color="#375885">
+		<li><a href="http://www.flcourts.org/gen_public/pubs/adamain.shtml" target="_blank">ADA Guidelines</a></li>
+		<li><a href="/Directions/tampa.shtml">Tampa Branch</a></li>
+		<li><a href="../RobertButlerGallery.shtml">Robert Butler Gallery</a></li>
+		<li><a href="/Clerk/Notices/LegalResearchPage.shtml">Legal Resources</a> </li>
+		<li><a href="../Historic Info/Former Judges.shtml">Former Judges</a></li>
+		<li><a href="../RSS.shtml">RSS feeds</a></li>
+		<li><a href="/CourtHistory/history.shtml">Additional Court Information</a></li>
+		<li><a href="http://www.2dca.org/faq.shtml">FAQ's</a></li>
+<hr align="center" width="95%" size="1" color="#375885">
+<div align="left"><span style="font-variant:small-caps; margin-left:-1em; margin-bottom:0; padding-left:0; font-weight:bold;">Florida Court Links</span></div>
+<li><a href="http://www.flcourts.org/florida-courts/district-court-appeal.stml" target="_blank">Other DCA Websites</a></li>
+		<li><a href="http://www.floridasupremecourt.org/" target="_blank">Florida Supreme Court</a></li>
+		<li><a href="http://www.flcourts.org/index.shtml" target="_blank">Florida State Courts</a></li>
+		<li><a href="http://www.floridasupremecourt.org/education/index.shtml">Supreme Court Education and Tours</a>            </li>
+    </ul>
+     <hr align="center" width="90%" size="1" color="#375885">
+<div style="padding-top:0px; padding-bottom:0px" id="menu">
+  <p class="bodytextsmall" align="center">2nd District Court of Appeal <br />
+  1005 E. Memorial   Blvd.<br />
+  Lakeland, FL 33801<br />
+  Telephone: (863) 499-2290</p>
+<p align="center"><a href="/Directions/LakelandDirections.shtml">Map and Directions</a> </p>
+</div>
+<hr align="center" width="95%" size="1" color="#375885">
+<div style="padding:0" align="center"><a href="http://www.2dca.org/index2.shtml">2nd DCA Home</a></div>
+<hr align="center" width="95%" size="1" color="#375885">
+</div>
+</td>
+</tr>
+
+</table>
+
+
+
+
+	</td>
+    <td width="539" valign="top" style="padding-left:15px; padding-right:15px"><br />
+      <a id="main" name="main"></a>
+    <!-- InstanceBeginEditable name="textContent" -->
+    <table width="99%" summary="Opinions for Wednesday, May 07, 2014.">
+      <tr>
+        <th height="87" scope="col"><h1>March  09, 2016</h1>
+          <p class="test"><a href="March 09, 2016/2D13-3440.pdf"><strong>2D13-3440</strong></a><strong><a href="March 09, 2016/2D13-3440.pdf"> / Elder v. State</a></strong><br />
+            <a href="March 09, 2016/2D13-5714rh.pdf"><br />
+            <strong>2D13-5714</strong> / Wright v. State</a><br />
+            <br />
+            <a href="March 09, 2016/2D14-1051.pdf"><strong>2D14-1051</strong> / Baskin v. State</a><br />
+            <br />
+            <a href="March 09, 2016/2D14-1719.pdf"><strong>2D14-1719</strong> / Rodriguez-Aguilar v. State</a><br />
+            <a href="March 09, 2016/2D14-2793.pdf"><br />
+            <strong>2D14-2793</strong> / Rodriguez-Aguilar v. State</a><br />
+            <br />
+            <a href="March 09, 2016/2D14-2960.pdf"><strong>2D14-2960</strong> / Hill v. State</a><br />
+            <br />
+            <a href="March 09, 2016/2D14-4566.pdf"><strong>2D14-4566</strong> / Tenev. Thurston</a><br />
+            <br />
+            <a href="March 09, 2016/2D14-4595.pdf"><strong>2D14-4595</strong> / Vigliani v. Bank of America</a><br />
+            <a href="March 09, 2016/2D14-5011.pdf"><br />
+            <strong>2D14-5011</strong> / Santa Lucia v. LeVine</a><a href="March 09, 2016/2D14-5011.pdf"></a><br />
+            <strong><br />
+            <a href="March 09, 2016/2D14-5541.pdf">2D14-5541</a></strong><a href="March 09, 2016/2D14-5541.pdf"> / Morgan v. State</a><br />
+            <br />
+            <a href="March 09, 2016/2D15-1518.pdf"><strong>2D15-1518</strong> / State v. Caraballo</a><br />
+            <strong><br />
+            <a href="March 09, 2016/2D15-3411.pdf">2D15-3411</a></strong><a href="March 09, 2016/2D15-3411.pdf"> / Williams v. Justice</a> </p></th>
+      </tr>
+      <tr>
+        <th height="20" scope="col">&nbsp;</th>
+      </tr>
+    </table>
+    <!-- InstanceEndEditable --></td>
+  </tr>
+  <tr>
+   <td width="15">&nbsp;</td>
+    <td width="200" valign="top">&nbsp;</td>
+    <td width="539" align="center" style="padding-top:5px; padding-left:1px; padding-right:5px"><div id="bottomMenu" align="center" style="padding:0">
+		   <hr width="75%" style="padding:0">
+		   <ul style="margin-left:0; margin-bottom:0; padding-left:1em; padding-bottom:0px;">
+
+			<li><a href="http://www.2dca.org/index2.shtml">Return Home</a></li>
+			/
+            <li><a href="http://www.2dca.org/search.shtml">Search</a></li>
+            /
+            <li><a href="http://www.2dca.org/Judges/judges.shtml">Judges</a></li>
+            /
+            <li><a href="http://www.2dca.org/Clerk/clerks_office.shtml">Clerk's Office</a></li>
+            /
+            <li><a href="http://www.2dca.org/OralArgumentCalendar/calendardates.shtml">Oral Arguments</a></li>
+            /
+			<li><a href="http://www.2dca.org/opinions/opinions.shtml">Opinions</a></li>
+			<br />
+			<li><a href="http://199.242.69.70/pls/ds/ds_docket_search?pscourt=2" target="_blank">Online Dockets</a></li>
+
+            /
+			<li><a href="http://www.2dca.org/plugins.shtml">Using This Site & Plug-Ins</a></li>
+			/
+			<li><a href="http://www.2dca.org/privacy.shtml">Privacy Policy</a></li>
+			/
+			<li><a href="http://www.2dca.org/accessibility.shtml">Accessibility</a></li>
+          </ul>
+        <p>All Content Copyright 2016 Second District Court of Appeal</p>
+</div>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-46755357-6', 'auto');
+  ga('send', 'pageview');
+
+</script></td>
+  </tr>
+</table>
+
+</body>
+<!-- InstanceEnd --></html>
+


### PR DESCRIPTION
coloctapp was breaking due to regex in colo, washctapp_p was breaking due to regex in wash, and fladistctapp_2 was breaking due to bad formatting on one of the current resource pages.  I've added a new test for coloctapp and fladistctapp_2 to account for new edge formatting cases.  I updated nyappdiv_3rd to have a more strict regex test based on recent discussion with @mlissner about our policy to fail loudly.  I wanted to add a test for coloctapp, but couldn't get the current html to fail the unit tests.  When I would execute this scraper and then dump the json from within the python terminal, it would fail.  But when I added the html to the unit tests, it would not (I believe the naming convention was correct, and saw the counter for coloctapp tests increment by one after adding the new html, but it wouldn't fail). This coloctapp scraper is showing 24 critical error counts in 24 daily executions though, so it most definitely is broken, but this commit should resolve it.