### PR TITLE
Fixing ill scraper to handle non-standard formatting

### DIFF
--- a/opinions/united_states/state/ill.py
+++ b/opinions/united_states/state/ill.py
@@ -2,6 +2,7 @@
 #   2013-08-16: Created by Krist Jin
 #   2014-12-02: Updated by Mike Lissner to remove the summaries code.
 #   2016-02-26: Updated by arderyp: simplified thanks to new id attribute identifying decisions table
+#   2016-03-27: Updated by arderyp: fixed to handled non-standard formatting
 
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.string_utils import convert_date_string
@@ -26,13 +27,24 @@ class Site(OpinionSite):
         return [convert_date_string(date_string) for date_string in self.html.xpath(path)]
 
     def _get_precedential_statuses(self):
-        path = '%s//div/strong/text()' % self._get_decisions_table_cell_path(3)
-        return ['Unpublished' if 'NRel' in text else 'Published' for text in self.html.xpath(path)]
+        statuses = []
+        path = '%s//div' % self._get_decisions_table_cell_path(3)
+        for div in self.html.xpath(path):
+            text = div.xpath('strong/text()')
+            if text and 'NRel' in text:
+                statuses.append('Unpublished')
+            else:
+                statuses.append('Published')
+        return statuses
 
     def _get_docket_numbers(self):
-        path = '%s//div/text()' % self._get_decisions_table_cell_path(3)
-        return [' '.join(text.split()) for text in self.html.xpath(path)]
-
+        docket_numbers = []
+        path = '%s//div' % self._get_decisions_table_cell_path(3)
+        for div in self.html.xpath(path):
+            text = div.xpath('text()')
+            text = ''.join(text).replace('cons.', '')
+            docket_numbers.append(' '.join(text.split()))
+        return docket_numbers
 
     def _get_neutral_citations(self):
         path = '%s//div/text()' % self._get_decisions_table_cell_path(4)

--- a/tests/examples/opinions/united_states/ill_example_2.html
+++ b/tests/examples/opinions/united_states/ill_example_2.html
@@ -1,0 +1,695 @@
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>Recent Supreme Court Opinions</title>
+<link rel="stylesheet" href="../judicial.css" type="text/css" />
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+<meta name="keyword" content="Illinois Courts Official Site, Illinois Courts, Courts, opinions,Judges, Judiciary, Illinois Judiciary, Illinois Supreme Court, Illinois Appellate Courts, Appellate Courts, Circuit Courts, Court Opinions, Administrative Office of the IllinoisCourts" />
+<meta name="Description" content="Illinois Courts Information Site. Contains Supreme, Appellate and Circuit Court information, including judges, and the opinions of the Supreme and Appellate Courts." />
+<script type="text/javascript" src="../flashobject.js"></script>
+<style type="text/css">
+<!--
+.style2 {color: #FF0000}
+.style8 {font-size: 11px}
+
+-->
+</style>
+<!-- ImageReady Preload Script (SubscribeButton.psd) -->
+<script type="text/javascript">
+<!--
+
+function newImage(arg) {
+	if (document.images) {
+		rslt = new Image();
+		rslt.src = arg;
+		return rslt;
+	}
+}
+
+function changeImages() {
+	if (document.images && (preloadFlag == true)) {
+		for (var i=0; i<changeImages.arguments.length; i+=2) {
+			document[changeImages.arguments[i]].src = changeImages.arguments[i+1];
+		}
+	}
+}
+
+var preloadFlag = false;
+function preloadImages() {
+	if (document.images) {
+		SubscribeButton_01_over = newImage("images/SubscribeButton_01-over.gif");
+		preloadFlag = true;
+	}
+}
+
+// -->
+</script>
+<!-- End Preload Script -->
+</head>
+<body bgcolor="#FFFFFF" leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onload="preloadImages();">
+<script type="text/javascript" src='../tablesort.js'></script>
+<noscript>Your browser does not support script</noscript>
+<!--This is the header -->
+<!-- begin header container -->
+<div id="includeheader" class="header">
+  <!-- begin container for date and search bar -->
+  <div id="searchsection">
+  <!-- empty left container -->
+  <div id="searchleft">&nbsp;</div>
+  <!-- center date container -->
+  <div id="includedate" class="includedate">
+  <script type="text/javascript">
+  <!--
+  var mydate=new Date()
+  var year=mydate.getYear()
+  if (year < 1000)
+  year+=1900
+  var day=mydate.getDay()
+  var month=mydate.getMonth()
+  var daym=mydate.getDate()
+  if (daym<10)
+  daym="0"+daym
+  var dayarray=new Array("Sunday","Monday","Tuesday","Wednesday","Thursday","Friday","Saturday")
+  var montharray=new Array("January","February","March","April","May","June","July","August","September","October","November","December")
+  document.write("<font size='1' color='000000' face='Verdana, Arial, Helvetica, sans-serif'><b>"+dayarray[day]+", "+montharray[month]+" "+daym+", "+year+"<\/b><\/font>")
+  //-->
+  </script>
+  <noscript>Your browser does not support script</noscript>
+  </div>
+  <!-- right search container -->
+  <div id="gcs">
+  	<!-- Google custom search code 6/18/13 NEW-->
+	<div id='cse-search-form' style='width: 70%;'>Loading</div>
+	<script src='http://www.google.com/jsapi' type='text/javascript'></script>
+	<script type='text/javascript'>
+	google.load('search', '1', {language: 'en', style: google.loader.themes.DEFAULT});
+	google.setOnLoadCallback(function() {
+  	var customSearchOptions = {};
+  	customSearchOptions['adoptions'] = {'layout' : 'noTop'};
+  	var customSearchControl =   new google.search.CustomSearchControl('004275949654453169572:htl21pney-i', customSearchOptions);
+  	customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
+  	var options = new google.search.DrawOptions();
+  	options.enableSearchboxOnly('http://www.illinoiscourts.gov/search-results2.asp', 'q');
+  	customSearchControl.draw('cse-search-form', options);
+	}, true);
+	</script>
+	<!-- deleted old google stylesheet reference 08/19/14 - LAB -->
+    <style type="text/css">
+    <!--
+	.cse .gsc-branding, .gsc-branding {
+	display: none;
+	}
+    -->
+    </style>
+</div>
+<!-- end google custom search -->
+</div>
+<!-- end right search container -->
+
+<!-- begin logo section container -->
+
+<div id="logosection">
+     <div id="centerlogo">
+	   	<div id="includelogo"><img src="/images/bg1.gif" alt="Welcome to the Illinois Courts website" width="290" height="140" /></div>
+		<div id="slideshow">
+			<!-- using spring graphics -->
+			<div><img src="/images/header/spring/Bench_Spring.jpg" width="412" height="140"></div>
+			<div><img src="/images/header/spring/Corner_Spring.jpg" width="412" height="140"></div>
+			<div><img src="/images/header/spring/Murals_Spring.jpg" width="412" height="140"></div>
+			<div><img src="/images/header/spring/AOIC_Sign_Spring.jpg" width="412" height="140"></div>
+			<div><img src="/images/header/spring/AOIC_Inside_Spring.jpg" width="412" height="140"></div>
+		</div>
+		<div id="include_audi"><img src="/images/audi.jpg" alt="Welcome to the Illinois Courts website" width="227" height="140" /></div>
+     </div>
+</div>
+<!-- end logosection -->
+
+
+ <!-- begin top nav container -->
+  <div id="includetopnav">
+  <div id="menu" style="position:relative"></div>
+  </div>
+ <!-- end top navigation container -->
+</div>
+<!-- end header -->
+
+<!--Editing may start here -->
+ <table cellspacing="0" cellpadding="0" class="body2">
+  <tr>
+  <!--Left side of table starts here -->
+
+
+
+<td class="left" valign="top">
+<script type="text/javascript">
+<!--
+function MM_jumpMenu(targ,selObj,restore){ //v3.0
+  eval(targ+".location='"+selObj.options[selObj.selectedIndex].value+"'");
+  if (restore) selObj.selectedIndex=0;
+}
+//-->
+</script><noscript>Your browser does not support script</noscript>
+
+
+<!-- begin table to hold left nav -->
+<table width="195" cellspacing="0" cellpadding="0">
+  <tr>
+  <td width="195" valign="top" style="padding-top:10px;width:195">
+  <a href="/quicklinks.asp"><img src="/images/tabs/quicklinks.gif" alt="Quick Links" width="195" height="23" border="0" /></a><br />
+  <a href="/legal.asp"><img src="/images/tabs/legal.gif" alt="Legal Community" width="195" height="23" border="0" /></a><br />
+  <a href="/ebus_online.asp"><img src="/images/tabs/ebus_online.gif" alt="E-Business Online Services" width="195" height="23" border="0" /></a><br />
+  <a href="/citizen.asp"><img src="/images/tabs/citizen.gif" alt="Citizen Self Help" width="195" height="23" border="0" /></a><br />
+  <a href="/educator.asp"><img src="/images/tabs/educ.gif" alt="Education" width="195" height="23" border="0" /></a>
+
+	<div style="padding-top:45px;padding-left:12px">
+	<form name="form1" id="form1" action="#">Local Court Information:
+		<select name="Local Court Information" onchange="MM_jumpMenu('parent',this,0)">
+		<option value="x">Select a County</option>
+		<option value="/CircuitCourt/CircuitMap/8th.asp#Adams">Adams County</option>
+		<option value="/CircuitCourt/CircuitMap/1st.asp#Alexander">Alexander County</option>
+		<option value="/CircuitCourt/CircuitMap/3rd.asp#Bond">Bond County</option>
+		<option value="/CircuitCourt/CircuitMap/17th.asp#Boone">Boone County</option>
+		<option value="/CircuitCourt/CircuitMap/8th.asp#Brown">Brown County</option>
+		<option value="/CircuitCourt/CircuitMap/13th.asp#Bureau">Bureau County</option>
+		<option value="/CircuitCourt/CircuitMap/8th.asp#Calhoun">Calhoun County</option>
+		<option value="/CircuitCourt/CircuitMap/15th.asp#Carroll">Carroll County</option>
+		<option value="/CircuitCourt/CircuitMap/8th.asp#Cass">Cass County</option>
+		<option value="/CircuitCourt/CircuitMap/6th.asp#Champaign">Champaign County</option>
+		<option value="/CircuitCourt/CircuitMap/4th.asp#Christian">Christian County</option>
+		<option value="/CircuitCourt/CircuitMap/5th.asp#Clark">Clark County</option>
+		<option value="/CircuitCourt/CircuitMap/4th.asp#Clay">Clay County</option>
+		<option value="/CircuitCourt/CircuitMap/4th.asp#Clinton">Clinton County</option>
+		<option value="/CircuitCourt/CircuitMap/5th.asp#Coles">Coles County</option>
+		<option value="/CircuitCourt/CircuitMap/Cook.asp#Cook">Cook County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Crawford">Crawford County</option>
+		<option value="/CircuitCourt/CircuitMap/5th.asp#Cumberland">Cumberland County</option>
+		<option value="/CircuitCourt/CircuitMap/23rd.asp#DeKalb">DeKalb County</option>
+		<option value="/CircuitCourt/CircuitMap/6th.asp#DeWitt">DeWitt County</option>
+		<option value="/CircuitCourt/CircuitMap/6th.asp#Douglas">Douglas County</option>
+		<option value="/CircuitCourt/CircuitMap/18th.asp#DuPage">DuPage County</option>
+		<option value="/CircuitCourt/CircuitMap/5th.asp#Edgar">Edgar County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Edwards">Edwards County</option>
+		<option value="/CircuitCourt/CircuitMap/4th.asp#Effingham">Effingham County</option>
+		<option value="/CircuitCourt/CircuitMap/4th.asp#Fayette">Fayette County</option>
+		<option value="/CircuitCourt/CircuitMap/11th.asp#Ford">Ford County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Franklin">Franklin County</option>
+		<option value="/CircuitCourt/CircuitMap/9th.asp#Fulton">Fulton County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Gallatin">Gallatin County</option>
+		<option value="/CircuitCourt/CircuitMap/7th.asp#Greene">Greene County</option>
+		<option value="/CircuitCourt/CircuitMap/13th.asp#Grundy">Grundy County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Hamilton">Hamilton County</option>
+		<option value="/CircuitCourt/CircuitMap/9th.asp#Hancock">Hancock County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Hardin">Hardin County</option>
+		<option value="/CircuitCourt/CircuitMap/9th.asp#Henderson">Henderson County</option>
+		<option value="/CircuitCourt/CircuitMap/14th.asp#Henry">Henry County</option>
+		<option value="/CircuitCourt/CircuitMap/21st.asp#Iroquois">Iroquois County</option>
+		<option value="/CircuitCourt/CircuitMap/1st.asp#Jackson">Jackson County</option>
+		<option value="/CircuitCourt/CircuitMap/4th.asp#Jasper">Jasper County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Jefferson">Jefferson County</option>
+		<option value="/CircuitCourt/CircuitMap/7th.asp#Jersey">Jersey County</option>
+		<option value="/CircuitCourt/CircuitMap/15th.asp#JoDaviess">JoDaviess County</option>
+		<option value="/CircuitCourt/CircuitMap/1st.asp#Johnson">Johnson County</option>
+		<option value="/CircuitCourt/CircuitMap/16th.asp#Kane">Kane County</option>
+		<option value="/CircuitCourt/CircuitMap/21st.asp#Kankakee">Kankakee County</option>
+		<option value="/CircuitCourt/CircuitMap/23rd.asp#Kendall">Kendall County</option>
+		<option value="/CircuitCourt/CircuitMap/9th.asp#Knox">Knox County</option>
+		<option value="/CircuitCourt/CircuitMap/19th.asp#Lake">Lake County</option>
+		<option value="/CircuitCourt/CircuitMap/13th.asp#LaSalle">LaSalle County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Lawrence">Lawrence County</option>
+		<option value="/CircuitCourt/CircuitMap/15th.asp#Lee">Lee County</option>
+		<option value="/CircuitCourt/CircuitMap/11th.asp#Livingston">Livingston County</option>
+		<option value="/CircuitCourt/CircuitMap/11th.asp#Logan">Logan County</option>
+		<option value="/CircuitCourt/CircuitMap/10th.asp#Marshall">Marshall County</option>
+		<option value="/CircuitCourt/CircuitMap/9th.asp#McDonough">McDonough County</option>
+		<option value="/CircuitCourt/CircuitMap/22nd.asp#McHenry">McHenry County</option>
+		<option value="/CircuitCourt/CircuitMap/11th.asp#McLean">McLean County</option>
+		<option value="/CircuitCourt/CircuitMap/6th.asp#Macon">Macon County</option>
+		<option value="/CircuitCourt/CircuitMap/7th.asp#Macoupin">Macoupin County</option>
+		<option value="/CircuitCourt/CircuitMap/3rd.asp#Madison">Madison County</option>
+		<option value="/CircuitCourt/CircuitMap/4th.asp#Marion">Marion County</option>
+		<option value="/CircuitCourt/CircuitMap/8th.asp#Mason">Mason County</option>
+		<option value="/CircuitCourt/CircuitMap/1st.asp#Massac">Massac County</option>
+		<option value="/CircuitCourt/CircuitMap/8th.asp#Menard">Menard County</option>
+		<option value="/CircuitCourt/CircuitMap/14th.asp#Mercer">Mercer County</option>
+		<option value="/CircuitCourt/CircuitMap/20th.asp#Monroe">Monroe County</option>
+		<option value="/CircuitCourt/CircuitMap/4th.asp#Montgomery">Montgomery County</option>
+		<option value="/CircuitCourt/CircuitMap/7th.asp#Morgan">Morgan County</option>
+		<option value="/CircuitCourt/CircuitMap/6th.asp#Moultrie">Moultrie County</option>
+		<option value="/CircuitCourt/CircuitMap/15th.asp#Ogle">Ogle County</option>
+		<option value="/CircuitCourt/CircuitMap/20th.asp#Perry">Perry County</option>
+		<option value="/CircuitCourt/CircuitMap/10th.asp#Peoria">Peoria County</option>
+		<option value="/CircuitCourt/CircuitMap/6th.asp#Piatt">Piatt County</option>
+		<option value="/CircuitCourt/CircuitMap/8th.asp#Pike">Pike County</option>
+		<option value="/CircuitCourt/CircuitMap/1st.asp#Pope">Pope County</option>
+		<option value="/CircuitCourt/CircuitMap/1st.asp#Pulaski">Pulaski County</option>
+		<option value="/CircuitCourt/CircuitMap/10th.asp#Putnam">Putnam County</option>
+		<option value="/CircuitCourt/CircuitMap/20th.asp#Randolph">Randolph County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Richland">Richland County</option>
+		<option value="/CircuitCourt/CircuitMap/14th.asp#RockIsland">Rock Island County</option>
+		<option value="/CircuitCourt/CircuitMap/20th.asp#St.Clair">St. Clair County</option>
+		<option value="/CircuitCourt/CircuitMap/1st.asp#Saline">Saline County</option>
+		<option value="/CircuitCourt/CircuitMap/7th.asp#Sangamon">Sangamon County</option>
+		<option value="/CircuitCourt/CircuitMap/8th.asp#Schuyler">Schuyler County</option>
+		<option value="/CircuitCourt/CircuitMap/7th.asp#Scott">Scott County</option>
+		<option value="/CircuitCourt/CircuitMap/4th.asp#Shelby">Shelby County</option>
+		<option value="/CircuitCourt/CircuitMap/10th.asp#Stark">Stark County</option>
+		<option value="/CircuitCourt/CircuitMap/15th.asp#Stephenson">Stephenson County</option>
+		<option value="/CircuitCourt/CircuitMap/10th.asp#Tazewell">Tazewell County</option>
+		<option value="/CircuitCourt/CircuitMap/1st.asp#Union">Union County</option>
+		<option value="/CircuitCourt/CircuitMap/5th.asp#Vermilion">Vermilion County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Wabash">Wabash County</option>
+		<option value="/CircuitCourt/CircuitMap/9th.asp#Warren">Warren County</option>
+		<option value="/CircuitCourt/CircuitMap/20th.asp#Washington">Washington County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#Wayne">Wayne County</option>
+		<option value="/CircuitCourt/CircuitMap/2nd.asp#White">White County</option>
+		<option value="/CircuitCourt/CircuitMap/14th.asp#Whiteside">Whiteside County</option>
+		<option value="/CircuitCourt/CircuitMap/12th.asp#Will">Will County</option>
+		<option value="/CircuitCourt/CircuitMap/1st.asp#Williamson">Williamson County</option>
+		<option value="/CircuitCourt/CircuitMap/17th.asp#Winnebago">Winnebago County</option>
+		<option value="/CircuitCourt/CircuitMap/11th.asp#Woodford">Woodford County</option>
+        </select>
+    </form>
+	</div>
+
+	<div style="padding-top:100px"><img src="/images/transparent.gif" alt="spacer gif" height="50px" /></div>
+	</td>
+	</tr>
+	</table>
+	<!-- end table to hold left nav -->
+
+</td>
+
+
+
+	<!--Center content begins here -->
+    <td valign="top" class="center">
+	<table width="380" border="1" align="right" bordercolor="#011184">
+      <tr>
+        <td width="380" height="50"><div style="font-size:11px;color:#666666;margin-left:4pt;margin-top:2px;font-weight:bold"><span style="font-weight:bold">The Illinois Courts now offer two ways to be notified of news and court-related information. </span></div>
+            <ul style="margin-top:1px">
+              <li><span class="style8"><a href="http://twitter.com/illinoiscourts" target="_blank">Illinois Courts Twitter Account</a> <img src="../images/twitter_sm.gif" width="16" height="21" border="0" /></span></li>
+              <li><span class="style8"> <a href="sub_sup.asp">E-mail List Notification </a><img src="../images/SubscribeButton_01.gif" width="100" border="0" height="17" /></span></li>
+            </ul></td>
+      </tr>
+    </table>
+	<h1>Recent Supreme Court Opinions</h1>
+	<hr align="left" style="margin-top:5px;width:350px;height:1px" />
+
+	<p>&nbsp;</p>
+	<table class="content">
+			<tr>
+			<td height="0" align="left" valign="top">
+
+<div>
+<span style="font-size:14px">Search Opinions:</span>
+<div id="cse" style="width: 50%;">Loading</div>
+<script src="http://www.google.com/jsapi" type="text/javascript"></script>
+<script type="text/javascript">
+  google.load('search', '1', {language : 'en'});
+  google.setOnLoadCallback(function() {
+    var customSearchOptions = {};
+    var customSearchControl = new google.search.CustomSearchControl(
+      '004275949654453169572:gctadjgzmac', customSearchOptions);
+    customSearchControl.setResultSetSize(google.search.Search.FILTERED_CSE_RESULTSET);
+    customSearchControl.draw('cse');
+  }, true);
+</script>
+<link rel="stylesheet" href="http://www.google.com/cse/style/look/default.css" type="text/css" />
+</div><br />
+			      The following opinions were uploaded to the Illinois Courts Web Site on the indicated Posted date. This listing will be maintained for 90 days at which time the oldest opinions will be moved to an <a href="archive.asp">Archive table.</a><br />
+                    <br />
+                  All Opinions are in PDF format. To view a PDF file you will need <a href="http://www.adobe.com/products/acrobat/readstep2.html" target="_blank">Adobe Acrobat Reader</a> which is available free of charge.</p>
+		          <p><strong>NRel</strong> beside case number indicates slip opinion not yet released for
+		            publication.<br />
+              <strong>Official Reports </strong> indicates the final, released version of the opinion.<br />
+		            For additional information, please read <a href="caution.asp">A Caution on Court Opinions</a>. </p>
+		          <p><span class="style2"><strong>Sorting Opinions</strong>: Opinions may be sorted by 'Posting Date', 'Filing Date', 'Docket #', 'Public Domain Citation #&quot;, or 'Case Name.' &nbsp;</span><span class="style2">Click on the column name/header, the opinions will sort in descending/ascending order.</span></p>
+		          <!-- REPLACE ABOVE CODE -->
+                  <!-- LEAVE BELOW CODE -->
+<h3><strong>For opinions older than 90 days, please go to our <a href="../Opinions/archive.asp">Opinions Archive</a> page.</strong></h3>		  </td>
+		</tr>
+	  </table>
+    <table id="decisions" border="1" cellspacing="0" bgcolor="#FFFFFF" cellpadding="2" width="100%">
+      <thead class="sortable">
+        <tr>
+          <th width="12%" height="43" align="center" valign="middle" nowrap="nowrap"
+		 bordercolor="#C0C0C0" bgcolor="#edf3ff" class="sortable"><div align="center">Posting Date</div></th>
+          <th class="sortable" width="12%" align="center" valign="middle" nowrap="nowrap"
+		 bordercolor="#C0C0C0" bgcolor="#edf3ff"><div align="center"><strong>Filing Date</strong></div></th>
+          <th class="sortable" width="12%" valign="middle" bordercolor="#C0C0C0" bgcolor="#edf3ff"> <div align="center"><strong>Docket #</strong></div></th>
+          <th class="sortable" width="20%" valign="middle" bordercolor="#C0C0C0" bgcolor="#edf3ff"><div align="center"><strong>Public Domain <br />
+            Citation #</strong></div></th>
+          <th class="sortable"
+		 valign="middle" bordercolor="#C0C0C0" bgcolor="#edf3ff"> <div align="center"><strong><br />
+            Case Name</strong> <strong>(PDF)</strong></div></th>
+          <th width="12%" valign="middle" bordercolor="#C0C0C0" bgcolor="#edf3ff"> <div align="center"><strong>Case Summary</strong></div></th>
+		 </tr>
+
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118181 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118181 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118181.pdf">People v. Timmsen</a> </div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118181s.pdf"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+		  </tr>
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118422 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118422 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118422.pdf">State of Illinois v. American Federation of State, County &amp; Municipal Employees, Council 31 </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118422s.pdf"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+		  </tr>
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118674 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118674 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118674.pdf">People v. Bradford </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118674s.pdf"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+		  </tr>
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118845 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118845 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118845.pdf">People v. Clark</a> </div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118845s.pdf"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+		  </tr>
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118973 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118973 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118973.pdf">People v. Burns </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118973s.pdf"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+		  </tr>
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">119181 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 119181 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/119181.pdf">Vaughn v. City of Carbondale </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/119181s.pdf"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+		  </tr>
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/24/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">119618, 119620,  119638, 119639,<br />  	    119644 cons.</div></td>
+		  <td valign="top"><div align="left">2016 IL 119618 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/119618.pdf">Jones v. Municipal Employees' Annuity &amp; Benefit Fund </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/119618s.pdf"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+		  </tr>
+
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/03/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118693 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118693 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118693.pdf">People v. Salem </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118693s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/03/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">115769 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 115769 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/115769.pdf">People v. Cummings</a> </div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/115769s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/03/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">117911 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 117911 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/117911.pdf">People v. Chambers </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/117911s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/03/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">117952 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 117952 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/117952.pdf">Coleman v. East Joliet Fire Protection District </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/117952s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/03/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118123 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118123 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118123.pdf">People v. Sanders </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118123s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/03/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118217 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118217 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118217.pdf">Klaine v. Southern Illinois Hospital Services </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118217s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/03/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118375 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118375 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118375.pdf">People v. Williams </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118375s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">03/03/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118496 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118496 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118496.pdf">People v. Lerma </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118496s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">02/26/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">02/26/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118661 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118661 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118661.pdf">People v. Boston</a> </div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118661s.pdf"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+		  </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">02/19/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">02/19/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118023 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118023 </div></td>
+		  <td valign="top"><a href="SupremeCourt/2016/118023.pdf">People v. Ligon</a></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118023s.pdf"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+
+
+
+
+
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">02/04/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">02/04/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118562 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118562 </div></td>
+		  <td valign="top"><a href="SupremeCourt/2016/118562.pdf">Petrovic v. The Department of Employment Security</a></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118562s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+
+
+
+
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/28/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">11/04/15</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118139 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2015 IL 118139 </div></td>
+		  <td valign="top"><a href="SupremeCourt/2015/118139.pdf">Henderson Square Condominium Association v. LAB Townhomes, LLC</a> -  <span class="style2">Modified on Denial of Rehearing 1/28/16 </span></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/118139s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+
+
+        <tr>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center">01/25/16</div></td>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center">12/17/15</div></td>
+          <td valign="top" nowrap="nowrap"><div align="left">117242 <strong>Offical Reports </strong></div></td>
+          <td valign="top"><div align="left">2015 IL 117242 </div></td>
+          <td valign="top"><div align="left"><a href="SupremeCourt/2015/117242.pdf">People v. Hughes </a></div></td>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/117242s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+        </tr>
+        <tr>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center">01/25/16</div></td>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center">12/17/15</div></td>
+          <td valign="top" nowrap="nowrap"><div align="left">117387<strong>Offical Reports</strong></div></td>
+          <td valign="top"><div align="left">2015 IL 117387 </div></td>
+          <td valign="top"><div align="left"><a href="SupremeCourt/2015/117387.pdf">People v. Burns </a></div></td>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/117387s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+        </tr>
+        <tr>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center">01/25/16</div></td>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center">12/17/15</div></td>
+          <td valign="top" nowrap="nowrap"><div align="left">118043, 118072 cons. <strong>Offical Reports</strong></div></td>
+          <td valign="top"><div align="left">2015 IL 118043 </div></td>
+          <td valign="top"><div align="left"><a href="SupremeCourt/2015/118043.pdf">Board of Education of the City of Chicago v. Illinois Educational Labor Relations Board </a></div></td>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/118043s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+        </tr>
+        <tr>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center">01/25/16</div></td>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center">12/17/15</div></td>
+          <td valign="top" nowrap="nowrap"><div align="left">119178 <strong>Offical Reports</strong></div></td>
+          <td valign="top"><div align="left">2015 IL 119178 </div></td>
+          <td valign="top"><div align="left"><a href="SupremeCourt/2015/119178.pdf">In re Michael D.</a> </div></td>
+          <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/119178s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+        </tr>
+		 </thead>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">117846 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 117846 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/117846.pdf">People v. Tolbert </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/117846s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/22/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap">01/22/16</td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118667 <strong>NRel</strong></div></td>
+		  <td valign="top"><div align="left">2016 IL 118667 </div></td>
+		  <td valign="top"><div align="left"><a href="SupremeCourt/2016/118667.pdf">People v. Thompson </a></div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2016/Summaries/118667s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/08/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">12/03/15</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">117709 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2015 IL 117709 </div></td>
+		  <td valign="top"><a href="SupremeCourt/2015/117709.pdf">People v. Carter</a></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/117709s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/08/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">12/03/15</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">117789 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2015 IL 117789 </div></td>
+		  <td valign="top"><a href="SupremeCourt/2015/117789.pdf">People v. Schweihs</a></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/117789s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/08/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">12/03/15</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118151 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2015 IL 118151 </div></td>
+		  <td valign="top"><a href="SupremeCourt/2015/118151.pdf">People v. Thompson</a></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/118151s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/08/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">12/03/15</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118218 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2015 IL 118218 </div></td>
+		  <td valign="top"><a href="SupremeCourt/2015/118218.pdf">People v. Espinoza</a></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/118218s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/08/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">12/03/15</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118372 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2015 IL 118372 </div></td>
+		  <td valign="top"><a href="SupremeCourt/2015/118372.pdf">1010 Lake Shore Association v. Deutsche Bank National Trust Company</a></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/118372s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+		<tr>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">01/08/16</div></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center">12/03/15</div></td>
+		  <td valign="top" nowrap="nowrap"><div align="left">118975 <strong>Official Reports</strong></div></td>
+		  <td valign="top"><div align="left">2015 IL 118975 </div></td>
+		  <td valign="top"><a href="SupremeCourt/2015/118975.pdf">DG Enterprises v. Cornelius</a></td>
+		  <td align="center" valign="top" nowrap="nowrap"><div align="center"><a href="SupremeCourt/2015/Summaries/118975s.htm"><img src="../images/i_text.gif" alt="Summary graphic" width="15" height="15" border="0" /></a></div></td>
+	    </tr>
+    </table>
+	<p>&nbsp;</p></td>
+
+  </tr>
+</table>
+<!--The bottom of the page -->
+
+<table class="footer">
+<tr>
+<td colspan="3" align="center" bgcolor="#FFFFFF"><span style="font-size:10px">
+<a href="http://www.illinois.gov" target="_blank">State of Illinois</a> |
+<a href="/Privacy.asp">Privacy Notice</a> | <a href="/Endorse.asp">Endorsement Notice</a> | <a href="mailto:webmaster@illinoiscourts.gov">Webmaster</a></span></td>
+</tr>
+</table>
+
+
+
+<!-- Google analytics -->
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-2592670-2', 'auto');
+  ga('send', 'pageview');
+
+</script>
+<!-- end -->
+
+
+<!-- javascript for rotating photos -->
+<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js"></script>
+  <script>
+		$(function() {
+
+			$("#slideshow > div:gt(0)").hide();
+
+			setInterval(function() {
+			  $('#slideshow > div:first')
+			    .fadeOut(7000)
+			    .next()
+			    .fadeIn(7000)
+			    .end()
+			    .appendTo('#slideshow');
+			},  7000);
+
+		});
+	</script>
+
+<script type='text/javascript'>function GO() {return}</script>
+<script type='text/javascript' src='/menu_newdomain.js'></script>
+<script type='text/javascript' src='/menu_com.js'></script><noscript>Your browser does not support script</noscript>
+
+</body>
+</html>


### PR DESCRIPTION
The ill court recently posted opinions that have non-standard formatting (excluded precedential status strings, and docket numbers broken over multiple lines), which was causing the scraper to fail.  This commit fixes the parsing to handle these cases, and includes a new test html file to test against them.