### PR TITLE
Fixing ca6 and kan/kanctapp

### DIFF
--- a/juriscraper/opinions/united_states/federal_appellate/ca6.py
+++ b/juriscraper/opinions/united_states/federal_appellate/ca6.py
@@ -1,94 +1,42 @@
-import time
-from datetime import date, timedelta
-
 from juriscraper.OpinionSite import OpinionSite
-from dateutil.rrule import rrule, DAILY
+from juriscraper.lib.string_utils import convert_date_string
 
 
 class Site(OpinionSite):
     def __init__(self, *args, **kwargs):
         super(Site, self).__init__(*args, **kwargs)
-        self.url = 'http://www.ca6.uscourts.gov/cgi-bin/opinions.pl'
-        self.method = 'POST'
-        self.parameters = {
-            'CASENUM': '',
-            'TITLE': '',
-            'FROMDATE': date.strftime(date.today(), '%m/%d/%Y'),
-            'TODATE': date.strftime(date.today(), '%m/%d/%Y'),
-            'OPINNUM': ''
-        }
         self.court_id = self.__module__
-        self.interval = 30
-        self.back_scrape_iterable = [i.date() for i in rrule(
-            DAILY,
-            interval=self.interval,  # Every interval days
-            dtstart=date(2000, 1, 1),
-            until=date(2016, 1, 1),
-        )]
+        self.url = 'http://www.opn.ca6.uscourts.gov/opinions/opinions.php'
 
     def _get_case_names(self):
-        return [e for e in self.html.xpath('//table/tr/td[4]/text()[1]')]
+        return [string.split(' - ')[0] for string in self.get_nth_table_cell_data(4)]
 
     def _get_download_urls(self):
-        return [e for e in self.html.xpath('//table/tr/td[1]/a/@href')]
+        return self.get_nth_table_cell_data(1, href=True)
 
     def _get_case_dates(self):
-        dates = []
-        for text_string in self.html.xpath('//table/tr/td[3]/text()'):
-            date_string = text_string.strip()
-            dates.append(date.fromtimestamp(time.mktime(time.strptime(date_string, '%Y/%m/%d'))))
-        return dates
+        return [convert_date_string(date) for date in self.get_nth_table_cell_data(3)]
 
     def _get_docket_numbers(self):
-        return [num.strip() for num in self.html.xpath('//table/tr/td[2]/a/text()')]
+        return self.get_nth_table_cell_data(2)
 
     def _get_precedential_statuses(self):
         statuses = []
-        for filename in self.html.xpath('//table/tr/td[1]/a/text()'):
-            if 'n' in filename.lower():
+        for file_name in self.get_nth_table_cell_data(1, link_text=True):
+            if 'n' in file_name.lower():
                 statuses.append('Unpublished')
-            elif 'p' in filename.lower():
+            elif 'p' in file_name.lower():
                 statuses.append('Published')
             else:
                 statuses.append('Unknown')
         return statuses
 
-    def _get_lower_courts(self):
-        lower_courts = []
-        for e in self.html.xpath('//tr[position() > 1]/td[4]/font'):
-            try:
-                lower_courts.append(e.xpath('./text()')[0].strip())
-            except IndexError:
-                lower_courts.append('')
-        return lower_courts
-
-    def _download_backwards(self, d):
-        self.parameters = {
-            'CASENUM': '',
-            'TITLE': '',
-            'FROMDATE': d.strftime('%m/%d/%Y'),
-            'TODATE': (d + timedelta(self.interval)).strftime('%m/%d/%Y'),
-            'OPINNUM': ''
-        }
-
-        self.html = self._download()
-        if self.html is not None:
-            # Setting status is important because it prevents the download
-            # function from being run a second time by the parse method.
-            self.status = 200
-
-    def _post_parse(self):
-        """This will remove the cases without a case name"""
-        to_be_removed = [index for index, case_name in
-                         enumerate(self.case_names)
-                         if not case_name.replace('v.', '').strip()]
-
-        for attr in self._all_attrs:
-            item = getattr(self, attr)
-            if item is not None:
-                new_item = self.remove_elements(item, to_be_removed)
-                self.__setattr__(attr, new_item)
-
-    @staticmethod
-    def remove_elements(list_, indexes_to_be_removed):
-        return [i for j, i in enumerate(list_) if j not in indexes_to_be_removed]
+    def get_nth_table_cell_data(self, n, href=False, link_text=False):
+        path = '//table/tr/td[%d]' % n
+        if href:
+            path += '/a/@href'
+        elif link_text:
+            path += '/a/text()'
+        else:
+            path += '/text()'
+        return [data.strip() for data in self.html.xpath(path) if data.strip()]

--- a/tests/examples/opinions/united_states/ca6_example.html
+++ b/tests/examples/opinions/united_states/ca6_example.html
@@ -1,87 +1,669 @@
-<html><head><title>USCA6 Opinions List</title></head><body topmargin="0" bgcolor="white" link="blue" vlink="blue" alink="blue">
-<a href="http://www.ca6.uscourts.gov/default.htm">CA6 Home</a>
-<p>
-&#160; &#160;
-<font size="+1">
-Opinions in the cases listed below were filed by the U.S. Court of Appeals for the Sixth Circuit:
-</font>
-<br><br>
-        &#160;&#160;&#160;
-        PUBLISHED OPINIONS<br></p><table width="98%" bgcolor="lightblue" align="center" border="1"><tr bgcolor="lightblue"><th><b>Opinion</b></th>
-        <th><b>DocketSheet</b></th>
-        <th><b>Pub Date</b></th>
-        <th><b>Short Title/District</b></th>
-        </tr><tr bgcolor="#FAFFFD"><td align="center">
-    <a href="http://www.ca6.uscourts.gov/opinions.pdf/12a0053p-06.pdf">12a0053p.06</a>
-    </td><td align="center">
-<a href="http://www.ca6.uscourts.gov/paceruser.html">   10-3590</a>
-    </td><td align="center">2012/02/24
-    </td><td>&#160;Dion Berryman v. SuperValu Holdings, Inc.
-        <br>&#160;&#160;&#160;
-        <font size="-1">Southern District of Ohio at Dayton</font>
-    </td></tr><tr bgcolor="#FAFFFD"><td align="center">
-    <a href="http://www.ca6.uscourts.gov/opinions.pdf/12a0054p-06.pdf">12a0054p.06</a>
-    </td><td align="center">
-<a href="http://www.ca6.uscourts.gov/paceruser.html">   10-3092</a>
-    </td><td align="center">2012/02/24
-    </td><td>&#160;USA v. Thomas Cunningham
-        <br>&#160;&#160;&#160;
-        <font size="-1">Northern District of Ohio at Cleveland</font>
-</td></tr></table><p>
-        &#160;&#160;&#160;
-        NOT RECOMMENDED FOR FULL-TEXT PUBLICATION OPINIONS<br>
-        &#160;&#160;&#160;&#160;&#160;&#160;
-        NOTE: The "Filed" date for an unpublished opinion is not
-        always the date on which it is posted.
-        <br>&#160;&#160;&#160;&#160;&#160;&#160;
-        Please check the opinion for the correct filed date.
-        </p><table width="98%" align="center" border="1" bgcolor="lightblue"><tr bgcolor="lightblue"><th><b>Opinion</b></th>
-        <th><b>DocketSheet</b></th>
-        <th><b>Pub Date</b></th>
-        <th><b>Short Title/District</b></th>
-        </tr><tr bgcolor="#FAFFFD"><td align="center">
-    <a href="http://www.ca6.uscourts.gov/opinions.pdf/12a0220n-06.pdf">12a0220n.06</a>
-    </td><td align="center">
-    <a href="http://pacer.ca6.uscourts.gov/cgi-bin/reports.pl?CASENUM=08-2269&amp;puid=">
-    08-2269</a>
-    </td><td align="center">2012/02/24
-    </td><td>&#160;Benjamin McCoy v. Kurt Jones
-        <br>&#160;&#160;&#160;
-        <font size="-1">Eastern District of Michigan at Detroit</font>
-    </td></tr><tr bgcolor="#FAFFFD"><td align="center">
-    <a href="http://www.ca6.uscourts.gov/opinions.pdf/12a0221n-06.pdf">12a0221n.06</a>
-    </td><td align="center">
-    <a href="http://pacer.ca6.uscourts.gov/cgi-bin/reports.pl?CASENUM=10-4528&amp;puid=">
-    10-4528</a>
-    </td><td align="center">2012/02/24
-    </td><td>&#160;Jamie Ratliff v. Commissioner of Social Security
-        <br>&#160;&#160;&#160;
-        <font size="-1">Northern District of Ohio at Cleveland</font>
-    </td></tr><tr bgcolor="#FAFFFD"><td align="center">
-    <a href="http://www.ca6.uscourts.gov/opinions.pdf/12a0222n-06.pdf">12a0222n.06</a>
-    </td><td align="center">
-    <a href="http://pacer.ca6.uscourts.gov/cgi-bin/reports.pl?CASENUM=10-6059&amp;puid=">
-    10-6059</a>
-    </td><td align="center">2012/02/24
-    </td><td>&#160;USA v. Gary Fleming
-        <br>&#160;&#160;&#160;
-        <font size="-1">Eastern District of Tennessee at Winchester</font>
-    </td></tr><tr bgcolor="#FAFFFD"><td align="center">
-    <a href="http://www.ca6.uscourts.gov/opinions.pdf/12a0223n-06.pdf">12a0223n.06</a>
-    </td><td align="center">
-    <a href="http://pacer.ca6.uscourts.gov/cgi-bin/reports.pl?CASENUM=10-6107&amp;puid=">
-    10-6107</a>
-    </td><td align="center">2012/02/24
-    </td><td>&#160;USA v. Paul Marriott
-        <br>&#160;&#160;&#160;
-        <font size="-1">Eastern District of Tennessee at Greeneville</font>
-    </td></tr><tr bgcolor="#FAFFFD"><td align="center">
-    <a href="http://www.ca6.uscourts.gov/opinions.pdf/12a0224n-06.pdf">12a0224n.06</a>
-    </td><td align="center">
-    <a href="http://pacer.ca6.uscourts.gov/cgi-bin/reports.pl?CASENUM=10-6559&amp;puid=">
-    10-6559</a>
-    </td><td align="center">2012/02/24
-    </td><td>&#160;USA v. Donnie Justice
-        <br>&#160;&#160;&#160;
-        <font size="-1">Eastern District of Kentucky at Covington</font>
-</td></tr></table><br></body></html>
+<!DOCTYPE html>
+  <!--[if IEMobile 7]><html class="no-js ie iem7" lang="en" dir="ltr"><![endif]-->
+  <!--[if lte IE 6]><html class="no-js ie lt-ie9 lt-ie8 lt-ie7" lang="en" dir="ltr"><![endif]-->
+  <!--[if (IE 7)&(!IEMobile)]><html class="no-js ie lt-ie9 lt-ie8" lang="en" dir="ltr"><![endif]-->
+  <!--[if IE 8]><html class="no-js ie lt-ie9" lang="en" dir="ltr"><![endif]-->
+  <!--[if (gte IE 9)|(gt IEMobile 7)]><html class="no-js ie" lang="en" dir="ltr" prefix="content: http://purl.org/rss/1.0/modules/content/ dc: http://purl.org/dc/terms/ foaf: http://xmlns.com/foaf/0.1/ og: http://ogp.me/ns# rdfs: http://www.w3.org/2000/01/rdf-schema# sioc: http://rdfs.org/sioc/ns# sioct: http://rdfs.org/sioc/types# skos: http://www.w3.org/2004/02/skos/core# xsd: http://www.w3.org/2001/XMLSchema#"><![endif]-->
+  <!--[if !IE]><!--><html class="no-js" lang="en" dir="ltr" prefix="content: http://purl.org/rss/1.0/modules/content/ dc: http://purl.org/dc/terms/ foaf: http://xmlns.com/foaf/0.1/ og: http://ogp.me/ns# rdfs: http://www.w3.org/2000/01/rdf-schema# sioc: http://rdfs.org/sioc/ns# sioct: http://rdfs.org/sioc/types# skos: http://www.w3.org/2004/02/skos/core# xsd: http://www.w3.org/2001/XMLSchema#"><!--<![endif]-->
+<head>
+  <meta http-equiv="X-UA-Compatible" content="IE=9; IE=8; IE=7" />
+<meta charset="utf-8" />
+<link rel="apple-touch-icon" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon.png" />
+<link rel="apple-touch-icon" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon-57x57.png" sizes="57x57" />
+<link rel="apple-touch-icon" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon-114x114.png" sizes="114x114" />
+<link rel="apple-touch-icon-precomposed" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon-precomposed-72x72.png" sizes="72x72" />
+<link rel="apple-touch-icon" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon-60x60.png" sizes="60x60" />
+<link rel="apple-touch-icon-precomposed" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon-precomposed-114x114.png" sizes="114x114" />
+<link rel="apple-touch-icon" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon-72x72.png" sizes="72x72" />
+<link rel="apple-touch-icon-precomposed" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon-precomposed-196x196.png" sizes="196x196" />
+<link rel="apple-touch-icon-precomposed" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon-precomposed.png" />
+<link rel="apple-touch-icon" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon-76x76.png" sizes="76x76" />
+<link rel="profile" href="http://www.w3.org/1999/xhtml/vocab" />
+<link rel="shortcut icon" href="http://www.ca6.uscourts.gov/sites/all/themes/appeals/favicon.ico" type="image/vnd.microsoft.icon" />
+<meta name="Generator" content="Drupal 7 (http://drupal.org)" />
+<meta name="HandheldFriendly" content="true" />
+<meta name="MobileOptimized" content="width" />
+<link rel="apple-touch-icon-precomposed" href="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/apple-touch-icon-precomposed-152x152.png" sizes="152x152" />
+<meta http-equiv="cleartype" content="on" />
+<meta name="viewport" content="width=device-width" />
+  <title>Opinions | Sixth Circuit | United States Court of Appeals</title>
+  <style>
+  @font-face {
+  font-family: merriweather-regular;
+  src: url("../fonts/merriweather-regular/merriweather-regular-webfont.eot");
+  src: url("../fonts/merriweather-regular/merriweather-regular-webfont.eot?#iefix") format("embedded-opentype"), url("../fonts/merriweather-regular/merriweather-regular-webfont.woff") format("woff"), url("../fonts/merriweather-regular/merriweather-regular-webfont.ttf") format("truetype"), url("../fonts/merriweather-regular/merriweather-regular-webfont.svg#merriweather-regular") format("svg");
+  font-weight: 300;
+  font-style: normal;
+}
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/omega/omega/css/modules/system/system.base.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/omega/omega/css/modules/system/system.menus.theme.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/omega/omega/css/modules/system/system.messages.theme.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/omega/omega/css/modules/system/system.theme.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/calendar/css/calendar_multiday.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/date/date_api/date.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/date/date_popup/themes/datepicker.1.7.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/modules/node/node.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/omega/omega/css/modules/comment/comment.theme.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/features/us_courts_court_calendar/css/uscourts_calendar.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/omega/omega/css/modules/field/field.theme.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/features/us_courts_file_management/css/us_courts_file_management.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/extlink/extlink.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/omega/omega/css/modules/search/search.theme.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/views/css/views.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/omega/omega/css/modules/user/user.base.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/omega/omega/css/modules/user/user.theme.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/ckeditor/css/ckeditor.css?o8rzqb");
+</style>
+<style>
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/jquery_update/replace/ui/themes/base/minified/jquery.ui.core.min.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/cstbase/css/jquery_ui/jquery-ui.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/jquery_update/replace/ui/themes/base/minified/jquery.ui.button.min.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/jquery_update/replace/ui/themes/base/minified/jquery.ui.resizable.min.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/jquery_update/replace/ui/themes/base/minified/jquery.ui.dialog.min.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/ctools/css/ctools.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/custom_search/custom_search.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/contrib/responsive_menus/styles/meanMenu/meanmenu.min.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/custom/us_courts_home_slider/css/flexslider.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/modules/custom/us_courts_home_slider/css/us_courts_home_slider.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/libraries/fontawesome/css/font-awesome.css?o8rzqb");
+</style>
+<style>
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/cstbase/css/cstbase.normalize.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/cstbase/css/cstbase.hacks.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/cstbase/css/cstbase.styles.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/adaptive/css/adaptive.normalize.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/adaptive/css/adaptive.hacks.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/adaptive/css/adaptive.styles.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/appeals/css/appeals.normalize.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/appeals/css/appeals.hacks.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/appeals/css/appeals.styles.css?o8rzqb");
+</style>
+
+<!--[if lte IE 8]>
+<style>
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/cstbase/css/cstbase.no-query.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/adaptive/css/adaptive.no-query.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/appeals/css/appeals.no-query.css?o8rzqb");
+</style>
+<![endif]-->
+<style>
+@import url("http://www.ca6.uscourts.gov/sites/all/themes/adaptive/css/layouts/adaptive/adaptive.layout.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/ca6/files/css_injector/css_injector_8.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/ca6/files/css_injector/css_injector_9.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/ca6/files/css_injector/css_injector_12.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/ca6/files/css_injector/css_injector_13.css?o8rzqb");
+@import url("http://www.ca6.uscourts.gov/sites/ca6/files/css_injector/css_injector_14.css?o8rzqb");
+</style>
+  <script src="http://www.ca6.uscourts.gov/sites/all/libraries/modernizr/modernizr.custom.45361.js?o8rzqb"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
+<script>window.jQuery || document.write("<script src='/sites/all/modules/contrib/jquery_update/replace/jquery/1.8/jquery.min.js'>\x3C/script>")</script>
+<script src="http://www.ca6.uscourts.gov/misc/jquery.once.js?v=1.2"></script>
+<script src="http://www.ca6.uscourts.gov/misc/drupal.js?o8rzqb"></script>
+<script src="http://www.ca6.uscourts.gov/sites/all/themes/omega/omega/js/no-js.js?o8rzqb"></script>
+<script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.2/jquery-ui.min.js"></script>
+<script>window.jQuery.ui || document.write("<script src='/sites/all/modules/contrib/jquery_update/replace/ui/ui/minified/jquery-ui.min.js'>\x3C/script>")</script>
+<script src="http://www.ca6.uscourts.gov/sites/all/modules/custom/us_courts_helpers/js/json2.js?o8rzqb"></script>
+<script src="http://www.ca6.uscourts.gov/sites/all/modules/custom/us_courts_home_slider/js/jquery.flexslider-min.js?o8rzqb"></script>
+<script src="http://www.ca6.uscourts.gov/sites/all/modules/custom/us_courts_home_slider/js/home_slider.js?o8rzqb"></script>
+<script src="http://www.ca6.uscourts.gov/sites/all/modules/contrib/extlink/extlink.js?o8rzqb"></script>
+<script src="http://www.ca6.uscourts.gov/sites/all/modules/contrib/custom_search/js/custom_search.js?o8rzqb"></script>
+<script src="http://www.ca6.uscourts.gov/sites/all/modules/contrib/responsive_menus/styles/meanMenu/jquery.meanmenu.min.js?o8rzqb"></script>
+<script src="http://www.ca6.uscourts.gov/sites/all/modules/contrib/responsive_menus/styles/meanMenu/responsive_menus_mean_menu.js?o8rzqb"></script>
+<script src="http://www.ca6.uscourts.gov/sites/all/modules/contrib/google_analytics/googleanalytics.js?o8rzqb"></script>
+<script>(function(i,s,o,g,r,a,m){i["GoogleAnalyticsObject"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,"script","//www.google-analytics.com/analytics.js","ga");ga("create", "UA-78958293-1", {"cookieDomain":"auto"});ga("set", "anonymizeIp", true);ga("send", "pageview");</script>
+<script src="http://www.ca6.uscourts.gov/sites/all/themes/cstbase/js/cstbase.behaviors.js?o8rzqb"></script>
+<script src="http://www.ca6.uscourts.gov/sites/all/themes/adaptive/js/jquery.horizontalNav.min.js?o8rzqb"></script>
+<script src="http://www.ca6.uscourts.gov/sites/all/themes/adaptive/js/adaptive.behaviors.js?o8rzqb"></script>
+<script>jQuery.extend(Drupal.settings, {"basePath":"\/","pathPrefix":"","custom_search":{"form_target":"_self","solr":0},"responsive_menus":[{"selectors":"#main-menu, #block-superfish-1, .l-region--header .menu-name-main-menu","trigger_txt":"\u0026#8801; MENU","close_txt":"X CLOSE","close_size":"1em","position":"left","media_size":"960","show_children":"1","expand_children":"1","expand_txt":"\u25bc","contract_txt":"\u25b2","remove_attrs":"1","responsive_menus_style":"mean_menu"}],"us_courts_extlink":{"extlink_default_text":"You are now leaving the website of the Sixth Circuit. The link below contains information created and maintained by other public and private organizations.\r\n\r\nThis link is provided for the user\u0027s convenience. The Sixth Circuit does not control or guarantee the accuracy, relevance, timeliness, or completeness of this outside information; nor does it control or guarantee the ongoing availability, maintenance, or security of this Internet site. Further, the inclusion of links is not intended to reflect their importance or to endorse any views expressed, or products or services offered, on these outside sites, or the organizations sponsoring the sites."},"extlink":{"extTarget":"_blank","extClass":0,"extLabel":"(link is external)","extImgClass":0,"extSubdomains":1,"extExclude":"(-admin.jdc.ao.dcn)|(-dev.jdc.ao.dcn)","extInclude":"(pdf)$","extCssExclude":".main-slider","extCssExplicit":"","extAlert":0,"extAlertText":"You are now leaving the website of the Sixth Circuit. The link below contains information created and maintained by other public and private organizations.\r\n\r\nThis link is provided for the user\u0027s convenience. The Sixth Circuit does not control or guarantee the accuracy, relevance, timeliness, or completeness of this outside information; nor does it control or guarantee the ongoing availability, maintenance, or security of this Internet site. Further, the inclusion of links is not intended to reflect their importance or to endorse any views expressed, or products or services offered, on these outside sites, or the organizations sponsoring the sites.","mailtoClass":0,"mailtoLabel":"(link sends e-mail)"},"googleanalytics":{"trackOutbound":1,"trackMailto":1,"trackDownload":1,"trackDownloadExtensions":"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip"},"urlIsAjaxTrusted":{"\/rules-and-procedures":true}});</script>
+</head>
+<body class="html not-front not-logged-in page-rules-and-procedures section-rules-and-procedures">
+
+    <div id="header-outline">
+<div id="page-wrapper">
+  <div class="l-page has-no-sidebars">
+
+    <!-- Header -->
+    <header class="l-header" role="banner">
+      <div class="l-branding">
+                  <a href="http://www.ca6.uscourts.gov" title="Home" rel="home" class="site-logo"><img src="http://www.ca6.uscourts.gov/sites/ca6/files/logo.png" alt="Home" /></a>
+
+        <div class="court-info">
+                      <h1 class="court-title"><a href="http://www.ca6.uscourts.gov" title="Home" rel="home"><span>United States Court of Appeals</span></a></h1>
+
+
+                          <h2 class="site-name">
+                <a href="http://www.ca6.uscourts.gov" title="Home" rel="home">
+                  <span class="pretitle">for the</span>                  Sixth Circuit                </a>
+              </h2>
+
+                          <h1 class="site-slogan">
+                <a href="http://www.ca6.uscourts.gov" title="Home" rel="home"><span>R. Guy Cole, Jr., Chief Judge</span></a>
+              </h1>
+
+                  </div>
+
+              </div>
+
+        <div class="l-region l-region--header">
+
+<div id="block-us-courts-stock-font-resizer" class="block block--us-courts-stock text-resizer-block block--us-courts-stock-font-resizer">
+        <div class="block__content">
+    <div class="resizer-wrap clearfix">
+	<span>Text Size: </span>
+	<ul class="resizer">
+		<li class="decrease-font"><a href="#">Decrease font size</a></li>
+		<li class="reset-font"><a href="#">Reset font size</a></li>
+		<li class="increase-font"><a href="#">Increase font size</a></li>
+	</ul>
+</div>  </div>
+</div>
+<nav id="block-menu-block-us-courts-menu-blocks-main-nav" role="navigation" class="block block--menu-block block--menu-block-us-courts-menu-blocks-main-nav">
+
+  <div class="menu-block-wrapper menu-block-us_courts_menu_blocks_main_nav menu-name-main-menu parent-mlid-0 menu-level-1">
+  <ul class="menu"><li class="first expanded menu-mlid-481"><a href="http://www.ca6.uscourts.gov/about-court">About the Court</a><ul class="menu"><li class="first leaf menu-mlid-1116"><a href="http://www.ca6.uscourts.gov/judges">Judges</a></li>
+<li class="leaf menu-mlid-549"><a href="http://www.ca6.uscourts.gov/circuit-history">Circuit History</a></li>
+<li class="leaf menu-mlid-483"><a href="http://www.ca6.uscourts.gov/court-info/court-locations">Contact Information</a></li>
+<li class="leaf menu-mlid-772"><a href="http://www.ca6.uscourts.gov/employment">Employment</a></li>
+<li class="leaf menu-mlid-1047"><a href="http://www.ca6.uscourts.gov/sites/ca6/files/documents/rules_procedures/Electronic_Device.pdf">Electronic Device Policy</a></li>
+<li class="leaf menu-mlid-1048"><a href="http://www.ca6.uscourts.gov/directions">Directions</a></li>
+<li class="leaf menu-mlid-1126"><a href="http://www.ca6.uscourts.gov/about/circuit-executive-staff-directory">Circuit Executive Staff Directory</a></li>
+<li class="leaf menu-mlid-1124"><a href="http://www.ca6.uscourts.gov/clerks-office-staff-directory">Clerk&#039;s Office Staff Directory</a></li>
+<li class="last leaf menu-mlid-1050"><a href="http://www.ca6.uscourts.gov/sites/ca6/files/documents/about_the_court/AdmissionPSC.pdf">Admission to the Courthouse</a></li>
+</ul></li>
+<li class="expanded menu-mlid-488"><a href="http://www.ca6.uscourts.gov/forms-and-fees">Forms and Fees</a><ul class="menu"><li class="first leaf menu-mlid-1129"><a href="http://www.ca6.uscourts.gov/court-forms">Forms</a></li>
+<li class="last leaf menu-mlid-950"><a href="http://www.ca6.uscourts.gov/fees">Fees</a></li>
+</ul></li>
+<li class="leaf menu-mlid-556"><a href="http://www.ca6.uscourts.gov/rules-and-procedures">Rules and Procedures</a></li>
+<li class="expanded menu-mlid-1174"><a href="http://www.ca6.uscourts.gov/opinions-and-oral-argument">Opinions and Oral Argument</a><ul class="menu"><li class="first leaf menu-mlid-1179"><a href="http://www.ca6.uscourts.gov/opinions">Opinions</a></li>
+<li class="leaf menu-mlid-1176"><a href="http://www.ca6.uscourts.gov/oral-argument-calendars">Oral Argument Calendar</a></li>
+<li class="last leaf menu-mlid-1177"><a href="http://www.ca6.uscourts.gov/audio-files-completed-arguments">Audio Files of Completed Arguments</a></li>
+</ul></li>
+<li class="leaf menu-mlid-497"><a href="http://www.ca6.uscourts.gov/attorneys">Attorneys</a></li>
+<li class="leaf menu-mlid-1149"><a href="http://www.ca6.uscourts.gov/criminal-justice-act">Criminal Justice Act</a></li>
+<li class="expanded menu-mlid-913"><a href="http://www.ca6.uscourts.gov/circuit-executive">Circuit Executive</a><ul class="menu"><li class="first leaf menu-mlid-1056"><a href="/judicial-conference">Judicial Conference</a></li>
+<li class="leaf menu-mlid-1058"><a href="http://www.ca6.uscourts.gov/judicial-complaints">Judicial Complaints</a></li>
+<li class="leaf menu-mlid-1059"><a href="http://www.ca6.uscourts.gov/selection-bankruptcy-judges-and-federal-public-defenders">Selection of Bankruptcy Judges and Federal Public Defenders</a></li>
+<li class="last leaf menu-mlid-1148"><a href="http://www.ca6.uscourts.gov/circuit-executive-staff-directory">Circuit Executive Staff Directory</a></li>
+</ul></li>
+<li class="last expanded menu-mlid-631"><a href="http://www.ca6.uscourts.gov/mediation">Mediation</a><ul class="menu"><li class="first leaf menu-mlid-1046"><a href="http://www.ca6.uscourts.gov/about-mediation-conferences">About Mediation Conferences</a></li>
+<li class="leaf menu-mlid-1051"><a href="http://www.ca6.uscourts.gov/confidentiality-local-rule-33">Confidentiality - Local Rule 33</a></li>
+<li class="leaf menu-mlid-1052"><a href="http://www.ca6.uscourts.gov/mediation-contact-information">Mediation Contact Information</a></li>
+<li class="leaf menu-mlid-769"><a href="http://www.ca6.uscourts.gov/court-forms/mediation">Mediation Forms</a></li>
+<li class="leaf menu-mlid-1053"><a href="http://www.ca6.uscourts.gov/remand-procedures-settled-cases">Remand Procedures for Settled Cases</a></li>
+<li class="last leaf menu-mlid-1054"><a href="http://www.ca6.uscourts.gov/circuit-mediators">Circuit Mediators</a></li>
+</ul></li>
+</ul></div>
+</nav>
+  </div>
+          </header>
+
+    <!-- Main Content -->
+    <div id="main-content-wrapper">
+      <div class="l-main">
+
+        <!-- Front page welcome message -->
+
+        <div class="l-welcome">
+                            </div>
+
+        <!-- Main Content -->
+        <div class="l-content" role="main">
+
+
+          <a href="http://www.ca6.uscourts.gov/">Home</a></li></ul>            <a id="main-content"></a>
+
+                      <h1 id="page-title">Opinions</h1>
+
+
+                      <div class="view view-rules-and-procedures view-id-rules_and_procedures view-display-id-page view-dom-id-6a55710207164756a828a9fe89656a73">
+            <div class="view-header">
+      <style type="text/css">
+body h2 {color:#6e0000;}
+</style>    </div>
+
+
+
+
+<html>
+
+
+
+
+
+
+	<h2><span style='color:#6e0000;'>Published Opinions</span></h2>
+	<table Width=100% align=center border=0>
+	<tr>
+	<th><B>Opinion</B></th>
+	<th><B>Case Number</B></th>
+	<th><B>Pub Date</B></th>
+	<th><b>Short Title/District</b></th>
+	<th><b>Panel</b></th>
+	</tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0144p-06.pdf>16a0144p.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-1054 target="_blank">//-->15-1054<!--</a>//--></td>
+				<td align=center>2016/06/21</td>
+				<td>&nbsp;Cheryl Minor v. Comm'r of Social Security -
+
+				<font size=-1>Western District of Michigan at Grand Rapids</font></td><td>RLG,HNW,JBS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0145p-06.pdf>16a0145p.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3961 target="_blank">//-->15-3961<!--</a>//--></td>
+				<td align=center>2016/06/21</td>
+				<td>&nbsp;Adam Eggers v. Warden, Lebanon Corr. Inst. -
+
+				<font size=-1>Southern District of Ohio at Dayton</font></td><td>EES,JMR,JSS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0146p-06.pdf>16a0146p.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-1479 target="_blank">//-->15-1479<!--</a>//--></td>
+				<td align=center>2016/06/23</td>
+				<td>&nbsp;Gianni-Paolo Ferrari v. Ford Motor Company -
+
+				<font size=-1>Eastern District of Michigan at Ann Arbor</font></td><td>ELC,JSG,JBS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0147p-06.pdf>16a0147p.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-5739 target="_blank">//-->15-5739<!--</a>//--></td>
+				<td align=center>2016/06/27</td>
+				<td>&nbsp;Amanda Brown v. BlueCross BlueShield of Tenn. -
+
+				<font size=-1>Eastern District of Tennessee of Chattanooga</font></td><td>RMK,BBD,JRR
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0148p-06.pdf>16a0148p.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=13-1761 target="_blank">//-->13-1761<!--</a>//--></td>
+				<td align=center>2016/06/27</td>
+				<td>&nbsp;USA v. Ricky Brown -
+
+				<font size=-1>Eastern District of Michigan at Detroit</font></td><td>ELC,JBS,TSB
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0149p-06.pdf>16a0149p.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3263 target="_blank">//-->15-3263<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Ryan Collins -
+
+				<font size=-1>Northern District of Ohio at Akron</font></td><td>RBG,AMB,DLC
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0149p-06.pdf>16a0149p.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3309 target="_blank">//-->15-3309<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Ryan Collins -
+
+				<font size=-1>Northern District of Ohio at Akron</font></td><td>RBG,AMB,DLC
+</td></tr></table>
+	<h2><span style='color:#6e0000;'>Not Recommended for Full-Text Publication Opinions</span></h2>
+			The "Filed" date for an unpublished opinion is not
+			always the date on which it is posted.
+			Please check the opinion for the correct filed date.<br>
+	<table Width=100% align=center border=0>
+	<tr>
+	<th><B>Opinion</B></th>
+	<th><B>Case Number</B></th>
+	<th><B>Pub Date</B></th>
+	<th><b>Short Title/District</b></th>
+	<th><b>Panel</b></th>
+	</tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0336n-06.pdf>16a0336n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-1625 target="_blank">//-->15-1625<!--</a>//--></td>
+				<td align=center>2016/06/20</td>
+				<td>&nbsp;Isarel Flatford v. UAW, Local 663 -
+
+				<font size=-1>Eastern District of Michigan at Detroit</font></td><td>EES,DLC,BBD
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0337n-06.pdf>16a0337n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-2094 target="_blank">//-->15-2094<!--</a>//--></td>
+				<td align=center>2016/06/20</td>
+				<td>&nbsp;Lennox Emanuel v. Wayne County, MI -
+
+				<font size=-1>Eastern District of Michigan at Detroit</font></td><td>MCD,ELC,JBS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0338n-06.pdf>16a0338n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-6134 target="_blank">//-->15-6134<!--</a>//--></td>
+				<td align=center>2016/06/21</td>
+				<td>&nbsp;Cheryl Sinclair v. Lauderdale County, Tenn. -
+
+				<font size=-1>Western District of Tennessee at Memphis</font></td><td>AEN,DWM,HNW
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0339n-06.pdf>16a0339n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-2170 target="_blank">//-->15-2170<!--</a>//--></td>
+				<td align=center>2016/06/21</td>
+				<td>&nbsp;Mahmoud Elzein v. FNMA -
+
+				<font size=-1>Eastern District of Michigan at Detroit</font></td><td>KNM,JSS,BBD
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0340n-06.pdf>16a0340n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=14-2391 target="_blank">//-->14-2391<!--</a>//--></td>
+				<td align=center>2016/06/21</td>
+				<td>&nbsp;USA v. Earl Coleman -
+
+				<font size=-1>Western District of Michigan at Grand Rapids</font></td><td>DJB,JMR,JBS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0342n-06.pdf>16a0342n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-6100 target="_blank">//-->15-6100<!--</a>//--></td>
+				<td align=center>2016/06/22</td>
+				<td>&nbsp;Taryn Murphy v. Sergey Lazarev -
+
+				<font size=-1>Middle District of Tennessee at Nashville</font></td><td>JSG,DWM,DML
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0343n-06.pdf>16a0343n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-2063 target="_blank">//-->15-2063<!--</a>//--></td>
+				<td align=center>2016/06/22</td>
+				<td>&nbsp;Edwin Siegner v. Township of Salem -
+
+				<font size=-1>Eastern District of Michigan at Flint</font></td><td>JSS,RAG,SO
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0344n-06.pdf>16a0344n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=13-3742 target="_blank">//-->13-3742<!--</a>//--></td>
+				<td align=center>2016/06/22</td>
+				<td>&nbsp;Terrance Walter v. Bennie Kelly -
+
+				<font size=-1>Northern District of Ohio at Cleveland</font></td><td>ELC,JSG,JBS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0345n-06.pdf>16a0345n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-1561 target="_blank">//-->15-1561<!--</a>//--></td>
+				<td align=center>2016/06/22</td>
+				<td>&nbsp;Alyson Luukkonen v. Comm'r of Social Security -
+
+				<font size=-1>Western District of Michigan at Grand Rapids</font></td><td>RGC,ELC,JSG
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0346n-06.pdf>16a0346n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-6189 target="_blank">//-->15-6189<!--</a>//--></td>
+				<td align=center>2016/06/22</td>
+				<td>&nbsp;Lynda Freeman v. DOL -
+
+				<font size=-1>Western District of Kentucky at Paducah</font></td><td>DJK,ELC,HNW
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0347n-06.pdf>16a0347n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-1643 target="_blank">//-->15-1643<!--</a>//--></td>
+				<td align=center>2016/06/23</td>
+				<td>&nbsp;Steven Scozzari v. City of Clare -
+
+				<font size=-1>Eastern District of Michigan at Bay City</font></td><td>RGC,DWM,RAG
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0347n-06.pdf>16a0347n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-1663 target="_blank">//-->15-1663<!--</a>//--></td>
+				<td align=center>2016/06/23</td>
+				<td>&nbsp;Steven Scozzari v. City of Clare -
+
+				<font size=-1>Eastern District of Michigan at Bay City</font></td><td>RGC,DWM,RAG
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0348n-06.pdf>16a0348n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=14-3995 target="_blank">//-->14-3995<!--</a>//--></td>
+				<td align=center>2016/06/24</td>
+				<td>&nbsp;USA v. Michael Teadt -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DJB,BBD,JMH
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0348n-06.pdf>16a0348n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=14-4124 target="_blank">//-->14-4124<!--</a>//--></td>
+				<td align=center>2016/06/24</td>
+				<td>&nbsp;USA v. Bradford Huebner -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DJB,BBD,JMH
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0348n-06.pdf>16a0348n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=14-4125 target="_blank">//-->14-4125<!--</a>//--></td>
+				<td align=center>2016/06/24</td>
+				<td>&nbsp;USA v. Charles Emmenecker -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DJB,BBD,JMH
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0348n-06.pdf>16a0348n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3014 target="_blank">//-->15-3014<!--</a>//--></td>
+				<td align=center>2016/06/24</td>
+				<td>&nbsp;USA v. Michael Teadt -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DJB,BBD,JMH
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0348n-06.pdf>16a0348n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3015 target="_blank">//-->15-3015<!--</a>//--></td>
+				<td align=center>2016/06/24</td>
+				<td>&nbsp;USA v. Charles Emmenecker -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DJB,BBD,JMH
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0349n-06.pdf>16a0349n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3923 target="_blank">//-->15-3923<!--</a>//--></td>
+				<td align=center>2016/06/24</td>
+				<td>&nbsp;Phillip Miller v. Walter Davis, III -
+
+				<font size=-1>Southern District of Ohio at Columbus</font></td><td>EES,DLC,BBD
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0350n-06.pdf>16a0350n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=14-2498 target="_blank">//-->14-2498<!--</a>//--></td>
+				<td align=center>2016/06/24</td>
+				<td>&nbsp;USA v. Rufus Wilson -
+
+				<font size=-1>Eastern District of Michigan at Detroit</font></td><td>JSS,RAG,SO
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0350n-06.pdf>16a0350n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=14-2528 target="_blank">//-->14-2528<!--</a>//--></td>
+				<td align=center>2016/06/24</td>
+				<td>&nbsp;USA v. John Davis -
+
+				<font size=-1>Eastern District of Michigan at Detroit</font></td><td>JSS,RAG,SO
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0351n-06.pdf>16a0351n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-1592 target="_blank">//-->15-1592<!--</a>//--></td>
+				<td align=center>2016/06/27</td>
+				<td>&nbsp;Terry Tilley v. Kalamazoo County Road Comm'n -
+
+				<font size=-1>Western District of Michigan at Grand Rapids</font></td><td>EES,JSS,JBS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0352n-06.pdf>16a0352n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3725 target="_blank">//-->15-3725<!--</a>//--></td>
+				<td align=center>2016/06/27</td>
+				<td>&nbsp;USA v. David Kraus -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>AMB,DWM,JBS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0353n-06.pdf>16a0353n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-1569 target="_blank">//-->15-1569<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Phillip Walsh -
+
+				<font size=-1>Western District of Michigan at Grand Rapids</font></td><td>DJK,DLC,JBS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0353n-06.pdf>16a0353n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-2071 target="_blank">//-->15-2071<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Betty Jenkins -
+
+				<font size=-1>Western District of Michigan at Grand Rapids</font></td><td>DJK,DLC,JBS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0354n-06.pdf>16a0354n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-4197 target="_blank">//-->15-4197<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Kenneth Clegg, Jr. -
+
+				<font size=-1>Southern District of Ohio at Dayton</font></td><td>AMB,RMK,JEL
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0355n-06.pdf>16a0355n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-4127 target="_blank">//-->15-4127<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;4218868 Canada, Inc. v. Barry Kwasny -
+
+				<font size=-1>Northern District of Ohio at Cleveland</font></td><td>RFS,DWM,BBD
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0356n-06.pdf>16a0356n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3496 target="_blank">//-->15-3496<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Gary Wymer -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DWM,RAG,WOB
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0356n-06.pdf>16a0356n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3510 target="_blank">//-->15-3510<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Terrance Wymer -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DWM,RAG,WOB
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0356n-06.pdf>16a0356n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3511 target="_blank">//-->15-3511<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Gary Wymer, Jr. -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DWM,RAG,WOB
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0356n-06.pdf>16a0356n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3512 target="_blank">//-->15-3512<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Robert Debolt, Jr. -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DWM,RAG,WOB
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0356n-06.pdf>16a0356n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3513 target="_blank">//-->15-3513<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. John Debolt -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DWM,RAG,WOB
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0356n-06.pdf>16a0356n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3519 target="_blank">//-->15-3519<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Michael Wymer -
+
+				<font size=-1>Northern District of Ohio at Toledo</font></td><td>DWM,RAG,WOB
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0357n-06.pdf>16a0357n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-4242 target="_blank">//-->15-4242<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;Henri Solari v. Goodyear Tire & Rubber Co. -
+
+				<font size=-1>Northern District of Ohio at Akron</font></td><td>DLC,RMK,EAS
+</td></tr><tr>
+				<td align=center>
+				<a href=/opinions.pdf/16a0358n-06.pdf>16a0358n.06</a></td>
+				<td align=center>
+				<!--<a href=https://ecf.ca6.uscourts.gov/cmecf/servlet/TransportRoom?servlet=CaseSelectionTable.jsp?csnum1=15-3695 target="_blank">//-->15-3695<!--</a>//--></td>
+				<td align=center>2016/06/29</td>
+				<td>&nbsp;USA v. Berryon Moore, III -
+
+				<font size=-1>Southern District of Ohio at Columbus</font></td><td>DJB,ELC,RLG
+</td></tr></table>
+
+
+
+
+
+</div>
+          </div>
+
+
+        <!-- Triptych -->
+        <div class="l-triptych">
+                                      </div>
+
+      </div>
+    </div>
+
+     <!-- Footer -->
+  <footer class="l-footer" role="contentinfo">
+        <div class="l-region l-region--footer">
+    <div id="block-nodeblock-nb-footer-coptright" class="block block--nodeblock block--nodeblock-nb-footer-coptright">
+        <div class="block__content">
+          <div class="field field--name-body field--type-text-with-summary field--label-hidden"><div class="field__items"><div class="field__item even" property="content:encoded"><p><a class="ql-first" href="http://www.ca6.uscourts.gov/">Home</a> | <a href="http://www.ca6.uscourts.gov/court-info/court-locations/">Contact Us</a> | <a href="http://www.ca6.uscourts.gov/employment">Employment</a> | <a href="http://www.uscourts.gov/Common/Glossary.aspx" target="_blank">Glossary of Legal Terms</a> | <a href="http://www.uscourts.gov/frequently-asked-questions-faqs" target="_blank">FAQs</a></p><div id="block-nodeblock-nb-footer-quick-links" class="block block--nodeblock block--nodeblock-nb-footer-quick-links">
+        <div class="block__content">
+          <div class="field field--name-body field--type-text-with-summary field--label-hidden"><div class="field__items"><div class="field__item even" property="content:encoded"><p>
+</div></div></div>
+</div></div></div>  </div>
+
+
+
+</div>
+  </div>
+</div>
+<div id="block-nodeblock-nb-footer-quick-links" class="block block--nodeblock block--nodeblock-nb-footer-quick-links">
+        <div class="block__content">
+          <div class="field field--name-body field--type-text-with-summary field--label-hidden"><div class="field__items"><div class="field__item even" property="content:encoded">
+            <p><a class="ql-first" href="http://www.ca6.uscourts.gov/privacy-policy/">Privacy Policy</a> | <a class="ql-last" href="http://www.ca6.uscourts.gov/browsealoud-information/">BrowseAloud</a></p>
+</div></div></div>  </div>
+
+
+
+</div>
+  </div>
+</div>
+  </body>
+</html>
+


### PR DESCRIPTION
ca6 was failing because their site url changed, as well as their site format.  I've replaced the old example file with the new format's source.  kan was not broken, but it has a bug that was preventing some cases (both kan and kanctapp) from getting discovered. No new kan/kanctapp example files necessary, as the business logic remains the same.