### PR TITLE
Fixing fladistctapp_2 scraper to handle typo in docket number

### DIFF
--- a/juriscraper/__init__.py
+++ b/juriscraper/__init__.py
@@ -3,7 +3,7 @@ __all__ = [
     'oral_args',
 ]
 
-__version__ = "1.1.8.6"
+__version__ = "1.1.8.7"
 
 __title__ = "juriscraper"
 __description__ = "An API to scrape American court websites for metadata."

--- a/juriscraper/opinions/united_states/state/fladistctapp_2.py
+++ b/juriscraper/opinions/united_states/state/fladistctapp_2.py
@@ -8,11 +8,11 @@
 # - 2014-08-28: Updated by mlr.
 
 import re
-from datetime import date
-
 import certifi
 import requests
 from lxml import html
+from datetime import date
+
 from juriscraper.AbstractSite import logger
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.string_utils import convert_date_string
@@ -111,6 +111,10 @@ class Site(OpinionSite):
         dockets = []
         for text in list(html_tree.xpath(path)):
             text = text.strip()
+
+            # Sometimes the clerk enter (typo) spaces before/after dash
+            text = ''.join(text.split())
+
             if re.match('^\w+-\d+$', text):
                 dockets.append(text)
         return dockets

--- a/tests/examples/opinions/united_states/fladistctapp_2_example_4.html
+++ b/tests/examples/opinions/united_states/fladistctapp_2_example_4.html
@@ -1,0 +1,208 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="../../../../Templates/dca_main_second.dwt" codeOutsideHTMLIsLocked="false" -->
+<head>
+<!-- InstanceBeginEditable name="doctitle" -->
+<title>Florida's Second District Court of Appeal's Website</title>
+<!-- InstanceEndEditable -->
+<script language="JavaScript1.2" type="text/javascript" src="/stylesheets/init_homepg.js"></script>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+  <meta http-equiv="PRAGMA" content="NO-CACHE" />
+  <meta http-equiv="Expires" content="0" />
+<!-- InstanceBeginEditable name="head" --><!-- InstanceEndEditable -->
+<link href="/stylesheets/main.css" rel="stylesheet" type="text/css" />
+<link href="/stylesheets/print.css" rel="stylesheet" type="text/css" media="print">
+</head>
+<body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0" onLoad="MM_preloadImages('/images/navbar_home.jpg','/images/navbar_judgeshover.jpg','/images/navbar_homehover.jpg','/images/navbar_clerkhover.jpg','/images/navbar_argumentshover.jpg','/images/navbar_dockethover.jpg','/images/navbar_opinionshover.jpg','/images/navbar_eaccesshover.jpg','/images/navbar_searchhover.jpg')">
+<script language="JavaScript" type="text/JavaScript">
+<!--
+
+
+
+function MM_preloadImages() { //v3.0
+  var d=document; if(d.images){ if(!d.MM_p) d.MM_p=new Array();
+    var i,j=d.MM_p.length,a=MM_preloadImages.arguments; for(i=0; i<a.length; i++)
+    if (a[i].indexOf("#")!=0){ d.MM_p[j]=new Image; d.MM_p[j++].src=a[i];}}
+}
+//-->
+</script>
+<link href="/New WebPage/Stylesheets/main.css" rel="stylesheet" type="text/css">
+<script type="text/JavaScript">
+<!--
+function MM_swapImgRestore() { //v3.0
+  var i,x,a=document.MM_sr; for(i=0;a&&i<a.length&&(x=a[i])&&x.oSrc;i++) x.src=x.oSrc;
+}
+
+function MM_findObj(n, d) { //v4.01
+  var p,i,x;  if(!d) d=document; if((p=n.indexOf("?"))>0&&parent.frames.length) {
+    d=parent.frames[n.substring(p+1)].document; n=n.substring(0,p);}
+  if(!(x=d[n])&&d.all) x=d.all[n]; for (i=0;!x&&i<d.forms.length;i++) x=d.forms[i][n];
+  for(i=0;!x&&d.layers&&i<d.layers.length;i++) x=MM_findObj(n,d.layers[i].document);
+  if(!x && d.getElementById) x=d.getElementById(n); return x;
+}
+
+function MM_swapImage() { //v3.0
+  var i,j=0,x,a=MM_swapImage.arguments; document.MM_sr=new Array; for(i=0;i<(a.length-2);i+=3)
+   if ((x=MM_findObj(a[i]))!=null){document.MM_sr[j++]=x; if(!x.oSrc) x.oSrc=x.src; x.src=a[i+2];}
+}
+//-->
+</script>
+<body onLoad="MM_preloadImages('/New WebPage/images/navbar_home.jpg','/New WebPage/images/navbar_judgeshover.jpg','/New WebPage/images/navbar_homehover.jpg','/New WebPage/images/navbar_clerkhover.jpg','/New WebPage/images/navbar_argumentshover.jpg','/New WebPage/images/navbar_dockethover.jpg','/New WebPage/images/navbar_opinionshover.jpg','/New WebPage/images/navbar_searchhover.jpg')">
+<table border="0" cellpadding="0" cellspacing="0" bgcolor="#375885">
+  <tr>
+
+	<td align="right" valign="top"><table width="100%"  border="0" cellpadding="0" cellspacing="0" bgcolor="#365886">
+      <tr>
+        <td background="/New WebPage/images/banner_background.jpg"><img src="http://www.2dca.org/images/banner_text_second.jpg" width="752" height="82" align="right"></td>
+      </tr>
+      <tr>
+        <td background="/New WebPage/images/banner_background.jpg">
+          <table width="98%" border="2" align="right" "cellpadding="0" cellspacing="0" bordercolor="#999999" bgcolor="#ECE9D8">
+            <tr>
+
+			  <td width="8%" bgcolor="#ECE9D8"><div align="center"><a href="/index.shtml"></a><a href="http://www.2dca.org/index2.shtml"><img src="/images/navbar_home.jpg" alt="home button" width="50" height="15" border="0" id="Image1" onMouseOver="MM_swapImage('Image1','','/New WebPage/images/navbar_home.jpg',1);MM_swapImage('Image1','','/New WebPage/images/navbar_homehover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="9%"><div align="center" class="boldbodytext"><a href="/judges.shtml"></a><a href="http://www.2dca.org/Judges/judges.shtml"><img src="/images/navbar_judges.jpg" alt="judges button" name="Image2" width="50" height="15" border="0" id="Image2" onMouseOver="MM_swapImage('Image2','','/New WebPage/images/navbar_judgeshover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="16%"><div align="center" class="boldbodytext"><a href="/clerks_office.shtml"></a><a href="http://www.2dca.org/Clerk/clerks_office.shtml"><img src="/images/navbar_clerk.jpg" alt="clerk's office button" name="Image3" width="104" height="15" border="0" id="Image3" onMouseOver="MM_swapImage('Image3','','/New WebPage/images/navbar_clerkhover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="18%" bgcolor="#ECE9D8"><div align="center" class="boldbodytext"><a href="/oralarguments.shtml"></a><a href="http://www.2dca.org/OralArgumentCalendar/calendardates.shtml"><img src="/images/navbar_arguments.jpg" alt="oral arguments button" name="Image4" width="110" height="15" border="0" id="Image4" onMouseOver="MM_swapImage('Image4','','/New WebPage/images/navbar_argumentshover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="17%" bordercolor="#999999"><div align="center" class="boldbodytext"><a href="http://jweb.flcourts.org/pls/docket/ds_docket_search%20"></a><a href="http://199.242.69.70/pls/ds/ds_docket_search"><img src="/images/navbar_docket.jpg" alt="on-line docket button" name="Image5" width="110" height="15" border="0" id="Image5" onMouseOver="MM_swapImage('Image5','','/New WebPage/images/navbar_dockethover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+              <td width="11%"><div align="center" class="boldbodytext"><a href="/New WebPage/opinions.shtml"></a><a href="http://www.2dca.org/opinions/opinions.shtml"><img src="/images/navbar_opinions.jpg" alt="opinions button" name="Image6" width="68" height="15" border="0" id="Image6" onMouseOver="MM_swapImage('Image6','','/New WebPage/images/navbar_opinionshover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="10%"><div align="center" class="boldbodytext"><a href="http://www.1dca.org/cgi-bin/mclient.cgi"></a><a href="http://www.2dca.org/search.shtml"><img src="/images/navbar_search.jpg" alt="search button" width="68" height="15" border="0" id="Image8" onMouseOver="MM_swapImage('Image8','','/New WebPage/images/navbar_searchhover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  </tr>
+          </table>          </td>
+      </tr>
+    </table>    </td>
+
+    <td width="100%"align="top" background="/New WebPage/images/banner_background.jpg"></td>
+    <td align="top">&nbsp;</td>
+  </tr>
+</table>
+
+
+<table width="754" border="0" cellpadding="0" cellspacing="0" bordercolor="#003366">
+  <tr>
+    <td width="15" valign="top"><a href="#main"><img src="../../../../images/banner_background_spacer.jpg" alt="Skip Navigation" width="4" height="15" border="0" /></a></td>
+    <td width="200" valign="top" align="left">
+
+	<style type="text/css">
+<!--
+.style1 {color: #FF0000}
+-->
+</style>
+<table  width="100%" border="0">
+  <tr>
+    <td style="padding-top:1px; padding-left:6px; padding-bottom:0px">
+<div id="menu">
+	 <ul style="margin-left:0; margin-bottom:0; padding-left:1em; padding-bottom:0px;">
+    	<li><a href="http://www.2dca.org/Clerk/clerks_office.shtml">Clerk's Office</a></li>
+        <li><a href="http://www.2dca.org/opinions/opinions.shtml">Opinions</a></li>
+        <li><a href="http://www.2dca.org/PCA/PCA.shtml">Per Curiam Affirmances</a> </li>
+        <li><a href="http://www.2dca.org/opinions/ArchivedOpinions.shtml">Archived Opinions</a></li>
+        <li><a href="/OralArgumentCalendar/calendardates.shtml">Oral Argument Calendar</a></li>
+        <li><a href="../OralArgumentCalendar/oa-streaming.shtml"> Live Oral Argument</a> </li>
+        <li><a href="http://www.2dca.org/marshal/Marshal_Office.shtml">Marshal's Office</a></li>
+        <li><a href="http://www.2dca.org/Employment/employment.shtml">Employment</a></li>
+        <hr align="center" width="95%" size="1" color="#375885">
+		<li><a href="http://www.flcourts.org/gen_public/pubs/adamain.shtml" target="_blank">ADA Guidelines</a></li>
+		<li><a href="/Directions/tampa.shtml">Tampa Branch</a></li>
+		<li><a href="../RobertButlerGallery.shtml">Robert Butler Gallery</a></li>
+		<li><a href="/Clerk/Notices/LegalResearchPage.shtml">Legal Resources</a> </li>
+		<li><a href="../Historic Info/Former Judges.shtml">Former Judges</a></li>
+		<li><a href="../RSS.shtml">RSS feeds</a></li>
+		<li><a href="/CourtHistory/history.shtml">Additional Court Information</a></li>
+		<li><a href="http://www.2dca.org/faq.shtml">FAQ's</a></li>
+<hr align="center" width="95%" size="1" color="#375885">
+<div align="left"><span style="font-variant:small-caps; margin-left:-1em; margin-bottom:0; padding-left:0; font-weight:bold;">Florida Court Links</span></div>
+<li><a href="http://www.flcourts.org/florida-courts/district-court-appeal.stml" target="_blank">Other DCA Websites</a></li>
+		<li><a href="http://www.floridasupremecourt.org/" target="_blank">Florida Supreme Court</a></li>
+		<li><a href="http://www.flcourts.org/index.shtml" target="_blank">Florida State Courts</a></li>
+		<li><a href="http://www.floridasupremecourt.org/education/index.shtml">Supreme Court Education and Tours</a>            </li>
+    </ul>
+     <hr align="center" width="90%" size="1" color="#375885">
+<div style="padding-top:0px; padding-bottom:0px" id="menu">
+  <p class="bodytextsmall" align="center">2nd District Court of Appeal <br />
+  1005 E. Memorial   Blvd.<br />
+  Lakeland, FL 33801<br />
+  Telephone: (863) 499-2290</p>
+<p align="center"><a href="/Directions/LakelandDirections.shtml">Map and Directions</a> </p>
+</div>
+<hr align="center" width="95%" size="1" color="#375885">
+<div style="padding:0" align="center"><a href="http://www.2dca.org/index2.shtml">2nd DCA Home</a></div>
+<hr align="center" width="95%" size="1" color="#375885">
+</div>
+</td>
+</tr>
+
+</table>
+
+
+
+
+	</td>
+    <td width="539" valign="top" style="padding-left:15px; padding-right:15px"><br />
+      <a id="main" name="main"></a>
+    <!-- InstanceBeginEditable name="textContent" -->
+    <table width="99%" summary="Opinions for Wednesday, May 07, 2014.">
+      <tr>
+        <th height="87" scope="col"><h1>July 01, 2016</h1>
+          <p class="test"><a href="July 01, 2016/2D15-2969.pdf"><strong>2D15- 2969</strong> / Sovereign Healthcare v. The Estate of Otto N. Schmitt</a><strong><br />
+            <br />
+            </strong><a href="July 01, 2016/2D15-3254.pdf"><strong>2D15-3254</strong> / Clark v. State</a><strong><br />
+            <br />
+            </strong><a href="July 01, 2016/2D15-3812.pdf"><strong>2D15-3812</strong> / Deutsche Bank National Trust Co. v. Kummer</a><strong><br />
+            <br />
+            </strong><a href="July 01, 2016/2D15-3964.pdf"><strong>2D15-3964</strong> / S.T.L. v. State</a><strong><a href="July 01, 2016/2D15-3964.pdf"> <br />
+            </a></strong><a href="June 01, 2016/2D14-3474.pdf"><br />
+          </a></p></th>
+      </tr>
+      <tr>
+        <th height="20" scope="col">&nbsp;</th>
+      </tr>
+    </table>
+    <!-- InstanceEndEditable --></td>
+  </tr>
+  <tr>
+   <td width="15">&nbsp;</td>
+    <td width="200" valign="top">&nbsp;</td>
+    <td width="539" align="center" style="padding-top:5px; padding-left:1px; padding-right:5px"><div id="bottomMenu" align="center" style="padding:0">
+		   <hr width="75%" style="padding:0">
+		   <ul style="margin-left:0; margin-bottom:0; padding-left:1em; padding-bottom:0px;">
+
+			<li><a href="http://www.2dca.org/index2.shtml">Return Home</a></li>
+			/
+            <li><a href="http://www.2dca.org/search.shtml">Search</a></li>
+            /
+            <li><a href="http://www.2dca.org/Judges/judges.shtml">Judges</a></li>
+            /
+            <li><a href="http://www.2dca.org/Clerk/clerks_office.shtml">Clerk's Office</a></li>
+            /
+            <li><a href="http://www.2dca.org/OralArgumentCalendar/calendardates.shtml">Oral Arguments</a></li>
+            /
+			<li><a href="http://www.2dca.org/opinions/opinions.shtml">Opinions</a></li>
+			<br />
+			<li><a href="http://199.242.69.70/pls/ds/ds_docket_search?pscourt=2" target="_blank">Online Dockets</a></li>
+
+            /
+			<li><a href="http://www.2dca.org/plugins.shtml">Using This Site & Plug-Ins</a></li>
+			/
+			<li><a href="http://www.2dca.org/privacy.shtml">Privacy Policy</a></li>
+			/
+			<li><a href="http://www.2dca.org/accessibility.shtml">Accessibility</a></li>
+          </ul>
+        <p>All Content Copyright 2016 Second District Court of Appeal</p>
+</div>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-46755357-6', 'auto');
+  ga('send', 'pageview');
+
+</script></td>
+  </tr>
+</table>
+
+</body>
+<!-- InstanceEnd --></html>
+


### PR DESCRIPTION
Scraper is currently breaking due to space in the docket number.  This fix removed spaces form the raw_docket text string before regex matching.  Added new test tile.  Incremented version number.