### PR TITLE
Fixing mass scraper

### DIFF
--- a/juriscraper/__init__.py
+++ b/juriscraper/__init__.py
@@ -3,7 +3,7 @@ __all__ = [
     'oral_args',
 ]
 
-__version__ = "1.1.8.7"
+__version__ = "1.1.8.8"
 
 __title__ = "juriscraper"
 __description__ = "An API to scrape American court websites for metadata."

--- a/juriscraper/opinions/united_states/state/mass.py
+++ b/juriscraper/opinions/united_states/state/mass.py
@@ -11,9 +11,9 @@ History:
 """
 
 import re
-import time
-from datetime import date
+
 from juriscraper.OpinionSite import OpinionSite
+from juriscraper.lib.string_utils import convert_date_string
 
 
 class Site(OpinionSite):
@@ -22,7 +22,7 @@ class Site(OpinionSite):
         self.url = 'http://www.mass.gov/courts/court-info/sjc/about/reporter-of-decisions/opinions.xml'
         self.court_id = self.__module__
         self.court_identifier = 'SJC'
-        self.grouping_regex = re.compile("(.*)\s+\((SJC[-\s]+\d+(?:, \d+)*)\)\s+\((.+)\)")
+        self.grouping_regex = re.compile("(.*)\s+\((SJC[-\s]+\d+(?:,?;? \d+)*)\)\s+\((.+)\)")
         self.base_path = "//title[not(contains(., 'List of Un')) and contains(., '{id}')]".format(id=self.court_identifier)
 
     def _get_case_names(self):
@@ -39,8 +39,8 @@ class Site(OpinionSite):
         dates = []
         path = self.base_path + "//text()[contains(., '{id}')]".format(id=self.court_identifier)
         for s in self.html.xpath(path):
-            s = self.grouping_regex.search(s).group(3)
-            dates.append(date.fromtimestamp(time.mktime(time.strptime(s, '%B %d, %Y'))))
+            date_string = self.grouping_regex.search(s).group(3)
+            dates.append(convert_date_string(date_string))
         return dates
 
     def _get_docket_numbers(self):

--- a/tests/examples/opinions/united_states/mass_example_2.xml
+++ b/tests/examples/opinions/united_states/mass_example_2.xml
@@ -1,0 +1,326 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom" xmlns:taxo="http://purl.org/rss/1.0/modules/taxonomy/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:sy="http://purl.org/rss/1.0/modules/syndication/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+
+
+	<title>                            New &amp; Recent Published Opinions (and Lists of Unpublished Decisions)                , Reporter of Decisions, Court System, Commonwealth of Massachusetts</title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/court-info/sjc/about/reporter-of-decisions/opinions.html" />
+	<link rel="self" type="application/atom+xml" href="http://www.mass.gov/courts/court-info/sjc/about/reporter-of-decisions/opinions.xml" />
+	<category term="" label="" />
+	<author>
+           		   <name>                            New &amp; Recent Published Opinions (and Lists of Unpublished Decisions)                ,Court System,Commonwealth of Massachusetts</name>
+		   <uri>http://www.mass.gov/courts/court-info/sjc/about/reporter-of-decisions/opinions.xml</uri>
+    </author>
+	<id>http://www.mass.gov/courts/court-info/sjc/about/reporter-of-decisions/opinions.html</id>
+    <rights>&#169; 2011 Commonwealth of Massachusetts</rights>
+		<updated>2014-04-29T00:00:00Z</updated>
+
+
+		 				<entry>
+	<title>                            West Beit Olam Cemetery Corp. v. Board of Assessors of Wayland (15-P-128) (July 7, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/15p0128.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/15p0128.pdf</id>
+	<updated>2016-07-07T14:00:00Z</updated>
+	<published>2016-07-07T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            List of Unpublished Appeals Court Decisions for July 7, 2016                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0707.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0707.pdf</id>
+	<updated>2016-07-07T14:00:00Z</updated>
+	<published>2016-07-07T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            Hensley v. Attorney General; Allen v. Attorney General (SJC 12106; 12117) (July 6, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12106.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12106.pdf</id>
+	<updated>2016-07-06T14:00:00Z</updated>
+	<published>2016-07-06T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            Dunn v. Attorney General (SJC 12107) (July 6, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12107.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12107.pdf</id>
+	<updated>2016-07-06T14:00:00Z</updated>
+	<published>2016-07-06T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            Commonwealth v. Christie (AC 12-P-1659) (July 5, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12p1659.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12p1659.pdf</id>
+	<updated>2016-07-05T14:00:00Z</updated>
+	<published>2016-07-05T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            List of Unpublished Appeals Court Decisions for July 5, 2016                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0705.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0705.pdf</id>
+	<updated>2016-07-05T14:00:00Z</updated>
+	<published>2016-07-05T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            Commonwealth v. Carter (SJC 12043) (July 1, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12043.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12043.pdf</id>
+	<updated>2016-07-01T14:00:00Z</updated>
+	<published>2016-07-01T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            Gray v. Attorney General (SJC 12064) (July 1, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12064.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12064.pdf</id>
+	<updated>2016-07-01T14:00:00Z</updated>
+	<published>2016-07-01T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            Commonwealth v. Balboni (AC 14-P-697) (July 1, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/14p0697.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/14p0697.pdf</id>
+	<updated>2016-07-01T14:00:00Z</updated>
+	<published>2016-07-01T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            List of Unpublished Appeals Court Decisions for July 1, 2016                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0701.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0701.pdf</id>
+	<updated>2016-07-01T14:00:00Z</updated>
+	<published>2016-07-01T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            New England Survey Systems, Inc. v. Department of Industrial Accidents (AC 15-P-331) (June 30, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/15p0331.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/15p0331.pdf</id>
+	<updated>2016-06-30T14:00:00Z</updated>
+	<published>2016-06-30T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            Plymouth Public Schools v. Education Association of Plymouth &amp; Carver (AC 15-P-906) (June 30, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/15p0906.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/15p0906.pdf</id>
+	<updated>2016-06-30T14:00:00Z</updated>
+	<published>2016-06-30T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            List of Unpublished Appeals Court Decisions for June 30, 2016                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0630.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0630.pdf</id>
+	<updated>2016-06-30T14:00:00Z</updated>
+	<published>2016-06-30T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            List of Unpublished Appeals Court Decisions for June 29, 2016                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0629.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0629.pdf</id>
+	<updated>2016-06-29T14:00:00Z</updated>
+	<published>2016-06-29T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            Bogertman v. Attorney General (SJC 12063) (June 28, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12063.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/12063.pdf</id>
+	<updated>2016-06-28T14:00:00Z</updated>
+	<published>2016-06-28T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            List of Unpublished Appeals Court Decisions for June 28, 2016                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0628.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0628.pdf</id>
+	<updated>2016-06-28T14:00:00Z</updated>
+	<published>2016-06-28T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            List of Unpublished Appeals Court Decisions for June 27, 2016                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0627.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0627.pdf</id>
+	<updated>2016-06-27T14:00:00Z</updated>
+	<published>2016-06-27T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            DeMarco v. DeMarco (AC 16-P-190) (June 24, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/16p0190.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/16p0190.pdf</id>
+	<updated>2016-06-24T14:00:00Z</updated>
+	<published>2016-06-24T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            Commonwealth v. Tejeda (AC 15-P-1085) (June 24, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/15p1085.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/15p1085.pdf</id>
+	<updated>2016-06-24T14:00:00Z</updated>
+	<published>2016-06-24T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            List of Unpublished Appeals Court Decisions for June 24, 2016                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0624.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0624.pdf</id>
+	<updated>2016-06-24T14:00:00Z</updated>
+	<published>2016-06-24T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            Commonwealth v. Magadini (SJC 11874) (June 23, 2016)                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/11874.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/11874.pdf</id>
+	<updated>2016-06-23T14:00:00Z</updated>
+	<published>2016-06-23T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry><entry>
+	<title>                            List of Unpublished Appeals Court Decisions for June 23, 2016                </title>
+	<link rel="alternate" type="text/html" href="http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0623.pdf" />
+    <category term="" label="" />
+    <author>
+      <name>Court System</name>
+    </author>
+    <contributor>
+      <name>courts</name>
+    </contributor>
+    <id>http://www.mass.gov/courts/docs/sjc/reporter-of-decisions/new-opinions/list0623.pdf</id>
+	<updated>2016-06-23T14:00:00Z</updated>
+	<published>2016-06-23T14:00:00Z</published>
+	<summary type="html">                			                </summary>
+</entry></feed>


### PR DESCRIPTION
Adjusting regex to handle semicolon-delimited docket numbers in addition to comma-delimited.  Adding new test file.  Bumping version number.