### PR TITLE
Fixing vt_p

### DIFF
--- a/tests/examples/opinions/united_states/vt_p_example_2.html
+++ b/tests/examples/opinions/united_states/vt_p_example_2.html
@@ -1,0 +1,1057 @@
+<HTML xmlns:o="urn:schemas-microsoft-com:office:office" __expr-val-dir="ltr" dir="ltr">
+<HEAD><meta name="GENERATOR" content="Microsoft SharePoint" /><meta name="progid" content="SharePoint.WebPartPage.Document" /><meta HTTP-EQUIV="Content-Type" content="text/html; charset=utf-8" /><meta HTTP-EQUIV="Expires" content="0" />
+<!-- Added 3/4/2009 -->
+	<meta name="WebPartPageExpansion" content="full" /><meta HTTP-EQUIV="Content-Type" content="text/html; charset=windows-1252" /><meta name="description" content="The official web site of the Vermont Judicial System, with on-line Vermont Court forms and Vermont Legal Resources." /><meta name="keywords" content="Vermont Judicial System, Vermont Court Forms, Vermont Legal Resources, Vermont Supreme Court, State Court, Court" /><meta name="MSSmartTagsPreventParsing" content="false" /><meta name="robots" content="index,follow" /><meta name="revisit-after" content="30" /><meta name="author" content="Ed Grossman" /><meta name="copyright" content="Vermont Judiciary" /><meta name="reply-to" content="webmaster@vermontjudiciary.org" /><meta name="language" content="en" /><meta name="classification" content="Government" /><meta name="distribution" content="Local" />
+<!-- End 3/4/2009 add -->
+	<META NAME="ROBOTS" CONTENT="NOHTMLINDEX"/><title>
+
+</title><link rel="stylesheet" type="text/css" href="/_layouts/1033/styles/core.css?rev=5msmprmeONfN6lJ3wtbAlA%3D%3D"/>
+<link rel="stylesheet" type="text/css" href="/_catalogs/masterpage/jweb.css"/>
+<link rel="stylesheet" type="text/css" id="onetidThemeCSS" href="/LC/_themes/Lichen/Lich1011-65001.css?rev=12%2E0%2E0%2E6679"/><script type="text/javascript" language="javascript" src="/_layouts/1033/init.js?rev=SKi7C%2FTrsh1U%2FCnIwkB9Ag%3D%3D"></script>
+<script type="text/javascript" language="javascript" src="/_layouts/1033/non_ie.js?rev=yfNry4hY0Gwa%2FPDNGrqXVg%3D%3D"></script>
+<link type="text/xml" rel="alternate" href="/LC/_vti_bin/spsdisco.aspx" />
+	<!-- name="Microsoft Theme" content="Lichen 1011, default">-->
+
+	<!-- Start Vermont State Styles -->
+		<style type="text/css">
+		     /*#006633*/
+		<!--.footer{font-family:Verdana,Arial,sans-serif;font-size:65%; font-weight:bold;color:#69968B;text-decoration:none}
+			.footer a:active{color:#336600;text-decoration:none}
+			.footer a:visited{color:#336600;text-decoration:none}
+			.footer a:link{color:#336600;text-decoration:none}
+			.footer a:hover{color:#000000;text-decoration:underline }
+			.copyright{font-family:Verdana,Arial,sans-serif;font-size:70%;color:#336600 }
+.style3 {
+	margin-right: 0px;
+}
+-->
+
+		</style>
+	<!-- End Vermont State Styles -->
+
+
+<style type="text/css">
+	.zz1_TopNavigationMenu_0 { background-color:white;visibility:hidden;display:none;position:absolute;left:0px;top:0px; }
+	.zz1_TopNavigationMenu_1 { text-decoration:none; }
+	.zz1_TopNavigationMenu_2 {  }
+	.zz1_TopNavigationMenu_3 { border-style:none; }
+	.zz1_TopNavigationMenu_4 {  }
+	.zz1_TopNavigationMenu_5 {  }
+	.zz1_TopNavigationMenu_6 { border-style:none; }
+	.zz1_TopNavigationMenu_7 {  }
+	.zz1_TopNavigationMenu_8 { background-color:#F2F3F4;border-color:#A7B4CE;border-width:1px;border-style:solid; }
+	.zz1_TopNavigationMenu_9 { border-style:none; }
+	.zz1_TopNavigationMenu_10 {  }
+	.zz1_TopNavigationMenu_11 { border-style:none; }
+	.zz1_TopNavigationMenu_12 {  }
+	.zz1_TopNavigationMenu_13 { border-style:none; }
+	.zz1_TopNavigationMenu_14 {  }
+	.zz1_TopNavigationMenu_15 { border-style:none; }
+	.zz1_TopNavigationMenu_16 { background-color:#CBE3F0; }
+	.zz2_QuickLaunchMenu_0 { background-color:white;visibility:hidden;display:none;position:absolute;left:0px;top:0px; }
+	.zz2_QuickLaunchMenu_1 { text-decoration:none; }
+	.zz2_QuickLaunchMenu_2 {  }
+	.zz2_QuickLaunchMenu_3 { border-style:none; }
+	.zz2_QuickLaunchMenu_4 {  }
+	.zz2_QuickLaunchMenu_5 { border-style:none; }
+	.zz2_QuickLaunchMenu_6 {  }
+	.zz2_QuickLaunchMenu_7 {  }
+	.zz2_QuickLaunchMenu_8 {  }
+	.zz2_QuickLaunchMenu_9 { border-style:none; }
+	.zz2_QuickLaunchMenu_10 {  }
+	.zz2_QuickLaunchMenu_11 { border-style:none; }
+	.zz2_QuickLaunchMenu_12 {  }
+	.ctl00_PlaceHolderMain_g_31DCEC16A86649ADBA904C131E850F1A_0 { border-color:Black;border-width:1px;border-style:Solid; }
+	.ctl00_PlaceHolderMain_g_7F221620C8464BC9AD5D350FB17E54BC_0 { border-color:Black;border-width:1px;border-style:Solid; }
+
+</style></HEAD>
+<script type="text/javascript">
+	function OpenWindow(strURL)
+	{
+		window.open(strURL,'_self');
+	}
+</script>
+
+<script type="text/javascript">
+<!-- This function overrides the one written in core.js and fixes the group expand/colapse in firefox -->
+function ExpGroupBy(formObj)
+{
+  if ((browseris.w3c) && (!browseris.ie)) {
+	  document.all=document.getElementsByTagName("*");
+  }
+
+  docElts=document.all;
+  numElts=docElts.length;
+  images=formObj.getElementsByTagName("IMG");
+  img=images[0];
+  srcPath=img.src;
+  index=srcPath.lastIndexOf("/");
+  imgName=srcPath.slice(index+1);
+  if (imgName=='plus.gif')
+  {
+	  fOpen=true;
+	  displayStr="";
+	  img.src='/_layouts/images/minus.gif';
+  }
+  else
+  {
+	  fOpen=false;
+	  displayStr="none";
+	  img.src='/_layouts/images/plus.gif';
+  }
+  oldName=img.name;
+  img.name=img.alt;
+  img.alt=oldName;
+  spanNode=img;
+  while(spanNode !=null)
+  {
+	  spanNode=spanNode.parentNode;
+	  if (spanNode !=null &&
+		  spanNode.id !=null &&
+		  spanNode.id.length > 5 &&
+		  spanNode.id.substr(0, 5)=="group")
+		  break;
+  }
+  parentNode=spanNode;
+  while(parentNode !=null)
+  {
+	  parentNode=parentNode.parentNode;
+	  if (parentNode !=null &&
+		  parentNode.tagName=="TABLE")
+		  break;
+  }
+  lastNode=null;
+  if (parentNode !=null)
+  {
+	  lastNode=parentNode.lastChild;
+	  if (lastNode !=null && lastNode.tagName=="TBODY")
+		  lastNode=lastNode.lastChild;
+	  if (lastNode !=null && lastNode.tagName=="TR" && lastNode.lastChild !=null)
+		  lastNode=lastNode.lastChild;
+  }
+  for(var i=0;i<numElts;i++)
+  {
+	  var childObj=docElts[i];
+	  if (childObj==spanNode)
+		  break;
+  }
+  ID=spanNode.id.slice(5);
+  for(var j=i+1; j<numElts; j++)
+  {
+	  var childObj=docElts[j];
+	  if (childObj.id.length > 5 &&
+		  childObj.id.substr(0, 5)=="group")
+	  {
+		  curID=childObj.id.slice(5);
+		  if (curID <=ID)
+			  return;
+	  }
+	  parentNode=childObj;
+	  while(parentNode !=null)
+	  {
+		  parentNode=parentNode.parentElement;
+		  if (parentNode==spanNode)
+			  break;
+	  }
+	  if (parentNode==spanNode)
+		  continue;
+	  if (childObj !=img &&
+		  childObj.tagName=="IMG" &&
+		  childObj.src &&
+		  childObj.src.slice(childObj.src.length - 25)=='/_layouts/images/plus.gif')
+	  {
+		  childObj.src='/_layouts/images/minus.gif';
+		  oldName=childObj.name;
+		  childObj.name=childObj.alt;
+		  childObj.alt=oldName;
+	  }
+	  if (childObj.tagName==spanNode.tagName &&
+		  childObj.id !="footer")
+	  {
+		  childObj.style.display=displayStr;
+	  }
+	  if ((childObj.tagName=="TABLE" && lastNode==null) || childObj==lastNode)
+		  break;
+  }
+}
+
+</script>
+<BODY scroll="yes" onload="javascript:if (typeof(_spBodyOnLoadWrapper) != 'undefined') _spBodyOnLoadWrapper();">
+  <form name="aspnetForm" method="post" action="SupCrtPublish.aspx" id="aspnetForm" onsubmit="return _spFormOnSubmitWrapper();">
+<div>
+<input type="hidden" name="MSO_PageHashCode" id="MSO_PageHashCode" value="1927" />
+<input type="hidden" name="MSOWebPartPage_PostbackSource" id="MSOWebPartPage_PostbackSource" value="" />
+<input type="hidden" name="MSOTlPn_SelectedWpId" id="MSOTlPn_SelectedWpId" value="" />
+<input type="hidden" name="MSOTlPn_View" id="MSOTlPn_View" value="0" />
+<input type="hidden" name="MSOTlPn_ShowSettings" id="MSOTlPn_ShowSettings" value="False" />
+<input type="hidden" name="MSOGallery_SelectedLibrary" id="MSOGallery_SelectedLibrary" value="" />
+<input type="hidden" name="MSOGallery_FilterString" id="MSOGallery_FilterString" value="" />
+<input type="hidden" name="MSOTlPn_Button" id="MSOTlPn_Button" value="none" />
+<input type="hidden" name="__EVENTTARGET" id="__EVENTTARGET" value="" />
+<input type="hidden" name="__EVENTARGUMENT" id="__EVENTARGUMENT" value="" />
+<input type="hidden" name="__REQUESTDIGEST" id="__REQUESTDIGEST" value="0x188AE96173A910D7FA17B3220D40330F7A95914BABB80FC4669291C6BEF5E556FD123D2937CCBE9D04E077F12D05E229C0A89A4F5A9DF6193AD45284F805C729,28 Jul 2016 02:04:25 -0000" />
+<input type="hidden" name="MSOSPWebPartManager_DisplayModeName" id="MSOSPWebPartManager_DisplayModeName" value="Browse" />
+<input type="hidden" name="MSOWebPartPage_Shared" id="MSOWebPartPage_Shared" value="" />
+<input type="hidden" name="MSOLayout_LayoutChanges" id="MSOLayout_LayoutChanges" value="" />
+<input type="hidden" name="MSOLayout_InDesignMode" id="MSOLayout_InDesignMode" value="" />
+<input type="hidden" name="MSOSPWebPartManager_OldDisplayModeName" id="MSOSPWebPartManager_OldDisplayModeName" value="Browse" />
+<input type="hidden" name="MSOSPWebPartManager_StartWebPartEditingName" id="MSOSPWebPartManager_StartWebPartEditingName" value="false" />
+<input type="hidden" name="__VIEWSTATE" id="__VIEWSTATE" value="/wEPDwUBMA9kFgJmD2QWAmYPZBYCAgMPZBYKAgEPZBYCBSZnXzU4NmU5YjE1X2Y1YmNfNDg4Yl85OTg0X2U2ZDhiYmMwMmM1ZA8PFgQeDGZpbHRlcnN0cmluZ2UeD29sZGZpbHRlcnN0cmluZ2VkZAIbD2QWAgIBD2QWAmYPZBYCAgEPD2QWAh4FY2xhc3MFGG1zLXNidGFibGUgbXMtc2J0YWJsZS1leGQCKw9kFgICBw8PFgIeB1Zpc2libGVoZBYCAgQPZBYCZg88KwAJAQAPFgIeDU5ldmVyRXhwYW5kZWRnZGQCNQ9kFgICBA9kFgYCAw9kFgJmDw8WAh8DaGRkAgUPZBYCZg8PFgIfA2hkZAIHDw8WAh4LUGFyYW1WYWx1ZXMywAQAAQAAAP////8BAAAAAAAAAAwCAAAAWE1pY3Jvc29mdC5TaGFyZVBvaW50LCBWZXJzaW9uPTEyLjAuMC4wLCBDdWx0dXJlPW5ldXRyYWwsIFB1YmxpY0tleVRva2VuPTcxZTliY2UxMTFlOTQyOWMFAQAAAD1NaWNyb3NvZnQuU2hhcmVQb2ludC5XZWJQYXJ0UGFnZXMuUGFyYW1ldGVyTmFtZVZhbHVlSGFzaHRhYmxlAQAAAAVfY29sbAMcU3lzdGVtLkNvbGxlY3Rpb25zLkhhc2h0YWJsZQIAAAAJAwAAAAQDAAAAHFN5c3RlbS5Db2xsZWN0aW9ucy5IYXNodGFibGUHAAAACkxvYWRGYWN0b3IHVmVyc2lvbghDb21wYXJlchBIYXNoQ29kZVByb3ZpZGVyCEhhc2hTaXplBEtleXMGVmFsdWVzAAADAwAFBQsIHFN5c3RlbS5Db2xsZWN0aW9ucy5JQ29tcGFyZXIkU3lzdGVtLkNvbGxlY3Rpb25zLklIYXNoQ29kZVByb3ZpZGVyCOxROD8EAAAACgoLAAAACQQAAAAJBQAAABAEAAAAAwAAAAYGAAAABlVzZXJJRAYHAAAABkxpc3RJRAYIAAAABVRvZGF5EAUAAAADAAAABgkAAAAPQ3VycmVudFVzZXJOYW1lBgoAAAAme0IwQjVEODE3LTAwREUtNDZEOC1BNTY5LTAwNjg5QUJCNzExRn0GCwAAABQyMDE2LTA3LTI3VDIyOjA0OjI1WgtkZAI5DxYCHwNoFgJmD2QWBAICD2QWBgIBDxYCHwNoZAIDDxYCHwNoZAIFDxYCHwNoZAIDDw8WAh4JQWNjZXNzS2V5BQEvZGQYAQVFY3RsMDAkUGxhY2VIb2xkZXJUb3BOYXZCYXIkUGxhY2VIb2xkZXJIb3Jpem9udGFsTmF2JFRvcE5hdmlnYXRpb25NZW51Dw9kBSxTdGF0ZSBvZiBWZXJtb250IEp1ZGljaWFyeVxMZWdhbCBJbmZvcm1hdGlvbmSuBZIuA9jUY9kto5OP7yBHnP1zhA==" />
+</div>
+
+<script type="text/javascript">
+//<![CDATA[
+var theForm = document.forms['aspnetForm'];
+if (!theForm) {
+    theForm = document.aspnetForm;
+}
+function __doPostBack(eventTarget, eventArgument) {
+    if (!theForm.onsubmit || (theForm.onsubmit() != false)) {
+        theForm.__EVENTTARGET.value = eventTarget;
+        theForm.__EVENTARGUMENT.value = eventArgument;
+        theForm.submit();
+    }
+}
+//]]>
+</script>
+
+
+<script src="/WebResource.axd?d=_wrPFjM8fm6kgyoFgwGkgHAFrLUPVNE0MbdRI7wvB2SwjstsxRlhVPUkdmL1G4PU917MWPxpS47vCdrwZ9AI4me6Vok1&amp;t=635857236729967414" type="text/javascript"></script>
+
+<script> var MSOWebPartPageFormName = 'aspnetForm';</script>
+<script>
+function _spNavigateHierarchy(nodeDiv, dataSourceId, dataPath, url, listInContext, type) {
+    ProcessDefaultNavigateHierarchy(nodeDiv, dataSourceId, dataPath, url, listInContext, type, document.forms.aspnetForm, "", "\u002fLC\u002fSupCrtPublish.aspx");
+}
+</script>
+<script type="text/javascript">
+//<![CDATA[
+
+                function DoCallBack(filterText)
+                {
+                    WebForm_DoCallback('ctl00$PlaceHolderMain$g_2268c515_ff14_4c1d_8ce1_f97dd82dfc25',filterText,UpdateFilterCallback,0,CallBackError,true);
+                }
+                function CallBackError(result, clientsideString)
+                {
+                }
+            //]]>
+</script>
+<script type="text/JavaScript" language="JavaScript">
+<!--
+var L_Menu_BaseUrl="/LC";
+var L_Menu_LCID="1033";
+var L_Menu_SiteTheme="Lichen";
+//-->
+</script>
+<script type="text/javascript">
+//<![CDATA[
+
+var globalArg_g_586e9b15_f5bc_488b_9984_e6d8bbc02c5d;
+var globalContext_g_586e9b15_f5bc_488b_9984_e6d8bbc02c5d;
+function ExpGroupCallServerg_586e9b15_f5bc_488b_9984_e6d8bbc02c5d(arg, context)
+{
+    globalArg_g_586e9b15_f5bc_488b_9984_e6d8bbc02c5d = "GroupString=" + arg + "&ConnectionFilterString=";
+    globalContext_g_586e9b15_f5bc_488b_9984_e6d8bbc02c5d = context;
+    setTimeout("WebForm_DoCallback('ctl00$m$g_586e9b15_f5bc_488b_9984_e6d8bbc02c5d',globalArg_g_586e9b15_f5bc_488b_9984_e6d8bbc02c5d,ExpGroupReceiveData,globalContext_g_586e9b15_f5bc_488b_9984_e6d8bbc02c5d,ExpGroupOnError,true)", 0);
+}
+function ExpGroupOnError(message, context) {
+alert('An error has occurred with the data fetch.  Please refresh the page and retry.');
+}
+if (typeof(_spBodyOnLoadFunctionNames) != "undefined") {
+if (_spBodyOnLoadFunctionNames != null) {
+_spBodyOnLoadFunctionNames.push("ExpGroupOnPageLoad");
+}
+}//]]>
+</script>
+
+<script src="/WebResource.axd?d=NShExQFeiUXbiMIVgrKN5OHXijK6Yv8BNgwWSJhdf_oZgOUpzmDUNZxbyhTHUIpm6c05gdjky2bVYYF15z99QLi9Xj01&amp;t=635857236729967414" type="text/javascript"></script>
+<div>
+
+	<input type="hidden" name="__VIEWSTATEGENERATOR" id="__VIEWSTATEGENERATOR" value="C576741D" />
+	<input type="hidden" name="__EVENTVALIDATION" id="__EVENTVALIDATION" value="/wEWBALuu5+gCAKpn5bCCwKN/6CDBgLNrvW5A1w1yJ6qXCHC6LbQuCPfHaxG7Ih9" />
+</div>
+
+
+  <TABLE class="ms-main" CELLPADDING=0 CELLSPACING=0 BORDER=0 WIDTH="100%"><!--  HEIGHT="100%" -->
+	<tr>
+		<td>
+
+<!--
+		<table CELLPADDING=0 CELLSPACING=0 BORDER=0 WIDTH="100%">
+			<tr class="jweb_pageHeader">
+				<td>
+					<img src="../../images/logos/logo.gif">
+				</td>
+				<td colspan=4 >
+				</td>
+				<td align="right">
+					<img src="../../images/focushphotocourts.jpg">
+				</td>
+		   </tr>
+	   </table>
+-->
+
+	  	</td>
+	</tr>
+	<tr>
+	 <td class="jweb_globalTitleArea" ><!-- class="ms-globalTitleArea" or "jweb_navBackground" -->
+	  <table cellpadding=0 cellspacing=0 border=0 style="width: 99%" class="style3">
+	   <tr>
+		<td id="GlobalTitleAreaImage"  style="padding-left:40px;"><!-- class="ms-titleimagearea" -->
+			<a href="/">
+		<img src="/MasterImage/c-VTJudLogo.gif" border="none" width="122" height="66"></a>
+		</td>
+		<td valign="middle" >
+				<span id="TurnOnAccessibility" style="display:none">
+				   <a href="#" class="ms-skip" onclick="SetIsAccessibilityFeatureEnabled(true);UpdateAccessibilityUI();return false;">
+					Turn on more accessible mode</a>
+				</span>
+				<a href="javascript:;" onclick="javascript:this.href='#mainContent';" class="ms-skip" AccessKey="J">
+					Skip to main content
+				</a>
+				 <table cellpadding=0 cellspacing=0 height=100% class="ms-globalleft">
+				   <tr>
+					<td class="ms-globallinks" style="padding-top: 2px;" height=100% valign=middle>
+					 <div>
+					  <span id="TurnOffAccessibility" style="display:none">
+						<a href="#" class="ms-acclink" onclick="SetIsAccessibilityFeatureEnabled(false);UpdateAccessibilityUI();return false;">
+						Turn off more accessible mode</a>
+					  </span>
+
+							<h1 class="ms-sitetitle"><!-- class="ms-sitetitle" or "homepagetitle" -->
+								<a id="ctl00_PlaceHolderGlobalNavigationSiteMap_onetidProjectPropertyTitle" href="/LC/">Legal Community</a>
+							</h1>
+
+					  </div>
+					 </td>
+				   </tr>
+				 </table>
+			</td>
+		<td align="left" style="width:auto" ><!--width=100% class="ms-sitetitle" -->
+			<img src="/MasterImage/c-crtestopimage3.jpg" width="701" height="98"><img src="/MasterImage/seal.gif" width="100" height="94">
+			<!--
+
+
+		 	-->
+		</td>
+		<td>
+
+		</td>
+	   </tr>
+	  </table>
+	 </td>
+	</tr>
+</table>
+
+<!-- Start Vermont Header Bar -->
+		<!--
+		<script language="javascript" src="http://www.vermont.gov/nav/footer.js" type="text/javascript">
+		</script>
+		-->
+<!-- End Vermont Header Bar -->
+
+<table class="ms-main" CELLPADDING=0 CELLSPACING=0 BORDER=0 WIDTH="100%" HEIGHT="100%">
+<!--
+	<tr>
+		<td>
+			 test
+		 </td>
+	</tr>
+-->
+	<TR >
+	 <TD id="onetIdTopNavBarContainer" WIDTH=100% class="jweb_Background" ><!-- class="ms-bannerContainer" -->
+
+			<table cellspacing="0" cellpadding="0" width="100%"><!-- class="jweb_navBorder" class="ms-bannerframe" border="0" -->
+		   <tr class="jweb_navBackground" ><!-- jweb_navBorder class="jweb_navBackground" -->
+			<!--<td nowrap valign="middle"></td>-->
+			<td class="ms-topNavContainer" align="left" width=50% nowrap ID="HBN100"><!-- class=ms-banner -->
+			<!-- Origianlly the last part of the '<SharePoint:AspMenu  ID="TopNavigationMenu"' CssClass="ms-topNavContainer" -->
+
+	<table id="zz1_TopNavigationMenu" class="zz1_TopNavigationMenu_5 zz1_TopNavigationMenu_2" cellpadding="0" cellspacing="0" border="0">
+	<tr>
+		<td onmouseover="Menu_HoverRoot(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz1_TopNavigationMenun0"><table class="ms-topnav zz1_TopNavigationMenu_4" cellpadding="0" cellspacing="0" border="0" width="100%">
+			<tr>
+				<td style="white-space:nowrap;"><a class="zz1_TopNavigationMenu_1 ms-topnav zz1_TopNavigationMenu_3" href="/" accesskey="1" style="border-style:none;font-size:1em;">State of Vermont Judiciary</a></td>
+			</tr>
+		</table></td><td style="width:0px;"></td><td><table border="0" cellpadding="0" cellspacing="0" width="100%" class="zz1_TopNavigationMenu_5">
+			<tr>
+				<td style="width:0px;"></td><td onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz1_TopNavigationMenun1"><table class="ms-topnav zz1_TopNavigationMenu_4" cellpadding="0" cellspacing="0" border="0" width="100%">
+					<tr>
+						<td style="white-space:nowrap;"><a class="zz1_TopNavigationMenu_1 ms-topnav zz1_TopNavigationMenu_3" href="/GTC/default.aspx" style="border-style:none;font-size:1em;">Court Information</a></td>
+					</tr>
+				</table></td><td style="width:0px;"></td><td style="width:0px;"></td><td onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz1_TopNavigationMenun2"><table class="ms-topnav zz1_TopNavigationMenu_4" cellpadding="0" cellspacing="0" border="0" width="100%">
+					<tr>
+						<td style="white-space:nowrap;"><a class="zz1_TopNavigationMenu_1 ms-topnav zz1_TopNavigationMenu_3" href="/jc" style="border-style:none;font-size:1em;">Judicial Community</a></td>
+					</tr>
+				</table></td><td style="width:0px;"></td><td style="width:0px;"></td><td onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz1_TopNavigationMenun3"><table class="ms-topnav zz1_TopNavigationMenu_4 ms-topnavselected zz1_TopNavigationMenu_10" cellpadding="0" cellspacing="0" border="0" width="100%">
+					<tr>
+						<td style="white-space:nowrap;"><a class="zz1_TopNavigationMenu_1 ms-topnav zz1_TopNavigationMenu_3 ms-topnavselected zz1_TopNavigationMenu_9" href="/lc" style="border-style:none;font-size:1em;">Legal Information</a></td>
+					</tr>
+				</table></td><td style="width:0px;"></td><td style="width:0px;"></td><td onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz1_TopNavigationMenun4"><table class="ms-topnav zz1_TopNavigationMenu_4" cellpadding="0" cellspacing="0" border="0" width="100%">
+					<tr>
+						<td style="white-space:nowrap;"><a class="zz1_TopNavigationMenu_1 ms-topnav zz1_TopNavigationMenu_3" href="/contact" style="border-style:none;font-size:1em;">Contact Us</a></td>
+					</tr>
+				</table></td><td style="width:0px;"></td><td style="width:0px;"></td><td onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz1_TopNavigationMenun5"><table class="ms-topnav zz1_TopNavigationMenu_4" cellpadding="0" cellspacing="0" border="0" width="100%">
+					<tr>
+						<td style="white-space:nowrap;"><a class="zz1_TopNavigationMenu_1 ms-topnav zz1_TopNavigationMenu_3" href="/pe" style="border-style:none;font-size:1em;">Public Education</a></td>
+					</tr>
+				</table></td><td style="width:0px;"></td><td style="width:0px;"></td><td onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz1_TopNavigationMenun6"><table class="ms-topnav zz1_TopNavigationMenu_4" cellpadding="0" cellspacing="0" border="0" width="100%">
+					<tr>
+						<td style="white-space:nowrap;"><a class="zz1_TopNavigationMenu_1 ms-topnav zz1_TopNavigationMenu_3" href="/SRL/default.aspx" style="border-style:none;font-size:1em;">Representing Yourself</a></td>
+					</tr>
+				</table></td><td style="width:0px;"></td><td style="width:0px;"></td><td onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz1_TopNavigationMenun7"><table class="ms-topnav zz1_TopNavigationMenu_4" cellpadding="0" cellspacing="0" border="0" width="100%">
+					<tr>
+						<td style="white-space:nowrap;"><a class="zz1_TopNavigationMenu_1 ms-topnav zz1_TopNavigationMenu_3" href="/ng-cms/default.aspx" style="border-style:none;font-size:1em;">NEXT-GEN CMS</a></td>
+					</tr>
+				</table></td><td style="width:0px;"></td><td style="width:0px;"></td><td onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz1_TopNavigationMenun8"><table class="ms-topnav zz1_TopNavigationMenu_4" cellpadding="0" cellspacing="0" border="0" width="100%">
+					<tr>
+						<td style="white-space:nowrap;"><a class="zz1_TopNavigationMenu_1 ms-topnav zz1_TopNavigationMenu_3" href="https://www.VermontJudiciary.org/ExternalWeb.aspx" style="border-style:none;font-size:1em;">External Web</a></td>
+					</tr>
+				</table></td><td style="width:0px;"></td>
+			</tr>
+		</table></td>
+	</tr>
+</table>
+
+
+			</td>
+			<td class="ms-topNavContainer" width="100px">
+				<select name="courts" onchange="OpenWindow(this.value)" >
+					<option >List of Courts</option>
+					<option value="/GTC/civil/default.aspx">Civil Division</option>
+					<option value="/GTC/criminal/default.aspx">Criminal Division</option>
+					<option value="/GTC/family/default.aspx">Family Division</option>
+					<option value="/GTC/judicial/default.aspx">Judicial Bureau</option>
+					<option value="/GTC/supreme/default.aspx">Supreme Court</option>
+					<option value="/GTC/environmental/default.aspx">Environmental Division</option>
+					<option value="/GTC/probate/default.aspx">Probate Division</option>
+				</select>
+			</td>
+
+			<!--
+			<td valign=bottom align=right> <!-- class=ms-banner -->
+				<!-- Old Search area -->
+			<!--
+			</td>
+			<td valign=bottom align=right style="position:relative;bottom:0;left:0;">
+			</td>
+			-->
+		   </tr>
+		  </table>
+
+	 </TD>
+	</TR>
+
+
+
+
+
+	<tr class="jweb_Background">
+		<td>
+
+		</td>
+	</tr>
+
+	<TR height="100%"><TD><TABLE width="100%" height="100%" cellspacing="0" cellpadding="0">
+	<tr >
+	 <td  id="TitleAreaImageCell" valign="middle" nowrap><!-- class="ms-titlearealeft" -->
+	 <div class="jweb_Background" style="height:100%" ><!-- class="ms-titleareaframe" -->
+	 </div></td>
+	 <td  id="TitleAreaFrameClass"><!-- class="ms-titleareaframe" -->
+
+		<div ><!-- class="ms-titleareaframe" -->
+		<IMG SRC="/_layouts/images/blank.gif" width=1 height=100% alt=""></div>
+
+	 </td>
+	<td valign=top id="onetidPageTitleAreaFrame"  nowrap><!-- class='ms-pagetitleareaframe' -->
+	  <table id="onetidPageTitleAreaTable" cellpadding=0 cellspacing=0 width=100% border="0">
+	   <tr>
+		<td valign="top" class="syn-breadcrumb" style="color:#666666;font-family:tahoma;font-size:8pt !important;	letter-spacing:.1em;" ><!-- NodeStyle-CssClass="ms-sitemapdirectional" -->
+
+			You are here ►
+			<span id="ctl00_PlaceHolderTitleBreadcrumb_ContentMap"><span><a class="syn-breadcrumb" href="/">State of Vermont Judiciary</a></span><span> &gt; </span><span class="syn-breadcrumb">Legal Community</span></span>&nbsp;
+
+		</td>
+		<td valign="top" class="ms-titlearea">
+		<table align="right">
+		<tr>
+
+		<td style="position:relative; top:-1px;">
+		&nbsp;</td>
+
+		<td>
+		<div>
+
+					<table TOPLEVEL border="0" cellpadding="0" cellspacing="0" width="100%">
+	<tr>
+		<td valign="top"><div WebPartID="00000000-0000-0000-0000-000000000000" HasPers="true" id="WebPartWPQ1" width="100%" OnlyForMePart="true" allowDelete="false" style="" ><div id="SRSB"> <div>
+			<input name="ctl00$PlaceHolderSearchArea$ctl01$ctl00" type="hidden" id="ctl00_PlaceHolderSearchArea_ctl01_ctl00" value="https://www.VermontJudiciary.org/LC" /><table class="ms-sbtable ms-sbtable-ex" border="0">
+				<tr class="ms-sbrow">
+					<td class="ms-sbscopes ms-sbcell"><select name="ctl00$PlaceHolderSearchArea$ctl01$SBScopesDDL" id="ctl00_PlaceHolderSearchArea_ctl01_SBScopesDDL" title="Search Scope" class="ms-sbscopes">
+						<option selected="selected" value="This Site">This Site: Legal Community</option>
+
+					</select></td><td class="ms-sbcell"><input name="ctl00$PlaceHolderSearchArea$ctl01$S3031AEBB_InputKeywords" type="text" maxlength="200" id="ctl00_PlaceHolderSearchArea_ctl01_S3031AEBB_InputKeywords" accesskey="S" title="Enter search words" class="ms-sbplain" alt="Enter search words" onkeypress="javascript:return S3031AEBB_OSBEK(event);" style="width:170px;" /></td><td class="ms-sbgo ms-sbcell"><a id="ctl00_PlaceHolderSearchArea_ctl01_S3031AEBB_go" title="Go Search" href="javascript:S3031AEBB_Submit()"><img title="Go Search" onmouseover="this.src='/_layouts/images/gosearch.gif'" onmouseout="this.src='/_layouts/images/gosearch.gif'" alt="Go Search" src="/_layouts/images/gosearch.gif" style="border-width:0px;" /></a></td><td class="ms-sbLastcell"></td>
+				</tr>
+			</table>
+		</div></div></div></td>
+	</tr>
+</table>
+
+			</div>
+			<!-- <div style="position:relative; left: 0px; top: 0px"> -->
+				<!-- Start search -->
+				<!-- End search -->
+			<!-- </div> -->
+		</td>
+
+		</tr>
+		</table>
+
+		</td>
+	   </tr>
+	   <tr>
+		<td height=100% valign=top ID=onetidPageTitle class="ms-pagetitle">
+		  <h2 class="ms-pagetitle">
+
+		  </h2>
+		</td>
+	   </tr>
+	  </table>
+	 </td>
+	 <td class="ms-titlearearight">
+
+
+<div class="ms-titleareaframe" style='height:100%'><IMG SRC="/_layouts/images/blank.gif" width=1 height=1 alt=""></div>
+</td>
+	</tr>
+
+	<TR>
+	  <TD class="jweb_Background"  valign=top id="LeftNavigationAreaCell" style="height: 94%"><!-- class="ms-leftareacell" -->
+	   <table class="jweb_Background"  width=100% height=100% cellpadding=0 cellspacing=0><!-- class=ms-nav -->
+		<tr>
+		 <td>
+		  <TABLE height="100%" class=ms-navframe CELLPADDING=0 CELLSPACING=0 border="0">
+		   <tr valign="top">
+			<td width="4px"><IMG SRC="/_layouts/images/blank.gif" width=4 height=1 alt=""></td>
+			<td valign="top" width="100%">
+
+
+
+
+				<div class="ms-quicklaunchouter">
+				<div class="ms-quickLaunch" style="width:100%">
+				<h3 class="ms-standardheader">
+				<label class="ms-hidden">
+					Quick Launch
+				</label>
+				<span><div class="ms-quicklaunchheader"><a id="ctl00_PlaceHolderLeftNavBar_idNavLinkViewAll" accesskey="3" href="/LC/_layouts/viewlsts.aspx">View All Site Content</a></div></span>
+				</h3>
+				<div id="ctl00_PlaceHolderLeftNavBar_QuickLaunchNavigationManager">
+
+				<div>
+
+						<table id="zz2_QuickLaunchMenu" class="ms-navSubMenu1 zz2_QuickLaunchMenu_7 zz2_QuickLaunchMenu_2" cellpadding="0" cellspacing="0" border="0">
+		<tr onmouseover="Menu_HoverRoot(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun0">
+			<td><table class="ms-navheader zz2_QuickLaunchMenu_4" cellpadding="0" cellspacing="0" border="0" width="100%">
+				<tr>
+					<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navheader zz2_QuickLaunchMenu_3" href="/LC/default.aspx" style="border-style:none;font-size:1em;">Legal Information</a></td>
+				</tr>
+			</table></td>
+		</tr><tr>
+			<td><table border="0" cellpadding="0" cellspacing="0" width="100%" class="ms-navSubMenu2 zz2_QuickLaunchMenu_8">
+				<tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun1">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/LC/Shared%20Documents/Supreme%20Court%20Administrative%20Order%20No.%209%20and%20Rules_AmendmentsthroughDecember%209_2013.pdf" style="border-style:none;font-size:1em;">Administrative Order No. 9</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun2">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/LC/Shared%20Documents/AR-PRB-15.pdf" style="border-style:none;font-size:1em;">Annual Reports of the PRB</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun3">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="/LC/attydiscipline.aspx" style="border-style:none;font-size:1em;">Attorney Discipline Information</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun4">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="/LC/attylicensing.aspx" style="border-style:none;font-size:1em;">Attorney Licensing (Including Pro Hac Vice)</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun5">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="/LC/bbe.aspx" style="border-style:none;font-size:1em;">Bar Admissions</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun6">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/LC/Shared%20Documents/Brochure%20-%20March%202015.pdf" style="border-style:none;font-size:1em;">Complaint Brochure</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun7">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/MasterPages/tcdecisioncvl.aspx" style="border-style:none;font-size:1em;">Civil Division Opinions</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun8">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/GTC/Environmental/opinions.aspx" style="border-style:none;font-size:1em;">Environmental Division Opinions</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun9">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="/LC/masterpages/judicialconductboard.aspx" style="border-style:none;font-size:1em;">Judicial Conduct Board</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun10">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/LC/legallinks.aspx" style="border-style:none;font-size:1em;">Legal Links (Including Statutes and Rules)</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun11">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="/LC/cle.aspx" style="border-style:none;font-size:1em;">Mandatory Continuing Legal Education</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun12">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="/LC/MasterPages/MemotoBar.aspx" style="border-style:none;font-size:1em;">Memos to the Bar</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun13">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/LC/Shared%20Documents/Policies%20of%20the%20Professional%20Responsibility%20Board%20--%20Adopted%20March16-2011and%20amended%20October%202013.pdf" style="border-style:none;font-size:1em;">Policies</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun14">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/MasterPages/Court-prelimeval.aspx" style="border-style:none;font-size:1em;">Preliminary Evaluators</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun15">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="/LC/statutesandrules.aspx" style="border-style:none;font-size:1em;">Proposed and Promulgated Rules</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun16">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/LC/PRBDecisions.aspx" style="border-style:none;font-size:1em;">Professional Responsibility Board Decisions</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun17">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/LC/SupremeCourtDecisions.aspx" style="border-style:none;font-size:1em;">Supreme Court Decisions</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun18">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/LC/audioarguments.aspx" style="border-style:none;font-size:1em;">Supreme Court Oral Arguments</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun19">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/LC/Shared%20Documents/Trust%20Account%20Manual%20--%20FINAL%20-%20REVISED%20OCT%202014.pdf" style="border-style:none;font-size:1em;">Trust Account Manual</a></td>
+						</tr>
+					</table></td>
+				</tr><tr onmouseover="Menu_HoverStatic(this)" onmouseout="Menu_Unhover(this)" onkeyup="Menu_Key(event)" id="zz2_QuickLaunchMenun20">
+					<td><table class="ms-navitem zz2_QuickLaunchMenu_6" cellpadding="0" cellspacing="0" border="0" width="100%">
+						<tr>
+							<td style="width:100%;"><a class="zz2_QuickLaunchMenu_1 ms-navitem zz2_QuickLaunchMenu_5" href="https://www.VermontJudiciary.org/LC/Shared%20Documents/VermontRulesofProfessionalConduct_withamendmentsthroughJune2011.pdf" style="border-style:none;font-size:1em;">VT Rules of Professional Conduct</a></td>
+						</tr>
+					</table></td>
+				</tr>
+			</table></td>
+		</tr>
+	</table>
+				</div>
+
+</div>
+
+				<table width="100%" cellpadding="0" cellspacing="0" border="0">
+				<tr><td>
+		<table class="ms-recyclebin" width="100%" cellpadding="0" cellspacing="0" border="0">
+		<tr>
+			<td nowrap>
+				<!-- Recycle Bin -->
+			</td>
+		</tr>
+		</table>
+		</td></tr></table>
+				</div>
+				</div>
+
+
+			</td>
+		   </tr>
+		   <tr><td colspan=2><IMG SRC="/_layouts/images/blank.gif" width=138 height=1 alt=""></td></tr>
+		  </TABLE>
+		 </td>
+		 <td></td>
+		</tr>
+	   </table>
+	  </TD>
+	  <td style="height: 94%">
+
+			<div  ><!-- class="ms-pagemargin" -->
+				&nbsp;<!--
+				<IMG SRC="/_layouts/images/blank.gif" width=10 height=1 alt="">
+				--></div>
+
+	  </td>
+	  <td class='ms-bodyareacell' valign="top" style="height: 94%">
+		<PlaceHolder id="ctl00_MSO_ContentDiv">
+		<table id="MSO_ContentTable" width=100% height="100%" border="0" cellspacing="0" cellpadding="0" class="ms-propertysheet">
+		  <tr>
+			 <td class='ms-bodyareaframe' valign="top" height="100%">
+			   <A name="mainContent"></A>
+
+
+
+	<table style="width: 889px; height: 626px;">
+		<!-- MSTableType="layout" -->
+		<tr>
+			<td valign="top" style="height: 10px">
+			<table width="100%" cellpadding="0" cellspacing="0" border="0">
+	<tr>
+		<td id="MSOZoneCell_WebPartWPQ3" vAlign="top"><table TOPLEVEL border="0" cellpadding="0" cellspacing="0" width="100%">
+			<tr>
+				<td valign="top"><div WebPartID="3c5b2de3-79aa-4184-9326-5176024db894" HasPers="false" id="WebPartWPQ3" width="100%" class="ms-WPBody" allowDelete="false" style="" ><P class=style5 style="WIDTH: 674px" align=center>Vermont Supreme Court</P>
+<P class=style10 style="WIDTH: 674px" align=center>Published Opinions and Entry
+Orders</P>
+<P>
+<HR class=style8>
+</P>
+<P align=center><FONT size=3>The Vermont Supreme Court issues opinions on
+Fridays. The opinions are posted by 11 a.m. EST/EDT. To view an opinion, click
+on the year of decision and then select the title of the opinion you wish to
+view.</FONT></P>
+<P>&nbsp;</P></div></td>
+			</tr>
+		</table></td>
+	</tr>
+</table>
+</td>
+			<td valign="top" style="width: 191px" rowspan="2">
+
+
+
+			<img alt="Supreme Court Building" src="../MasterImage/p-supremecrt2-08.jpg" width="220" height="177"><br>
+			<table width="100%" cellpadding="0" cellspacing="0" border="0">
+	<tr>
+		<td id="MSOZoneCell_WebPartWPQ4" vAlign="top"><table TOPLEVEL border="0" cellpadding="0" cellspacing="0" width="100%">
+			<tr>
+				<td class="ms-WPBorderBorderOnly" valign="top"><div WebPartID="586e9b15-f5bc-488b-9984-e6d8bbc02c5d" HasPers="false" id="WebPartWPQ4" width="100%" allowMinimize="false" allowRemove="false" allowDelete="false" allowExport="false" style="" ><TABLE width="100%" cellspacing=0 cellpadding=0 border=0><SCRIPT>
+ctx = new ContextInfo();
+ctx.listBaseType = 0;
+ctx.listTemplate = 100;
+ctx.listName = "{9FB88F40-2950-432A-8186-64ED944A9352}";
+ctx.view = "{586E9B15-F5BC-488B-9984-E6D8BBC02C5D}";
+ctx.listUrlDir = "\u002fLC\u002fLists\u002fSupreme\u002520Court\u002520Decision\u002520Announcements";
+ctx.HttpPath = "\u002fLC\u002f_vti_bin\u002fowssvr.dll?CS=65001";
+ctx.HttpRoot = "https:\u002f\u002fwww.vermontjudiciary.org\u002fLC";
+ctx.imagesPath = "\u002f_layouts\u002fimages\u002f";
+ctx.PortalUrl = "";
+ctx.SendToLocationName = "";
+ctx.SendToLocationUrl = "";
+ctx.RecycleBinEnabled = -1;
+ctx.OfficialFileName = "";
+ctx.WriteSecurity = "1";
+ctx.SiteTitle = "Legal Community";
+ctx.ListTitle = "Supreme Court Decision Announcements";
+if (ctx.PortalUrl == "") ctx.PortalUrl = null;
+ctx.displayFormUrl = "\u002fLC\u002fLists\u002fSupreme\u002520Court\u002520Decision\u002520Announcements\u002fDispForm.aspx";
+ctx.editFormUrl = "\u002fLC\u002fLists\u002fSupreme\u002520Court\u002520Decision\u002520Announcements\u002fEditForm.aspx";
+ctx.isWebEditorPreview = 0;
+ctx.ctxId = 1;
+g_ViewIdToViewCounterMap[ "{586E9B15-F5BC-488B-9984-E6D8BBC02C5D}" ]= 1;
+ctx.CurrentUserId = -1;
+
+ctx1 = ctx;
+</SCRIPT><tr><td><TABLE ID="{9FB88F40-2950-432A-8186-64ED944A9352}-{586E9B15-F5BC-488B-9984-E6D8BBC02C5D}" Summary="Supreme Court Decision Announcements" o:WebQuerySourceHref="https://www.VermontJudiciary.org/LC/_vti_bin/owssvr.dll?CS=65001&XMLDATA=1&RowLimit=0&List={9FB88F40-2950-432A-8186-64ED944A9352}&View={586E9B15-F5BC-488B-9984-E6D8BBC02C5D}" width="100%" class="ms-listviewtable" border=0 cellspacing=0 cellpadding=1 dir="None" summary="Supreme Court Decision Announcements"><TR class="ms-viewheadertr" VALIGN=TOP><IFRAME src="javascript:false;" id="FilterIframe1" name="FilterIframe1" style="display:none" height="0" width="0" title="Hidden frame to filter list" FilterLink="https://www.VermontJudiciary.org/LC/SupCrtPublish.aspx?Filter=1&amp;View=%7b586E9B15%2dF5BC%2d488B%2d9984%2dE6D8BBC02C5D%7d"></IFRAME><TH nowrap scope="col" class="ms-vh2"><div style="width:100%;position:relative;left:0;top:0;"><TABLE style="width:100%;" Sortable="" SortDisable="" FilterDisable="" Filterable="" Name="LinkTitle" CtxNum="1" DisplayName="# of Decisions" FieldType="Computed" ResultType="" SortFields="SortField=LinkTitle&amp;SortDir=Asc&amp;View=%7b586E9B15%2dF5BC%2d488B%2d9984%2dE6D8BBC02C5D%7d" height="100%" cellspacing=1 cellpadding=0 class="ms-unselectedtitle" onmouseover="OnMouseOverFilter(this)"><TR><TD width="100%" Class="ms-vb" nowrap><A ID="diidSortLinkTitle" onfocus="OnFocusFilter(this)" TITLE="Sort by # of Decisions" HREF="javascript:" OnClick="javascript:return OnClickFilter(this,event);"  SORTINGFIELDS="SortField=LinkTitle&amp;SortDir=Asc&amp;View=%7b586E9B15%2dF5BC%2d488B%2d9984%2dE6D8BBC02C5D%7d"># of Decisions<img src="/_layouts/images/blank.gif" class="ms-hidden" border=0 width=1 height=1 alt="Use SHIFT+ENTER to open the menu (new window)."></A><IMG SRC="/_layouts/images/blank.gif" ALT="" BORDER=0><IMG SRC="/_layouts/images/blank.gif" BORDER=0 ALT=""></TD><TD style="position:absolute;"><IMG src="/_layouts/images/blank.gif" width=13px style="visibility: hidden" alt=""></TD></TR></TABLE></div></TH><TH nowrap scope="col" class="ms-vh2"><div style="width:100%;position:relative;left:0;top:0;"><TABLE style="width:100%;" Sortable="" SortDisable="" FilterDisable="" Filterable="" Name="Issued_x0020_On" CtxNum="1" DisplayName="Issued On" FieldType="DateTime" ResultType="" SortFields="SortField=Issued%5fx0020%5fOn&amp;SortDir=Asc&amp;View=%7b586E9B15%2dF5BC%2d488B%2d9984%2dE6D8BBC02C5D%7d" height="100%" cellspacing=1 cellpadding=0 class="ms-unselectedtitle" onmouseover="OnMouseOverFilter(this)"><TR><TD width="100%" Class="ms-vb" nowrap><A ID="diidSortIssued_x0020_On" onfocus="OnFocusFilter(this)" TITLE="Sort by Issued On" HREF="javascript:" OnClick="javascript:return OnClickFilter(this,event);"  SORTINGFIELDS="SortField=Issued%5fx0020%5fOn&amp;SortDir=Asc&amp;View=%7b586E9B15%2dF5BC%2d488B%2d9984%2dE6D8BBC02C5D%7d">Issued On<img src="/_layouts/images/blank.gif" class="ms-hidden" border=0 width=1 height=1 alt="Use SHIFT+ENTER to open the menu (new window)."></A><IMG SRC="/_layouts/images/blank.gif" ALT="" BORDER=0><IMG SRC="/_layouts/images/blank.gif" BORDER=0 ALT=""></TD><TD style="position:absolute;"><IMG src="/_layouts/images/blank.gif" width=13px style="visibility: hidden" alt=""></TD></TR></TABLE></div></TH></TR><TR class=""><TD Class="ms-vb-title" height="100%"><table height="100%" cellspacing=0 class="ms-unselectedtitle" onmouseover="OnItem(this)" CTXName="ctx1" Id="13" Url="/LC/Lists/Supreme%20Court%20Decision%20Announcements/13_.000" DRef="LC/Lists/Supreme Court Decision Announcements" Perm="0x31041" Type="" Ext="" Icon="icgen.gif||" OType="0" COUId="" HCD="" CSrc="" MS="0" CType="Item" CId="0x010024931A96C5298D46A1AF02F77F87C508" UIS="512" SUrl=""><tr><td width="100%" Class="ms-vb"><a onfocus="OnLink(this)" href="/LC/Lists/Supreme%20Court%20Decision%20Announcements/DispForm.aspx?ID=13" ONCLICK="GoToLink(this);return false;" target="_self">2<img src="/_layouts/images/blank.gif" class="ms-hidden" border=0 width=1 height=1 alt="Use SHIFT+ENTER to open the menu (new window)."></a></td><td><img src="/_layouts/images/blank.gif" width=13 style="visibility:hidden" alt=""></td></tr></table></TD><TD Class="ms-vb2"><NOBR>7/22/2016</NOBR></TD></TR></TABLE></td></tr></table><TABLE ID="ECBItems" style="display:none" height="0" width="0"><TR><TD>View in Web Browser</TD><TD>/_layouts/images/ichtmxls.gif</TD><TD>/LC/_layouts/xlviewer.aspx?listguid={ListId}&itemid={ItemId}&DefaultItemOpen=1</TD><TD>0x0</TD><TD>0x1</TD><TD>FileType</TD><TD>xlsx</TD><TD>255</TD></TR><TR><TD>View in Web Browser</TD><TD>/_layouts/images/ichtmxls.gif</TD><TD>/LC/_layouts/xlviewer.aspx?listguid={ListId}&itemid={ItemId}&DefaultItemOpen=1</TD><TD>0x0</TD><TD>0x1</TD><TD>FileType</TD><TD>xlsb</TD><TD>255</TD></TR><TR><TD>Snapshot in Excel</TD><TD>/_layouts/images/ewr134.gif</TD><TD>/LC/_layouts/xlviewer.aspx?listguid={ListId}&itemid={ItemId}&Snapshot=1</TD><TD>0x0</TD><TD>0x1</TD><TD>FileType</TD><TD>xlsx</TD><TD>256</TD></TR><TR><TD>Snapshot in Excel</TD><TD>/_layouts/images/ewr134.gif</TD><TD>/LC/_layouts/xlviewer.aspx?listguid={ListId}&itemid={ItemId}&Snapshot=1</TD><TD>0x0</TD><TD>0x1</TD><TD>FileType</TD><TD>xlsb</TD><TD>256</TD></TR></TABLE></div></td>
+			</tr>
+		</table></td>
+	</tr>
+</table>
+			<br>
+			</td>
+		</tr>
+		<tr>
+			<td valign="top" style="width: 688px; height: 549px;">
+			<table style="width: 100%">
+				<tr>
+					<td class="style7" valign="top">
+					<table TOPLEVEL border="0" cellpadding="0" cellspacing="0" width="100%">
+	<tr>
+		<td valign="top"><div WebPartID="00000000-0000-0000-0000-000000000000" HasPers="true" id="WebPartWPQ2" width="100%" OnlyForMePart="true" allowDelete="false" style="" ><table border="0" width="100%" cellpadding="2" cellspacing="0" xmlns:x="http://www.w3.org/2001/XMLSchema" xmlns:d="http://schemas.microsoft.com/sharepoint/dsp" xmlns:asp="http://schemas.microsoft.com/ASPNET/20" xmlns:__designer="http://schemas.microsoft.com/WebParts/v2/DataView/designer" xmlns:SharePoint="Microsoft.SharePoint.WebControls" xmlns:ddwrt2="urn:frontpage:internal"><tr valign="top"><th class="ms-vh" nowrap>File Name</th><th class="ms-vh" nowrap>Case Name</th><th class="ms-vh" nowrap>Public Domain #</th><th class="ms-vh" nowrap>Supreme Court Docket #</th><th class="ms-vh" nowrap>Date Issued</th></tr><tr id="group0" style="display:auto"><td class="ms-gb" style="background:#cccccc;" colspan="99"><a href="javascript:" onclick="javascript:ExpGroupBy(this);return false;"><img src="/_layouts/images/minus.gif" border="0" alt="collapse" name="expand"></a>&nbsp;<b>Year Published</b>: 2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-458.pdf">op15-458.pdf</a></td><td class="ms-vb">In re Stephanie H. Taylor, M.D.</td><td class="ms-vb">2016 VT 82</td><td class="ms-vb">2015-458</td><td class="ms-vb">7/22/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op16-030.pdf">op16-030.pdf</a></td><td class="ms-vb">Kevin Ward v. Renee LaRue</td><td class="ms-vb">2016 VT 81</td><td class="ms-vb">2016-030</td><td class="ms-vb">7/22/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-282.pdf">op15-282.pdf</a></td><td class="ms-vb">C &amp; S Wholesale Grocers, Inc.</td><td class="ms-vb">2016 VT 77</td><td class="ms-vb">2015-282</td><td class="ms-vb">7/15/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-299.pdf">op14-299.pdf</a></td><td class="ms-vb">State v. Glen Haskins, Jr.</td><td class="ms-vb">2016 VT 79</td><td class="ms-vb">2014-299</td><td class="ms-vb">7/15/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-421.pdf">op15-421.pdf</a></td><td class="ms-vb">State v. Jonathan Villeneuve</td><td class="ms-vb">2016 VT 80</td><td class="ms-vb">2015-421</td><td class="ms-vb">7/15/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op16-062.pdf">op16-062.pdf</a></td><td class="ms-vb">In re A.S. and K.S., Juveniles</td><td class="ms-vb">2016 VT 76</td><td class="ms-vb">2016-062</td><td class="ms-vb">7/8/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op16-018.pdf">op16-018.pdf</a></td><td class="ms-vb">In re J.W., Juvenile</td><td class="ms-vb">2016 VT 78</td><td class="ms-vb">2016-018</td><td class="ms-vb">7/8/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-218.pdf">op15-218.pdf</a></td><td class="ms-vb">Sharon Conant v. Entergy Corporation</td><td class="ms-vb">2016 VT 74</td><td class="ms-vb">2015-218</td><td class="ms-vb">7/8/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-118.pdf">op15-118.pdf</a></td><td class="ms-vb">State v. Ronald Bean</td><td class="ms-vb">2016 VT 73</td><td class="ms-vb">2015-118</td><td class="ms-vb">7/1/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-214.pdf">op15-214.pdf</a></td><td class="ms-vb">Deutsche Bank v. Kevin Pinette</td><td class="ms-vb">2016 VT 71</td><td class="ms-vb">2015-214</td><td class="ms-vb">6/24/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-195.pdf">op15-195.pdf</a></td><td class="ms-vb">In re D.C., Juvenile</td><td class="ms-vb">2016 VT 72</td><td class="ms-vb">2015-195</td><td class="ms-vb">6/24/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-280.pdf">op15-280.pdf</a></td><td class="ms-vb">Citibank (South Dakota), N.A. v. Dept. of Taxes / Sears, Roebuck &amp; Co. v. Dept. of Taxes</td><td class="ms-vb">2016 VT 69</td><td class="ms-vb">2015-280, 2015-281</td><td class="ms-vb">6/17/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op16-035.pdf">op16-035.pdf</a></td><td class="ms-vb">In re I.B., Juvenile</td><td class="ms-vb">2016 VT 70</td><td class="ms-vb">2016-035</td><td class="ms-vb">6/17/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-254.pdf">op15-254.pdf</a></td><td class="ms-vb">State v. B.C. / State v. D.H.</td><td class="ms-vb">2016 VT 66</td><td class="ms-vb">2015-254, 2015-263</td><td class="ms-vb">6/17/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op16-027.pdf">op16-027.pdf</a></td><td class="ms-vb">In re Petition of New England Police Benevolent Association</td><td class="ms-vb">2016 VT 67</td><td class="ms-vb">2016-027</td><td class="ms-vb">6/10/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-268.pdf">op15-268.pdf</a></td><td class="ms-vb">Mongeon Bay Properties, LLC v. Mallets Bay Homeowner's Assn., Anthony J. Sineni and Merrimack Mortagage Co.</td><td class="ms-vb">2016 VT 64</td><td class="ms-vb">2015-268</td><td class="ms-vb">6/10/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-451.pdf">op14-451.pdf</a></td><td class="ms-vb">State v. Jason L. Gagne</td><td class="ms-vb">2016 VT 68</td><td class="ms-vb">2014-451</td><td class="ms-vb">6/10/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-269.pdf">op15-269.pdf</a></td><td class="ms-vb">State v. Amy Koenig</td><td class="ms-vb">2016 VT 65</td><td class="ms-vb">2015-269</td><td class="ms-vb">6/3/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-386.pdf">op15-386.pdf</a></td><td class="ms-vb">Charles Chandler v. State </td><td class="ms-vb">2016 VT 62</td><td class="ms-vb">2015-386</td><td class="ms-vb">5/27/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-260.pdf">op15-260.pdf</a></td><td class="ms-vb">In re Burns Two-Unit Residential Building (Michael Long, et al. Appellants)</td><td class="ms-vb">2016 VT 63</td><td class="ms-vb">2015-260</td><td class="ms-vb">5/27/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-201.pdf">op15-201.pdf</a></td><td class="ms-vb">State v. Atlantic Richfield Company, et al.</td><td class="ms-vb">2016 VT 61</td><td class="ms-vb">2015-201</td><td class="ms-vb">5/27/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-407.pdf">op15-407.pdf</a></td><td class="ms-vb">State v. David G. Buckley</td><td class="ms-vb">2016 VT 59</td><td class="ms-vb">2015-407</td><td class="ms-vb">5/27/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-164.pdf">op15-164.pdf</a></td><td class="ms-vb">State v. Willy Levitt</td><td class="ms-vb">2016 VT 60</td><td class="ms-vb">2015-164</td><td class="ms-vb">5/27/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-440.pdf">op14-440.pdf</a></td><td class="ms-vb">State v. Shawn Kelley</td><td class="ms-vb">2016 VT 58</td><td class="ms-vb">2014-440</td><td class="ms-vb">5/20/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-070.pdf">op15-070.pdf</a></td><td class="ms-vb">Walter Lourie v. Sharlee Lourie</td><td class="ms-vb">2016 VT 57</td><td class="ms-vb">2015-070</td><td class="ms-vb">5/13/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-396.pdf">op14-396.pdf</a></td><td class="ms-vb">Carole Kuligoski, Individually and On Behalf of Michael J. Kuligoski, Mark Kuligoski and James Kuligoski v. Brattleboro Retreat and Northeast Kingdom Human Services</td><td class="ms-vb">2016 VT 54</td><td class="ms-vb">2014-396</td><td class="ms-vb">5/6/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-085.pdf">op15-085.pdf</a></td><td class="ms-vb">In re Wight Manning</td><td class="ms-vb">2016 VT 53</td><td class="ms-vb">2015-085</td><td class="ms-vb">5/6/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-233.pdf">op15-233.pdf</a></td><td class="ms-vb">State v. Robert Witham</td><td class="ms-vb">2015 VT 51</td><td class="ms-vb">2015-233</td><td class="ms-vb">5/6/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-091.pdf">op15-091.pdf</a></td><td class="ms-vb">Town of Milton Board of Health v. Armand Brisson</td><td class="ms-vb">2016 VT 56</td><td class="ms-vb">2015-091</td><td class="ms-vb">5/6/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-007.pdf">op15-007.pdf</a></td><td class="ms-vb">In re K.A., Juvenile</td><td class="ms-vb">2016 VT 52</td><td class="ms-vb">2015-007</td><td class="ms-vb">4/29/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-230.pdf">op15-230.pdf</a></td><td class="ms-vb">In re Petition of Rutland Renewable Energy, LLC for Certificate of Public Good Pursuant to 30 V.S.A. § 248, et al.</td><td class="ms-vb">2016 VT 50</td><td class="ms-vb">2015-230</td><td class="ms-vb">4/29/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-317.pdf">op15-317.pdf</a></td><td class="ms-vb">Kurt Daims &amp; Craig Newbert v. Town of Brattleboro</td><td class="ms-vb">2016 VT 55</td><td class="ms-vb">2015-317</td><td class="ms-vb">4/29/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-296.pdf">op15-296.pdf</a></td><td class="ms-vb">State v. Julianne Graham</td><td class="ms-vb">2016 VT 48</td><td class="ms-vb">2015-296</td><td class="ms-vb">4/29/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-044.pdf">op15-044.pdf</a></td><td class="ms-vb">State v. Stephen Howard</td><td class="ms-vb">2016 VT 49</td><td class="ms-vb">2015-044</td><td class="ms-vb">4/29/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-066.pdf">op15-066.pdf</a></td><td class="ms-vb">Concord General Mutual Insurance Company and Kevin Flanagan and Linda Flanagan v. Nathan Gritman, Austin Lawson, Nicholas T. Sweet, Elizabeth Plude, Kevin Spear and Dylan Stinson </td><td class="ms-vb">2016 VT 45</td><td class="ms-vb">2015-066</td><td class="ms-vb">4/22/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-319.pdf">op15-319.pdf</a></td><td class="ms-vb">Kathleen Zink v. Bryan Zink</td><td class="ms-vb">2016 VT 46</td><td class="ms-vb">2015-319</td><td class="ms-vb">4/22/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-020.pdf">op15-020.pdf</a></td><td class="ms-vb">State v. James Anderson</td><td class="ms-vb">2016 VT 40</td><td class="ms-vb">2015-020</td><td class="ms-vb">4/22/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-100.pdf">op15-100.pdf</a></td><td class="ms-vb">State v. Owen Cornell</td><td class="ms-vb">2016 VT 47</td><td class="ms-vb">2015-100</td><td class="ms-vb">4/22/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-259.pdf">op15-259.pdf</a></td><td class="ms-vb">In re  Waterfront Park Act 250 Amendment (Alison Lockwood, Appellant)</td><td class="ms-vb">2016 VT 39</td><td class="ms-vb">2015-259</td><td class="ms-vb">4/15/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-157.pdf">op15-157.pdf</a></td><td class="ms-vb">Laura Clark as Personal Representative of the Estate of Christopher Tylie Jackson-Clark, et al. v. Richard Baker, M.D., Mary Beerworth, M.D., et al.</td><td class="ms-vb">2016 VT 42</td><td class="ms-vb">2015-157</td><td class="ms-vb">4/15/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-146.pdf">op15-146.pdf</a></td><td class="ms-vb">State v. Leo Reynolds</td><td class="ms-vb">2016 VT 43</td><td class="ms-vb">2015-146</td><td class="ms-vb">4/8/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-158.pdf">op15-158.pdf</a></td><td class="ms-vb">TLOC Senior Living, LLC v. Albert R. (Alpine) Bingham III</td><td class="ms-vb">2016 VT 44</td><td class="ms-vb">2015-158</td><td class="ms-vb">4/8/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-129.pdf">op15-129.pdf</a></td><td class="ms-vb">Burlington Administrators' Association and Nicolas Molander v. Burlington Board of School Commissioners</td><td class="ms-vb">2016 VT 35</td><td class="ms-vb">2015-129</td><td class="ms-vb">4/1/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-424.pdf">op15-424.pdf</a></td><td class="ms-vb">In re D.S., Juvenile</td><td class="ms-vb">2016 VT 38</td><td class="ms-vb">2015-424</td><td class="ms-vb">3/25/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-142.pdf">op14-142.pdf</a></td><td class="ms-vb">State v. Thomas Gauthier</td><td class="ms-vb">2016 VT 37</td><td class="ms-vb">2014-142</td><td class="ms-vb">3/25/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-357.pdf">op15-357.pdf</a></td><td class="ms-vb">In re M.W., Juvenile</td><td class="ms-vb">2016 VT 28</td><td class="ms-vb">2015-357</td><td class="ms-vb">3/18/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op16-053.pdf">op16-053.pdf</a></td><td class="ms-vb">State v. Jeremy Gates</td><td class="ms-vb">2016 VT 36</td><td class="ms-vb">2016-053</td><td class="ms-vb">3/16/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-260.pdf">op14-260.pdf</a></td><td class="ms-vb">Fred Osier and Eugene H. Shaver v. Burlington Telecom, City of Burlington and Jonathan Leopold</td><td class="ms-vb">2016 VT 34</td><td class="ms-vb">2014-260</td><td class="ms-vb">3/11/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-250.pdf">op15-250.pdf</a></td><td class="ms-vb">In re Christena Obregon, Esq.</td><td class="ms-vb">2016 VT 32</td><td class="ms-vb">2015-250</td><td class="ms-vb">3/11/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-221.pdf">op15-221.pdf</a></td><td class="ms-vb">Matthew Burgess v. Lamoille Housing Partnership, Town of Morristown, Mary Ann Wilson as Collector of Taxes and Sharon Green, Esq.</td><td class="ms-vb">2016 VT 31</td><td class="ms-vb">2015-221</td><td class="ms-vb">3/11/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-427.pdf">op14-427.pdf</a></td><td class="ms-vb">State v. Tisa Farrow</td><td class="ms-vb">2016 VT 30</td><td class="ms-vb">2014-427</td><td class="ms-vb">3/11/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-086.pdf">op15-086.pdf</a></td><td class="ms-vb">Unifund CCR Partners v. Daniel Zimmer</td><td class="ms-vb">2016 VT 33</td><td class="ms-vb">2015-086</td><td class="ms-vb">3/11/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-253.pdf">op15-253.pdf</a></td><td class="ms-vb">Synecology Partners L3C v. Business RunTime, Inc., et al.</td><td class="ms-vb">2016 VT 29</td><td class="ms-vb">2015-253</td><td class="ms-vb">3/4/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-330.pdf">op14-330.pdf</a></td><td class="ms-vb">William Deveneau v. Susan Weilt and Brian Toomey</td><td class="ms-vb">2016 VT 21</td><td class="ms-vb">2014-330</td><td class="ms-vb">3/4/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-273.pdf">op14-273.pdf</a></td><td class="ms-vb">State v. Jason Atherton a/k/a Melton</td><td class="ms-vb">2016 VT 25</td><td class="ms-vb">2014-273</td><td class="ms-vb">2/26/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-080.pdf">op15-080.pdf</a></td><td class="ms-vb">State v. Michael Rosenfield</td><td class="ms-vb">2016 VT 27</td><td class="ms-vb">2015-080</td><td class="ms-vb">2/26/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-125.pdf">op15-125.pdf</a></td><td class="ms-vb">State v. Sergio Mendez</td><td class="ms-vb">2016 VT 24</td><td class="ms-vb">2015-125</td><td class="ms-vb">2/26/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/eo16-025.bail.pdf">eo16-025.bail.pdf</a></td><td class="ms-vb">State v. Aaron Lontine</td><td class="ms-vb">2016 VT 26</td><td class="ms-vb">2016-025, 2016-033</td><td class="ms-vb">2/18/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-455.pdf">op14-455.pdf</a></td><td class="ms-vb">Brisson Stone, LLC, Allan Brisson and Michael Brisson v. Town of Monkton and Claudia Orlandi</td><td class="ms-vb">2016 VT 15</td><td class="ms-vb">2014-455</td><td class="ms-vb">2/12/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op13-067.pdf">op13-067.pdf</a></td><td class="ms-vb">Debra Morisseau v. Hannaford Brothers</td><td class="ms-vb">2016 VT 17</td><td class="ms-vb">2013-067</td><td class="ms-vb">2/12/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-321.pdf">op15-321.pdf</a></td><td class="ms-vb">In re T.M. and A.M., Juveniles</td><td class="ms-vb">2016 VT 23</td><td class="ms-vb">2015-321</td><td class="ms-vb">2/12/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-168.pdf">op15-168.pdf</a></td><td class="ms-vb">In re Treetop Development Company Act 250 Development (Treetop at Stratton Condominium Assn., Inc., Appellant)</td><td class="ms-vb">2016 VT 20</td><td class="ms-vb">2015-168</td><td class="ms-vb">2/12/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-204.pdf">op15-204.pdf</a></td><td class="ms-vb">State v. Atlantic Richfield Company, et al.</td><td class="ms-vb">2016 VT 22</td><td class="ms-vb">2015-204</td><td class="ms-vb">2/12/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-001.pdf">op15-001.pdf</a></td><td class="ms-vb">State v. James Careau</td><td class="ms-vb">2016 VT 18</td><td class="ms-vb">2015-001</td><td class="ms-vb">2/12/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-347.pdf">op14-347.pdf</a></td><td class="ms-vb">State v. Shamel L. Alexander</td><td class="ms-vb">2016 VT 19</td><td class="ms-vb">2014-347</td><td class="ms-vb">2/12/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-362.pdf">op14-362.pdf</a></td><td class="ms-vb">State v. Thomas Bryan</td><td class="ms-vb">2016 VT 16</td><td class="ms-vb">2014-362</td><td class="ms-vb">2/12/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-296.pdf">op14-296.pdf</a></td><td class="ms-vb">In re Estate of Dezotell</td><td class="ms-vb">2016 VT 14</td><td class="ms-vb">2014-296</td><td class="ms-vb">2/5/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-270.pdf">op14-270.pdf</a></td><td class="ms-vb">Debra L. McGee / Office of Child Support v. Justin Gonyo</td><td class="ms-vb">2016 VT 8</td><td class="ms-vb">2014-270</td><td class="ms-vb">1/29/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-014.pdf">op15-014.pdf</a></td><td class="ms-vb">In re Appeal of the Estate of Elaine A. Holbrook Late of Salisbury, Vermont (David Holbrook, Cheryl Holbrook and Charles Holbrook III, Appellants)</td><td class="ms-vb">2016 VT 13</td><td class="ms-vb">2015-014</td><td class="ms-vb">1/29/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-369.pdf">op14-369.pdf</a></td><td class="ms-vb">In re Willowell Foundation Conditional Use Certificate of Occupancy (Andrew Higbee, Jr. and Sheryl Knauth, Appellants)</td><td class="ms-vb">2016 VT 12</td><td class="ms-vb">2014-369</td><td class="ms-vb">1/29/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-273.pdf">op15-273.pdf</a></td><td class="ms-vb">In re J.C. &amp; T.F., Juveniles</td><td class="ms-vb">2016 VT 9</td><td class="ms-vb">2015-273</td><td class="ms-vb">1/22/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-465.pdf">op14-465.pdf</a></td><td class="ms-vb">John T. Adams II v. Town of Sudbury</td><td class="ms-vb">2016 VT 11</td><td class="ms-vb">2014-465</td><td class="ms-vb">1/22/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-248.pdf">op15-248.pdf</a></td><td class="ms-vb">David Demarest, et al. v. Town of Underhill</td><td class="ms-vb">2016 VT 10</td><td class="ms-vb">2015-248</td><td class="ms-vb">1/15/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-021.pdf">op15-021.pdf</a></td><td class="ms-vb">Karen Wynkoop v. Gerard Stratthaus</td><td class="ms-vb">2016 VT 5</td><td class="ms-vb">2015-021</td><td class="ms-vb">1/15/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-133.pdf">op15-133.pdf</a></td><td class="ms-vb">Raymond Knutsen v. Karen Cegalis</td><td class="ms-vb">2016 VT 2</td><td class="ms-vb">2015-133</td><td class="ms-vb">1/15/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-432.pdf">op14-432.pdf</a></td><td class="ms-vb">In re Election Petitions</td><td class="ms-vb">2016 VT 7</td><td class="ms-vb">2014-432</td><td class="ms-vb">1/8/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-181.motion.pdf">op15-181.motion.pdf</a></td><td class="ms-vb">In re Joseph Bruyette</td><td class="ms-vb">2016 VT 3</td><td class="ms-vb">2015-181</td><td class="ms-vb">1/8/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-131.pdf">op15-131.pdf</a></td><td class="ms-vb">Lauritz Rasmussen v. Town of Fair Haven</td><td class="ms-vb">2016 VT 1</td><td class="ms-vb">2015-131</td><td class="ms-vb">1/8/2016</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-460.pdf">op14-460.pdf</a></td><td class="ms-vb">Sandra Baird and Jared Carter</td><td class="ms-vb">2016 VT 6</td><td class="ms-vb">2014-460</td><td class="ms-vb">1/8/2016</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-340.pdf">op14-340.pdf</a></td><td class="ms-vb">State v. Ivan Alcide</td><td class="ms-vb">2016 VT 4</td><td class="ms-vb">2014-340</td><td class="ms-vb">1/8/2016</td></tr><tr id="group0" style="display:auto"><td class="ms-gb" style="background:#cccccc;" colspan="99"><a href="javascript:" onclick="javascript:ExpGroupBy(this);return false;"><img src="/_layouts/images/minus.gif" border="0" alt="collapse" name="expand"></a>&nbsp;<b>Year Published</b>: 2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-445.pdf">op14-445.pdf</a></td><td class="ms-vb">Vermont Human Rights Commission, Lynne Silloway, Mary Bertrand and Lisa DeBlois v. State of Vermont, Department of Corrections and Department of Human Services</td><td class="ms-vb">2015 VT 138</td><td class="ms-vb">2014-445</td><td class="ms-vb">12/24/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/eo15-431.bail.pdf">eo15-431.bail.pdf</a></td><td class="ms-vb">State v. Joshua Blow</td><td class="ms-vb">2015 VT 143</td><td class="ms-vb">2015-431</td><td class="ms-vb">12/21/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-136.pdf">op15-136.pdf</a></td><td class="ms-vb">Christos Panagiotidis and Hrisanthi Panagiotidis v. Alexander Galanis</td><td class="ms-vb">2015 VT 134</td><td class="ms-vb">2015-136</td><td class="ms-vb">12/18/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-073.pdf">op15-073.pdf</a></td><td class="ms-vb">Neil and Patricia Whitney v. Vermont Mutual Insurance Company</td><td class="ms-vb">2015 VT 140</td><td class="ms-vb">2015-073</td><td class="ms-vb">12/11/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-009.pdf">op14-009.pdf</a></td><td class="ms-vb">State v. Peter A. Goewey</td><td class="ms-vb">2015 VT 142</td><td class="ms-vb">2014-009</td><td class="ms-vb">12/11/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/eo15-217.pdf">eo15-217.pdf</a></td><td class="ms-vb">In re Christopher Sullivan, Esq.</td><td class="ms-vb">2015 VT 141</td><td class="ms-vb">2015-217</td><td class="ms-vb">11/24/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-312.pdf">op14-312.pdf</a></td><td class="ms-vb">AIG Insurance Management Services, Inc. v. Vermont Department of Taxes</td><td class="ms-vb">2015 VT 137</td><td class="ms-vb">2014-312</td><td class="ms-vb">11/20/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-067.pdf">op15-067.pdf</a></td><td class="ms-vb">In re Petition of VTel Wireless Inc., for a Certificate of Public Good, Pursuant to 30 V.S.A. Section 248a, for the Installation of Telecommunications Equipment in Bennnington, VT (Susan Beal and David Pearson, Appellant)</td><td class="ms-vb">2015 VT 135</td><td class="ms-vb">2015-067</td><td class="ms-vb">11/20/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-075.pdf">op15-075.pdf</a></td><td class="ms-vb">Jennifer Weinstein v. Jeanmarie Leonard and Carol Sayour v. Lloyd J. Weinstein and The Weinstein Group, P.C.</td><td class="ms-vb">2015 VT 136</td><td class="ms-vb">2015-075</td><td class="ms-vb">11/13/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-284.pdf">op14-284.pdf</a></td><td class="ms-vb">State v. Anthony Gotavaskas / State v. Grant S. Bercik</td><td class="ms-vb">2015 VT 133</td><td class="ms-vb">2014-284, 2014-285 &amp; 2014-286</td><td class="ms-vb">11/13/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/eo14-335.pdf">eo14-335.pdf</a></td><td class="ms-vb">State v. Zahariah Theodorou</td><td class="ms-vb">2015 VT 139</td><td class="ms-vb">2014-335</td><td class="ms-vb">10/27/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-370.pdf">op14-370.pdf</a></td><td class="ms-vb">Timothy Terry and Penny Terry v. William O'Brien and Susan Cain O'Brien</td><td class="ms-vb">2015 VT 132</td><td class="ms-vb">2014-370</td><td class="ms-vb">10/23/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-301.pdf">op14-301.pdf</a></td><td class="ms-vb">Everbank, Successor by Assignment to Bank of America, N.A.</td><td class="ms-vb">2015 VT 131</td><td class="ms-vb">2014-301</td><td class="ms-vb">10/16/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-083.pdf">op15-083.pdf</a></td><td class="ms-vb">In re Application of Beach Properties, Inc. d/b/a Basin Harbor Club, for a Certificate of Public Good for an Interconnected Group Net-Metered Photovoltaic Electric Power System</td><td class="ms-vb">2015 VT 130</td><td class="ms-vb">2015-083</td><td class="ms-vb">10/16/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-092.pdf">op15-092.pdf</a></td><td class="ms-vb">Kenneth P. Felis v. Downs Rachlin Martin, PLLC, and Gallagher, Flynn &amp; Company, LLP</td><td class="ms-vb">2015 VT 129</td><td class="ms-vb">2015-092</td><td class="ms-vb">10/16/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-382.pdf">op14-382.pdf</a></td><td class="ms-vb">Dow Tillson and Susan Tillson v. Richard A. Lane, M.D. and Lane Eye Associates</td><td class="ms-vb">2015 VT 121</td><td class="ms-vb">2014-382</td><td class="ms-vb">10/9/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-434.pdf">op14-434.pdf</a></td><td class="ms-vb">In re Bove Demolition/Construction Application (Richard J. Bove, Sr. and Rick Bove, Appellants)</td><td class="ms-vb">2015 VT 123</td><td class="ms-vb">2014-434</td><td class="ms-vb">10/9/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-463.pdf">op14-463.pdf</a></td><td class="ms-vb">Amy Labate &amp; Robert Labate, Individually and On Behalf of Minor Daughter, J.L. v. Rutland Hospital, Inc. d/b/a Rutland Regional Medical Center and Santiago Cancio-Bello, M.D.</td><td class="ms-vb">2015 VT 128</td><td class="ms-vb">2014-463</td><td class="ms-vb">10/2/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-144.pdf">op15-144.pdf</a></td><td class="ms-vb">In re M.M. and C.M., Juveniles</td><td class="ms-vb">2015 VT 122</td><td class="ms-vb">2015-144</td><td class="ms-vb">10/2/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-207.pdf">op14-207.pdf</a></td><td class="ms-vb">State v. Eric K. Manning</td><td class="ms-vb">2015 VT 124</td><td class="ms-vb">2014-207</td><td class="ms-vb">10/2/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/eo15-331.bail.pdf">eo15-331.bail.pdf</a></td><td class="ms-vb">State v. Evan P. Ford</td><td class="ms-vb">2015 VT 127</td><td class="ms-vb">2015-331</td><td class="ms-vb">9/29/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-388.pdf">op14-388.pdf</a></td><td class="ms-vb">Connie C. Simendinger v. William Simendinger</td><td class="ms-vb">2015 VT 118</td><td class="ms-vb">2014-388</td><td class="ms-vb">9/18/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-170.pdf">op15-170.pdf</a></td><td class="ms-vb">In re M.O., Juvenile</td><td class="ms-vb">2015 VT 120</td><td class="ms-vb">2015-170</td><td class="ms-vb">9/18/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-275.pdf">op14-275.pdf</a></td><td class="ms-vb">Janet McKinstry &amp; Mark McKinstry</td><td class="ms-vb">2015 VT 125</td><td class="ms-vb">2014-275</td><td class="ms-vb">9/18/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-196.pdf">op14-196.pdf</a></td><td class="ms-vb">State v. Kent Richland, Jr.</td><td class="ms-vb">2015 VT 126</td><td class="ms-vb">2014-196</td><td class="ms-vb">9/18/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-035.pdf">op15-035.pdf</a></td><td class="ms-vb">Michael Bandler, MB&amp;Co, Ltd. a/k/a Michael Bandler &amp; Company v. Cohen Rosenthal &amp; Kramer, LLP</td><td class="ms-vb">2015 VT 115</td><td class="ms-vb">2015-035</td><td class="ms-vb">9/11/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-108.pdf">op14-108.pdf</a></td><td class="ms-vb">Roxanne Moran v. Vermont State Retirement Board and Vermont State Treasurer</td><td class="ms-vb">2015 VT 119</td><td class="ms-vb">2014-108</td><td class="ms-vb">9/11/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-292.pdf">op14-292.pdf</a></td><td class="ms-vb">State v. William O. Stanley, Sr.</td><td class="ms-vb">2015 VT 117</td><td class="ms-vb">2014-292</td><td class="ms-vb">9/11/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op13-477.pdf">op13-477.pdf</a></td><td class="ms-vb">State v. Adam Winters</td><td class="ms-vb">2015 VT 116</td><td class="ms-vb">2013-477</td><td class="ms-vb">9/4/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-020.pdf">op14-020.pdf</a></td><td class="ms-vb">State v. Billy Joe Putnam</td><td class="ms-vb">2015 VT 113</td><td class="ms-vb">2014-020</td><td class="ms-vb">9/4/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-363.pdf">op14-363.pdf</a></td><td class="ms-vb">In re A.M., Juvenile</td><td class="ms-vb">2015 VT 109</td><td class="ms-vb">2014-363</td><td class="ms-vb">8/28/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-160.pdf">op14-160.pdf</a></td><td class="ms-vb">James LeBlanc, Christine LeBlanc Fortin, David LeBlanc and Herman LeBlanc v. Robert E. Snelgrove</td><td class="ms-vb">2015 VT 112</td><td class="ms-vb">2014-160</td><td class="ms-vb">8/28/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-055.pdf">op14-055.pdf</a></td><td class="ms-vb">State v. David Tracy</td><td class="ms-vb">2015 VT 111</td><td class="ms-vb">2014-055</td><td class="ms-vb">8/28/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/eo15-274.bail.pdf">eo15-274.bail.pdf</a></td><td class="ms-vb">State v. James Cushing</td><td class="ms-vb">2015 VT 114</td><td class="ms-vb">2015-274</td><td class="ms-vb">8/25/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-352.pdf">op14-352.pdf</a></td><td class="ms-vb">In re Champlain Parkway Act 250 Permit (Fortieth Burlington LLC, Appellant)</td><td class="ms-vb">2015 VT 105</td><td class="ms-vb">2014-352</td><td class="ms-vb">8/21/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-003.pdf">op15-003.pdf</a></td><td class="ms-vb">Juanita Burch-Clay v. Debra J. Taylor, Individually and In Her Capacity as Superintendent of Schools, Rutland Central Supervisory Union</td><td class="ms-vb">2015 VT 110</td><td class="ms-vb">2015-003</td><td class="ms-vb">8/21/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-390.pdf">op14-390.pdf</a></td><td class="ms-vb">Kathleen Vanderbloom v. State of Vermont, Agency of Transportation</td><td class="ms-vb">2015 VT 103</td><td class="ms-vb">2014-390</td><td class="ms-vb">8/21/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-240.pdf">op14-240.pdf</a></td><td class="ms-vb">David A. Gauthier v. Keurig Green Mountain, Inc. f/k/a Green Mountain Coffee Roasters, Inc.</td><td class="ms-vb">2015 VT 108</td><td class="ms-vb">2014-240</td><td class="ms-vb">8/14/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-373.pdf">op14-373.pdf</a></td><td class="ms-vb">In re Cherie Hyde</td><td class="ms-vb">2015 VT 106</td><td class="ms-vb">2014-373</td><td class="ms-vb">8/14/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-246.pdf">op14-246.pdf</a></td><td class="ms-vb">In re Derrick Brown</td><td class="ms-vb">2015 VT 107</td><td class="ms-vb">2014-246</td><td class="ms-vb">8/14/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-419.pdf">op14-419.pdf</a></td><td class="ms-vb">State v. Kelly M. Taylor</td><td class="ms-vb">2015 VT 104</td><td class="ms-vb">2014-419</td><td class="ms-vb">8/14/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-121.pdf">op14-121.pdf</a></td><td class="ms-vb">State v. Leo Paul Pratt II</td><td class="ms-vb">2015 VT 89</td><td class="ms-vb">2014-121</td><td class="ms-vb">8/14/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op13-480.pdf">op13-480.pdf</a></td><td class="ms-vb">State v. Timothy P. Perley</td><td class="ms-vb">2015 VT 102</td><td class="ms-vb">2013-480</td><td class="ms-vb">8/14/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/eo15-258.pdf">eo15-258.pdf</a></td><td class="ms-vb">In re PRB Docket No. 2015.002</td><td class="ms-vb">2015 VT 101</td><td class="ms-vb">2015-258</td><td class="ms-vb">8/11/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-087.pdf">op14-087.pdf</a></td><td class="ms-vb">Equinox on the Battenkill Management Assn., Inc. v. Philadelphia Indemnity Ins. Co.</td><td class="ms-vb">2015 VT 98</td><td class="ms-vb">2014-087</td><td class="ms-vb">8/7/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-019.pdf">op15-019.pdf</a></td><td class="ms-vb">In re R.B., O.B. and K.C., Juveniles</td><td class="ms-vb">2015 VT 100</td><td class="ms-vb">2015-019</td><td class="ms-vb">8/7/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-410.pdf">op14-410.pdf</a></td><td class="ms-vb">State v. Paul Aiken</td><td class="ms-vb">2015 VT 99</td><td class="ms-vb">2014-410</td><td class="ms-vb">8/7/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-300.pdf">op14-300.pdf</a></td><td class="ms-vb">State v. David Wisowaty</td><td class="ms-vb">2015 VT 97</td><td class="ms-vb">2014-300</td><td class="ms-vb">7/24/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-269.pdf">op14-269.pdf</a></td><td class="ms-vb">State v. Salahdin Trowell</td><td class="ms-vb">2015 VT 96</td><td class="ms-vb">2014-269</td><td class="ms-vb">7/24/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-339.pdf">op14-339.pdf</a></td><td class="ms-vb">Brice Kirkland and Gordon Kirkland v. James Kolodziej and Barbara Kolodziej</td><td class="ms-vb">2015 VT 90</td><td class="ms-vb">2014-339</td><td class="ms-vb">7/17/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op15-022.pdf">op15-022.pdf</a></td><td class="ms-vb">In re J.M., Juvenile</td><td class="ms-vb">2015 VT 94</td><td class="ms-vb">2015-022</td><td class="ms-vb">7/17/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-190.pdf">op14-190.pdf</a></td><td class="ms-vb">In re North East Materials Group LLC ACT 250 JO #5-21 (Russell Austin, Pamela Austin, Julie Barre, Marc Bernier, et al., Appellants)</td><td class="ms-vb">2015 VT 79</td><td class="ms-vb">2014-190</td><td class="ms-vb">7/17/2015</td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/op14-283.pdf">op14-283.pdf</a></td><td class="ms-vb">In re Stephanie H. Taylor, M.D.</td><td class="ms-vb">2015 VT 95</td><td class="ms-vb">2014-283</td><td class="ms-vb">7/17/2015</td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/op13-201A.amended.pdf">op13-201A.amended.pdf</a></td><td class="ms-vb">State v. Scott Provost</td><td class="ms-vb">2014 VT 86A</td><td class="ms-vb">2013-201</td><td class="ms-vb">7/17/2015</td></tr><tr id="group0" style="display:auto"><td class="ms-gb" style="background:#cccccc;" colspan="99"><a href="javascript:" onclick="javascript:ExpGroupBy(this);return false;"><img src="/_layouts/images/minus.gif" border="0" alt="collapse" name="expand"></a>&nbsp;<b>Year Published</b>: </td></tr><tr class="ms-alternating"><td class="ms-vb"><a href="Supreme Court Published Decisions/In re Stephanie H. Taylor, M.D.Medical Practice Board.pdf">In re Stephanie H. Taylor, M.D.Medical Practice Board.pdf</a></td><td class="ms-vb"></td><td class="ms-vb"></td><td class="ms-vb"></td><td class="ms-vb"></td></tr><tr><td class="ms-vb"><a href="Supreme Court Published Decisions/Kevin Ward v. Renee LaRue.Peterson.Chittenden.pdf">Kevin Ward v. Renee LaRue.Peterson.Chittenden.pdf</a></td><td class="ms-vb"></td><td class="ms-vb"></td><td class="ms-vb"></td><td class="ms-vb"></td></tr></table></div></td>
+	</tr>
+</table></td>
+				</tr>
+				</table>
+			</td>
+		</tr>
+
+	</table>
+
+	<style type="text/css">
+.style5 {
+	font-family: "Monotype Corsiva";
+	font-size: x-large;
+	margin-bottom: 4px;
+}
+.style7 {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: small;
+	text-align: center;
+}
+.style8 {
+	color: #C2A770;
+}
+.style10 {
+				font-family: "Monotype Corsiva";
+				font-size: large;
+				margin-bottom: 4px;
+}
+</style>
+
+
+			 </td>
+		  </tr>
+		</table>
+		</PlaceHolder>
+	  </td>
+	  <td class="ms-rightareacell" style="height: 94%">
+<!-- Right Page Divider -->
+<div style="background-color:white" ><!-- class="ms-pagemargin" -->
+	<!--
+	<IMG SRC="/_layouts/images/blank.gif" width=10 height=1 alt="">
+	-->
+</div>
+
+</td>
+	</TR>
+<tr width="100px">
+	<td class="ms-pagebottommarginleft"><IMG SRC="/_layouts/images/blank.gif" width=1 height=10 alt=""></td>
+	<td class="ms-pagebottommargin"><IMG SRC="/_layouts/images/blank.gif" width=1 height=10 alt=""></td>
+	<td class="ms-bodyareapagemargin"><IMG SRC="/_layouts/images/blank.gif" width=1 height=10 alt=""></td>
+	<td class="ms-pagebottommarginright"><IMG SRC="/_layouts/images/blank.gif" width=1 height=10 alt=""></td>
+</tr>
+</TABLE>
+</TD>
+</TR>
+</table>
+
+<!-- Start Footer -->
+<div style="width:100%;background-color:#E2E9DA">
+<!--
+<table CELLPADDING=0 CELLSPACING=0 BORDER=0 style="width:100%"><!-- class="ms-main" -->
+<!--
+	<tr width="100%">
+		<td width="100%" colspan="3" align="center" class="ms-pagebottommarginright">
+-->
+			<!--	<P STYLE="text-align: center">
+					<font size="1">
+						<span class="style1">This website is compliant with the W3C's Web Accessibility Initiative Guidelines and is optimized for screen readers
+						</span>
+					</font>
+				</P>-->
+<!--
+
+		</td>
+	</tr>
+  </TABLE>
+</div>
+<!-- End Footer -->
+
+
+<!-- Start Site Action, etc -->
+
+<table class="ms-main" CELLPADDING=0 CELLSPACING=0 BORDER=0 WIDTH="100%">
+	<tr align="right">
+		<td class="ms-pagebottommarginright">
+			<div style="position:relative;top:5px;width:200px; right:240px;">
+			 <table cellpadding=0 cellspacing=0 border=0>
+			  <tr>
+			   <td>
+				<table height=100% class="ms-siteaction" cellpadding=0 cellspacing=0>
+				 <tr>	<td width="25px"></td>
+					   <td class="ms-siteactionsmenu" id="siteactiontd">
+
+					   </td>
+				 </tr>
+				</table>
+			   </td>
+			  </tr>
+			 </table>
+
+
+			</div>
+			<div style="position:relative;top:-14px;width:300px; right:30px;">
+					<table cellpadding="0" cellspacing="0" height=100% class="ms-globalright">
+						<tr>
+							<td valign="middle" class="ms-globallinks" style="padding-left:3px; padding-right:6px;">
+
+							</td>
+							<td valign="middle" class="ms-globallinks">
+
+<a id="ctl00_IdWelcome_ExplicitLogin" href="https://www.VermontJudiciary.org/LC/_layouts/Authenticate.aspx?Source=%2FLC%2FSupCrtPublish%2Easpx" style="display:block;">Sign In</a>
+
+							</td>
+							<td style="padding-left:1px;padding-right:3px;" class="ms-globallinks">&nbsp;<td valign="middle" class="ms-globallinks">
+								<table cellspacing="0" cellpadding="0">
+									<tr>
+									  	<td class="ms-globallinks">
+											</td>
+										<td class="ms-globallinks">
+
+<table><tr>
+<td class="ms-globallinks"></td>
+<td class="ms-globallinks"></td>
+</tr></table>
+</td>
+									</tr>
+								</table>
+							</td>
+							<td valign="middle" class="ms-globallinks">&nbsp;
+								<a href="javascript:TopHelpButtonClick('NavBarHelpHome')" id="ctl00_TopHelpLink" AccessKey="6" title="Help (new window)"><img src="/_layouts/images/helpicon.gif" align="absmiddle" border="0" alt="Help (new window)" /></a>
+							</td>
+						</tr>
+						<tr>
+							<td colspan="5" style="padding-top:8px;" valign=top>
+							</td>
+						</tr>
+					</table>
+			</div>
+		</td>
+	</tr>
+</table>
+
+<!-- End Site Action, etc -->
+
+
+
+
+   <input type="text" name="__spDummyText1" style="display:none;" size=1/>
+   <input type="text" name="__spDummyText2" style="display:none;" size=1/>
+
+
+
+
+
+	</div>
+
+
+<script type="text/javascript">
+//<![CDATA[
+
+var callBackFrameUrl='/WebResource.axd?d=_jy2GR1SlUQI9qY6zOl4dNtQyzh5hMXVZjaxouxH9EWhMTwMDcg9YucxdhA_eVZeh4EAeN4riSqrVvR3YE6bEdZO7NQ1&t=635857236729967414';
+WebForm_InitCallback();var __wpmExportWarning='This Web Part Page has been personalized. As a result, one or more Web Part properties may contain confidential information. Make sure the properties contain information that is safe for others to read. After exporting this Web Part, view properties in the Web Part description file (.WebPart) by using a text editor such as Microsoft Notepad.';var __wpmCloseProviderWarning='You are about to close this Web Part.  It is currently providing data to other Web Parts, and these connections will be deleted if this Web Part is closed.  To close this Web Part, click OK.  To keep this Web Part, click Cancel.';var __wpmDeleteWarning='You are about to permanently delete this Web Part.  Are you sure you want to do this?  To delete this Web Part, click OK.  To keep this Web Part, click Cancel.';var zz1_TopNavigationMenu_Data = new Object();
+zz1_TopNavigationMenu_Data.disappearAfter = 500;
+zz1_TopNavigationMenu_Data.horizontalOffset = 0;
+zz1_TopNavigationMenu_Data.verticalOffset = 0;
+zz1_TopNavigationMenu_Data.hoverClass = 'zz1_TopNavigationMenu_16 ms-topNavFlyOutsHover';
+zz1_TopNavigationMenu_Data.hoverHyperLinkClass = 'zz1_TopNavigationMenu_15 ms-topNavFlyOutsHover';
+zz1_TopNavigationMenu_Data.staticHoverClass = 'zz1_TopNavigationMenu_14 ms-topNavHover';
+zz1_TopNavigationMenu_Data.staticHoverHyperLinkClass = 'zz1_TopNavigationMenu_13 ms-topNavHover';
+zz1_TopNavigationMenu_Data.iframeUrl = '/WebResource.axd?d=_jy2GR1SlUQI9qY6zOl4dNtQyzh5hMXVZjaxouxH9EWhMTwMDcg9YucxdhA_eVZeh4EAeN4riSqrVvR3YE6bEdZO7NQ1&t=635857236729967414';
+if (typeof(overrideMenu_HoverStatic) == 'function' && typeof(Menu_HoverStatic) == 'function')
+{
+_spBodyOnLoadFunctionNames.push('enableFlyoutsAfterDelay');
+Menu_HoverStatic = overrideMenu_HoverStatic;
+}
+var flyoutsAllowed = false;
+function enableFlyoutsAfterDelay()
+{
+setTimeout('flyoutsAllowed = true;', 50);
+}
+function overrideMenu_HoverStatic(item)
+{
+if (!flyoutsAllowed || (document.readyState != null && document.readyState != 'complete'))
+{
+setTimeout(delayMenu_HoverStatic(item), 50);
+}
+else
+{
+// this code is the default ASP.NET implementation of Menu_HoverStatic
+var node = Menu_HoverRoot(item);
+var data = Menu_GetData(item);
+if (!data) return;
+__disappearAfter = data.disappearAfter;
+Menu_Expand(node, data.horizontalOffset, data.verticalOffset);
+}
+}
+function delayMenu_HoverStatic(item)
+{
+return (function()
+{
+overrideMenu_HoverStatic(item);
+});
+}
+//]]>
+</script>
+<script type="text/javascript" language="JavaScript" defer>
+<!--
+function S3031AEBB_Submit() {GoSearch(null,'ctl00_PlaceHolderSearchArea_ctl01_S3031AEBB_InputKeywords',null,true,true,'ctl00_PlaceHolderSearchArea_ctl01_SBScopesDDL','ctl00_PlaceHolderSearchArea_ctl01_ctl00',null,null,'https:\u002f\u002fwww.vermontjudiciary.org\u002fLC\u002f_layouts\u002fOSSSearchResults.aspx', 'This Site','This List', 'This Folder', 'Related Sites', '\u002fLC\u002f_layouts\u002fOSSSearchResults.aspx');}
+// -->
+</script><script type="text/javascript" language="JavaScript" >
+// append an onload event handler
+var S3031AEBB__onload= document.body.onload;
+if(typeof document.body.onload == 'function')
+{
+ document.body.onload = function()
+ {
+S3031AEBB__onload();
+  document.getElementById('ctl00_PlaceHolderSearchArea_ctl01_S3031AEBB_InputKeywords').name = 'InputKeywords';
+ }
+}
+else
+{
+ document.body.onload = function()
+ {
+  eval(S3031AEBB__onload);
+  document.getElementById('ctl00_PlaceHolderSearchArea_ctl01_S3031AEBB_InputKeywords').name = 'InputKeywords';
+ }
+}
+
+function S3031AEBB_OSBEK(event1) {
+var kCode = String.fromCharCode(event1.keyCode);
+if(kCode == "\n" || kCode == "\r")
+{
+S3031AEBB_Submit();
+}
+}
+// -->
+</script>
+<script type="text/javascript">
+//<![CDATA[
+var zz2_QuickLaunchMenu_Data = new Object();
+zz2_QuickLaunchMenu_Data.disappearAfter = 500;
+zz2_QuickLaunchMenu_Data.horizontalOffset = 0;
+zz2_QuickLaunchMenu_Data.verticalOffset = 0;
+zz2_QuickLaunchMenu_Data.iframeUrl = '/WebResource.axd?d=_jy2GR1SlUQI9qY6zOl4dNtQyzh5hMXVZjaxouxH9EWhMTwMDcg9YucxdhA_eVZeh4EAeN4riSqrVvR3YE6bEdZO7NQ1&t=635857236729967414';
+//]]>
+</script>
+<script type="text/javascript" language="javascript" src="/_layouts/1033/core.js?rev=mHKsOQ0iU3Q5jdm9OZNDdg%3D%3D"></script>
+<script type="text/javascript" language="javascript" src="/_layouts/1033/search.js?rev=yqBjpvg%2Foi3KG5XVf%2FStmA%3D%3D"></script>
+</form>
+  </BODY>
+</HTML>


### PR DESCRIPTION
There are some bogus records at the bottom of the page.  There are a lot of cases on the page in general, 130+.  Since we are only concerned about the newest cases, I've added a limit to extract, at most, the 100 most recent cases.  This solves the problem presented by the bogus records and reduces the network load by a bit.  That being said, the bogus records looks like they are valid opinions that were simply improperly entered.  I will try to reach out to the court to have them fix it.  Added new text file.