### PR TITLE
Second try at future-date-typo-fixing logic

### DIFF
--- a/juriscraper/AbstractSite.py
+++ b/juriscraper/AbstractSite.py
@@ -1,19 +1,20 @@
-from datetime import date, datetime
-import hashlib
+import re
 import json
-from urlparse import urlsplit, urlunsplit, urljoin
-
 import certifi
-from juriscraper.lib.date_utils import json_date_handler
+import hashlib
+import requests
+
+
+from lxml import html
+from datetime import date, datetime
+from requests.adapters import HTTPAdapter
+from urlparse import urlsplit, urlunsplit, urljoin
+from juriscraper.lib.test_utils import MockRequest
+from juriscraper.lib.date_utils import json_date_handler, fix_future_year_typo
 from juriscraper.lib.log_tools import make_default_logger
 from juriscraper.lib.string_utils import (
     harmonize, clean_string, trunc, CaseNameTweaker
 )
-from juriscraper.lib.test_utils import MockRequest
-from lxml import html
-import re
-import requests
-from requests.adapters import HTTPAdapter
 
 try:
     # Use cchardet for performance to detect the character encoding.
@@ -216,17 +217,26 @@ class AbstractSite(object):
                 prior_case_name = name
                 i += 1
 
-        for d in self.case_dates:
-            if not isinstance(d, date):
+        for index, case_date in enumerate(self.case_dates):
+            if not isinstance(case_date, date):
                 raise InsanityException(
                     '%s: member of case_dates list not a valid date object. '
                     'Instead it is: %s with value: %s' % (
-                        self.court_id, type(d), d)
+                        self.court_id, type(case_date), case_date)
                 )
-            if d.year > 2025:
+            # Sanitize case date, fix typo of current year if present
+            fixed_date = fix_future_year_typo(case_date)
+            if fixed_date != case_date:
+                logger.info(
+                    "Date year typo detected. Converting %s to %s "
+                    "for case '%s' in %s" % (case_date, fixed_date, self.case_names[index], self.court_id)
+                )
+                case_date = fixed_date
+                self.case_dates[index] = fixed_date
+            if case_date.year > 2025:
                 raise InsanityException(
                     '%s: member of case_dates list is from way in the future, '
-                    'with value %s' % (self.court_id, d.year)
+                    'with value %s' % (self.court_id, case_date.year)
                 )
 
         # Is cookies a dict?

--- a/juriscraper/__init__.py
+++ b/juriscraper/__init__.py
@@ -3,7 +3,7 @@ __all__ = [
     'oral_args',
 ]
 
-__version__ = "1.1.9.1"
+__version__ = "1.1.9.2"
 
 __title__ = "juriscraper"
 __description__ = "An API to scrape American court websites for metadata."

--- a/juriscraper/lib/date_utils.py
+++ b/juriscraper/lib/date_utils.py
@@ -154,3 +154,12 @@ def is_first_month_in_quarter(month):
     :return: Whether that month is the first month in a quarter
     """
     return month in [1, 4, 7, 10]
+
+def fix_future_year_typo(future_date):
+    """Fix current year typo, convert 2106 to 2016 in year 2016"""
+    current_year = str(datetime.date.today().year)
+    transposed_year = current_year[0] + current_year[2] + current_year[1] + current_year[3]
+    if transposed_year == str(future_date.year):
+        fixed_date = '%d/%d/%s' % (future_date.month, future_date.day, current_year)
+        return datetime.datetime.strptime(fixed_date, "%m/%d/%Y").date()
+    return future_date

--- a/tests/test_everything.py
+++ b/tests/test_everything.py
@@ -12,11 +12,12 @@ import datetime
 sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
 from juriscraper.lib.importer import build_module_list
-from juriscraper.lib.date_utils import parse_dates, quarter, \
-    is_first_month_in_quarter
+from juriscraper.lib.date_utils import (
+    parse_dates, quarter, is_first_month_in_quarter, fix_future_year_typo
+)
 from juriscraper.lib.string_utils import (
     clean_string, fix_camel_case, force_unicode, harmonize, titlecase,
-    CaseNameTweaker,
+    CaseNameTweaker, convert_date_string
 )
 from juriscraper.opinions.united_states.state import massappct, pa, mass, nh, colo
 from juriscraper.oral_args.united_states.federal_appellate import ca6
@@ -49,6 +50,17 @@ class DateParserTest(unittest.TestCase):
         for pair in test_pairs:
             dates = parse_dates(pair[0])
             self.assertEqual(dates, pair[1])
+
+    def test_fix_future_year_typo(self):
+        expectations = {
+            '12/01/2106': '12/01/2016',  # Here's the fix
+            '12/01/2016': '12/01/2016',  # Should not change
+            '12/01/2806': '12/01/2806',  # Should not change
+            '12/01/2886': '12/01/2886',  # Should not change
+        }
+        for before, after in expectations.iteritems():
+            fixed_date = fix_future_year_typo(convert_date_string(before))
+            self.assertEqual(fixed_date, convert_date_string(after))
 
 
 class ScraperExampleTest(unittest.TestCase):


### PR DESCRIPTION
Now the logic will only fix typoed dates for the current year.  Expanded logging to be more informative.