### PR TITLE
Fixing colo/coloctapp

### DIFF
--- a/juriscraper/__init__.py
+++ b/juriscraper/__init__.py
@@ -3,7 +3,7 @@ __all__ = [
     'oral_args',
 ]
 
-__version__ = "1.1.9.3"
+__version__ = "1.1.9.4"
 
 __title__ = "juriscraper"
 __description__ = "An API to scrape American court websites for metadata."


### PR DESCRIPTION
Fixing issue in cleanup_content() that was causing coloctapp to flop, removing unused method, and added new functionality to get direct pdf links.  Also added logic to parse case name from resource url/page, which allowed me to get rid of the bad 'Unknown Title' logic.