### PR TITLE
Moving sample_caller.py and updating examples in usage documentation

### DIFF
--- a/sample_caller.py
+++ b/sample_caller.py
@@ -83,9 +83,9 @@ def main():
 
     usage = ('usage: %prog -c COURTID [-d|--daemon] [-b|--binaries]\n\n'
              'To test ca1, downloading binaries, use: \n'
-             '    python %prog -c opinions.united_states.federal_appellate.ca1 -b\n\n'
+             '    python %prog -c juriscraper.opinions.united_states.federal_appellate.ca1 -b\n\n'
              'To test all federal courts, omitting binaries, use: \n'
-             '    python %prog -c opinions.united_states.federal_appellate')
+             '    python %prog -c juriscraper.opinions.united_states.federal_appellate')
     parser = OptionParser(usage)
     parser.add_option('-c', '--courts', dest='court_id', metavar="COURTID",
                       help=('The court(s) to scrape and extract. This should be in '


### PR DESCRIPTION
Maybe this isn't right, but the sample caller script does not work for me unless it's moved up one directory.  I tested making adjustments to it where it was, including manipulating the python path, but I couldn't get past the maze of import errors.  Once I solved one, another cropped up.