### PR TITLE
Fixing fladistctapp_5

### DIFF
--- a/juriscraper/opinions/united_states/state/fladistctapp_5.py
+++ b/juriscraper/opinions/united_states/state/fladistctapp_5.py
@@ -85,12 +85,11 @@ class Site(OpinionSite):
         return case_names
 
     def _return_case_names(self, html_tree):
-        path = "{base}/text()".format(base=self.base_path)
-        # Uncomment for inevitable regex debugging.
-        # for s in html_tree.xpath(path):
-        #     print "s: %s" % s
-        #     re.search(self.case_regex, s).group(2)
-        return [re.search(self.case_regex, s).group(2) for s in html_tree.xpath(path)]
+        names = []
+        for anchor in html_tree.xpath(self.base_path):
+            text = anchor.text_content().strip()
+            names.append(re.search(self.case_regex, text).group(2))
+        return names
 
     def _get_download_urls(self):
         download_urls = []
@@ -114,7 +113,7 @@ class Site(OpinionSite):
         date_string = re.search('.* week of (.*)', text).group(1).strip()
         case_date = convert_date_string(date_string)
         count = int(html_tree.xpath("count({base})".format(base=self.base_path)))
-        return [case_date for i in range(count) ]
+        return [case_date for i in range(count)]
 
     def _get_precedential_statuses(self):
         return ['Published'] * len(self.case_dates)
@@ -126,5 +125,10 @@ class Site(OpinionSite):
         return docket_numbers
 
     def _return_docket_numbers(self, html_tree):
-        path = "{base}/text()".format(base=self.base_path)
-        return [re.search(self.case_regex, e).group(1) for e in html_tree.xpath(path)]
+        dockets = []
+        for anchor in html_tree.xpath(self.base_path):
+            text = anchor.text_content().strip()
+            docket_raw = re.search(self.case_regex, text).group(1)
+            docket_clean = docket_raw.replace('&', '').replace(',', '')
+            dockets.append(', '.join(docket_clean.split()))
+        return dockets

--- a/tests/examples/opinions/united_states/fladistctapp_5_example_3.html
+++ b/tests/examples/opinions/united_states/fladistctapp_5_example_3.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><!-- InstanceBegin template="/Templates/dca_main_fifth.dwt" codeOutsideHTMLIsLocked="false" -->
+<head>
+<!-- InstanceBeginEditable name="doctitle" -->
+<title>Florida's Fifth District Court of Appeal</title>
+<!-- InstanceEndEditable -->
+<script language="JavaScript1.2" type="text/javascript" src="/stylesheets/init_homepg.js"></script>
+<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
+  <meta http-equiv="PRAGMA" content="NO-CACHE" />
+  <meta http-equiv="Expires" content="0" />
+<!-- InstanceBeginEditable name="head" --><!-- InstanceEndEditable -->
+<link href="/stylesheets/main.css" rel="stylesheet" type="text/css" />
+<link href="/stylesheets/print.css" rel="stylesheet" type="text/css" media="print" />
+</head>
+<body leftmargin="0" topmargin="0" marginwidth="0" marginheight="0">
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN">
+
+
+<script language="JavaScript" type="text/JavaScript" >
+
+
+
+
+function MM_preloadImages() { //v3.0
+  var d=document; if(d.images){ if(!d.MM_p) d.MM_p=new Array();
+    var i,j=d.MM_p.length,a=MM_preloadImages.arguments; for(i=0; i<a.length; i++)
+    if (a[i].indexOf("#")!=0){ d.MM_p[j]=new Image; d.MM_p[j++].src=a[i];}}
+}
+
+</script>
+
+<link href="/stylesheets/main.css" rel="stylesheet" type="text/css">
+<script type="text/JavaScript">
+<!--
+function MM_swapImgRestore() { //v3.0
+  var i,x,a=document.MM_sr; for(i=0;a&&i<a.length&&(x=a[i])&&x.oSrc;i++) x.src=x.oSrc;
+}
+
+function MM_findObj(n, d) { //v4.01
+  var p,i,x;  if(!d) d=document; if((p=n.indexOf("?"))>0&&parent.frames.length) {
+    d=parent.frames[n.substring(p+1)].document; n=n.substring(0,p);}
+  if(!(x=d[n])&&d.all) x=d.all[n]; for (i=0;!x&&i<d.forms.length;i++) x=d.forms[i][n];
+  for(i=0;!x&&d.layers&&i<d.layers.length;i++) x=MM_findObj(n,d.layers[i].document);
+  if(!x && d.getElementById) x=d.getElementById(n); return x;
+}
+
+function MM_swapImage() { //v3.0
+  var i,j=0,x,a=MM_swapImage.arguments; document.MM_sr=new Array; for(i=0;i<(a.length-2);i+=3)
+   if ((x=MM_findObj(a[i]))!=null){document.MM_sr[j++]=x; if(!x.oSrc) x.oSrc=x.src; x.src=a[i+2];}
+}
+//-->
+</script>
+
+<body onLoad="MM_preloadImages('/images/navbar_home.jpg','/images/navbar_judgeshover.jpg','/images/navbar_homehover.jpg','/images/navbar_clerkhover.jpg','/images/navbar_argumentshover.jpg','/images/navbar_dockethover.jpg','/images/navbar_opinionshover.jpg','/images/navbar_eaccesshover.jpg','/images/navbar_searchhover.jpg')">
+<table border="0" cellpadding="0" cellspacing="0" bgcolor="#375885">
+  <tr>
+
+	<td align="right" valign="top"><table width="100%"  border="0" cellpadding="0" cellspacing="0" bgcolor="#365886">
+      <tr>
+        <td background="/images/banner_background.jpg"><img src="/images/banner_text_fifth.jpg" width="752" height="82" align="right" alt="Fifth District Court of Appeal Website"></td>
+      </tr>
+      <tr>
+        <td background="/images/banner_background.jpg">
+          <table width="98%" border="2" align="right" "cellpadding="0" cellspacing="0" bordercolor="#999999" bgcolor="#ECE9D8">
+            <tr>
+
+			  <td width="8%" bgcolor="#ECE9D8"><div align="center"><a href="/index.shtml"></a><a href="/default.shtml"><img src="/images/navbar_home.jpg" alt="home" name="Image1" width="50" height="15" border="0" id="Image1" onMouseOver="MM_swapImage('Image1','','/images/navbar_home.jpg',1);MM_swapImage('Image1','','/images/navbar_homehover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="9%"><div align="center" class="boldbodytext"><a href="/judges.shtml"></a><a href="/judges.shtml"><img src="/images/navbar_judges.jpg" alt="judges" name="Image2" width="50" height="15" border="0" id="Image2" onMouseOver="MM_swapImage('Image2','','/images/navbar_judgeshover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="16%"><div align="center" class="boldbodytext"><a href="/clerks_office.shtml"></a><a href="/clerks_office.shtml"><img src="/images/navbar_clerk.jpg" alt="clerk's office" name="Image3" width="104" height="15" border="0" id="Image3" onMouseOver="MM_swapImage('Image3','','/images/navbar_clerkhover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="18%" bgcolor="#ECE9D8"><div align="center" class="boldbodytext"><a href="/oralarguments.shtml"></a><a href="/oralarguments.shtml"><img src="/images/navbar_arguments.jpg" alt="oral arguments" name="Image4" width="110" height="15" border="0" id="Image4" onMouseOver="MM_swapImage('Image4','','/images/navbar_argumentshover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="17%" bordercolor="#999999"><div align="center" class="boldbodytext"><a href="http://jweb.flcourts.org/pls/docket/ds_docket_search%20"></a><a href="http://199.242.69.70/pls/ds/ds_docket_search?pscourt=5 " target="_blank"><img src="/images/navbar_docket.jpg" alt="on-line docket" name="Image5" width="110" height="15" border="0" id="Image5" onMouseOver="MM_swapImage('Image5','','/images/navbar_dockethover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+              <td width="11%"><div align="center" class="boldbodytext"><a href="/opinions.shtml"></a><a href="/opinions.shtml"><img src="/images/navbar_opinions.jpg" alt="opinions" name="Image6" width="68" height="15" border="0" id="Image6" onMouseOver="MM_swapImage('Image6','','/images/navbar_opinionshover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="11%"><div align="center" class="boldbodytext"><a href="https://edca.5dca.org"><img src="../Images/navbar_eaccess.jpg" alt="eDCA" name="Image7" width="68" height="15" border="0" id="Image7" onMouseOver="MM_swapImage('Image7','','/images/navbar_eaccesshover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  <td width="10%"><div align="center" class="boldbodytext"><a href="http://www.1dca.org/cgi-bin/mclient.cgi"></a><a href="http://search.flcourts.org/texis/search?pr=5DCA"><img src="/images/navbar_search.jpg" alt="search" name="Image8" width="68" height="15" border="0" id="Image8" onMouseOver="MM_swapImage('Image8','','/images/navbar_searchhover.jpg',1)" onMouseOut="MM_swapImgRestore()"></a></div></td>
+			  </tr>
+          </table>          </td>
+      </tr>
+    </table>    </td>
+
+    <td width="100%"align="top" background="/images/banner_background.jpg"></td>
+    <td align="top">&nbsp;</td>
+  </tr>
+</table>
+
+
+<table width="754" border="0" cellpadding="0" cellspacing="0">
+  <tr>
+    <td width="15" valign="top" align="left"><a href="#main"><img src="images/banner_background_spacer.jpg" alt="Skip Navigation" width="4" height="15" border="0" /></a></td>
+    <td width="200" align="left" valign="top" id="menu"><style type="text/css">
+<!--
+.style7 {font-size: large}
+.style8 {font-size: medium}
+-->
+</style>
+<table  width="100%" border="0">
+  <tr>
+    <td>
+<div id="menu">
+	 <ul style="margin-left:0; margin-bottom:0; padding-left:1em; padding-bottom:5px;">
+	    <li><a href="http://www.5dca.org/clerks_office.shtml">Clerk's Office</a></li>
+        <li><a href="../pub_info.shtml">Public Information</a></li>
+        <li><a href="../ordersframe.shtml">Administrative Orders</a></li>
+        <li><a href="http://www.5dca.org/opinions.shtml">Opinions</a></li>
+        <li><a href="http://www.5dca.org/opinions_recent.shtml">Most Recent Opinions</a></li>
+        <li><a href="http://www.5dca.org/Mediation/mediation.shtml">Mediation</a></li>
+        <li><a href="http://www.5dca.org/opinions_archived.shtml">Archived Opinions</a>      </li>
+        <li><a href="http://www.5dca.org/courtcalendar.shtml">Holiday Calendar</a></li>
+        <li><a href="http://www.5dca.org/marshal.shtml">Marshal's Office</a></li>
+		<li><a href="http://www.5dca.org/oralarguments.shtml">Oral Arguments</a></li>
+        <li><a href="http://www.5dca.org/employment.shtml">Employment</a></li>
+        <li><a href="../5DCA_ADA.shtml" target="_blank">ADA Guidelines</a></li>
+        <li><a href="http://www.5dca.org/faq.shtml">FAQ</a></li>
+        <li><a href="http://www.5dca.org/courtlinks.shtml">Additional Court Info.</a></li>
+        </ul>
+ <hr align="center" width="95%" size="1" color="#375885">
+         <div align="center" class="style7"><a href="http://edca.5dca.org" target="_blank"><strong>EDCA</strong></a></div>
+<hr align="center" width="95%" size="1" color="#375885">
+         <div align="left"><span style="font-variant:small-caps; margin-left:-1em; margin-bottom:0; padding-left:1em; font-weight:bold;">Florida Court Links</span>
+        <ul style="margin-left:0; margin-bottom:0; padding-left:1em; padding-bottom:5px; padding-top:0px">
+<li><a href="http://www.flcourts.org/courts/dca/dca.shtml" target="_blank">Other DCA Websites</a></li>
+		<li><a href="http://www.floridasupremecourt.org/" target="_blank">Florida Supreme Court</a></li>
+		<li><a href="http://www.flcourts.org/" target="_blank">Florida State Courts</a></li>
+		<li><a href="http://www.floridasupremecourt.org/education/index.shtml">Supreme Court Education and Tours</a></li>
+	 </ul> </div>
+<hr align="center" width="90%" size="1" color="#375885">
+<div style="padding-top:0px; padding-bottom:0px">
+<p class="bodytextsmall" align="center">Fifth District Court of Appeal<br />
+300 South Beach Street<br/>
+Daytona Beach, FL 32114<br/>
+(386) 947-1530
+</div>
+<p align="center"><a href="http://www.5dca.org/General Information/Directions/map.htm" target="_blank">Map and Directions </a></p>
+    <hr align="center" width="95%" size="1" color="#375885">
+<div style="padding:0" align="center"><a href="http://www.5dca.org/default.shtml">5th DCA HOME</a></div>
+<hr align="center" width="95%" size="1" color="#375885">
+</div></td>
+  </tr>
+</table>
+
+</td>
+    <td width="539" align="left" valign="top" style="padding-left:25px; padding-right:25px"><br /><a id="main" name="main"></a>
+      <h1 align="center">ARCHIVED OPINIONS</h1>
+      <p align="center"><img src="Images/Courthousedrawing.jpg" alt="CourtHouse" width="400" height="136" /></p>
+      <h2 align="center"><a href="http://search.flcourts.org/texis/search/?pr=5DCA" target="_blank">Search Archive Opinions </a></h2>
+      <p align="center">Week Of:</p>
+      <p align="center"><a href="http://www.5dca.org/Opinions/Opin2016/080116/filings 080116.html" target="_blank">August 1, 2016</a></p>
+      <p align="center"><a href="http://www.5dca.org/Opinions/Opin2016/072516/filings 072516.html" target="_blank">July 25, 2016</a></p>
+      <!-- EDITED FOR TESTING PURPOSES TO ONLY INCLUDE TWO DATES ABOVE -->
+    </td>
+  </tr>
+  <tr>
+   <td width="15">&nbsp;</td>
+    <td width="200" valign="top">&nbsp;</td>
+    <td width="539" align="left" id="bottomMenu"><div id="bottomMenu" align="center"><hr width="70%" style="padding:0">
+		   <ul style="margin-left:0; margin-bottom:0; padding-left:1px; padding-bottom:0px;">
+
+			<li><a href="http://www.5dca.org/default.shtml">Return Home</a></li>
+             /
+            <li><a href="http://search.flcourts.org/texis/search?pr=5DCA" target="_blank">Search</a></li>
+             /
+            <li><a href="http://www.5dca.org/judges.shtml">Judges</a></li>
+             /
+            <li><a href="http://www.5dca.org/clerks_office.shtml">Clerk's Office</a></li>
+             /
+            <li><a href="http://www.5dca.org/oralarguments.shtml">Oral Arguments</a></li>
+            /
+            <li><a href="http://www.5dca.org/opinions.shtml">Opinions</a></li>
+            <br />
+
+            <li><a href="http://199.242.69.70/pls/ds/ds_docket_search?pscourt=5" target="_blank">Online Dockets</a></li>
+            /
+            <li><a href="http://edca.5dca.org" target="_blank">eDCA</a></li>
+            /
+            <li><a href="http://www.5dca.org/site.shtml">Using This Site & Plug-Ins</a></li>
+            <br />
+
+            <li><a href="http://www.5dca.org/privacy.shtml">Privacy Policy</a></li>
+            /
+            <li><a href="http://www.5dca.org/accessibility.shtml">Accessibility</a></li>
+            /
+            <li><a href="http://www.5dca.org/rss.shtml"><img src="/Images/rss.gif" alt="RSS FEED" border="0" /></a>
+            </ul>
+      </div>
+
+<script>
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+  ga('create', 'UA-46755357-9', 'auto');
+  ga('send', 'pageview');
+
+</script>
+</td>
+  </tr>
+</table>
+
+
+</body>
+<!-- InstanceEnd --></html>


### PR DESCRIPTION
The `<br>` tags in the link text was breaking the xpath.  I switched it up to cycle over the anchors and use .text_content() instead to avoid these pesky <br> issues.  Added new example test file.