### PR TITLE
doc fixes, rss tests, and a command-line driver

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -193,6 +193,18 @@ iterates over all courts of a certain jurisdiction that is provided by a
 script. See ``lib/importer.py`` for an example that's used in
 the sample caller.
 
+District Court Parser
+=====================
+A sample driver to run the PACER District Court parser on an html file is included.
+It takes HTML file(s) as arguments and outputs JSON to stdout.
+
+Example usage:
+
+::
+
+   PYTHONPATH=`pwd` juriscraper/pacerdocket.py tests/examples/pacer/dockets/district/nysd.html
+
+
 Tests
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,13 @@ You may need to also install Juriscraper locally with:
 
    pip install .
 
+If you've not installed juriscraper, you can run `sample_caller.py` as:
+
+::
+
+   PYTHONPATH=`pwd` python  juriscraper/sample_caller.py
+
+
 Usage
 =====
 
@@ -192,6 +199,14 @@ Tests
 We got that! You can (and should) run the tests with
 ``tox``. This will run ``python setup.py test`` for all supported Python runtimes,
 iterating over all of the ``*_example*`` files and run the scrapers against them.
+
+Individual tests can be run with:
+
+   python -m unittest tests.test_pacer.DocketParseTest.test_district_court_dockets
+
+Or, to run and drop to the Python debugger if it fails:
+
+  nosetests -v --pdb tests/test_pacer.py:DocketParseTest.test_district_court_dockets
 
 In addition, we use `Travis-CI <https://travis-ci.org/>`__ to
 automatically run the tests whenever code is committed to the repository

--- a/README.rst
+++ b/README.rst
@@ -216,7 +216,7 @@ Individual tests can be run with:
 
    python -m unittest tests.test_pacer.DocketParseTest.test_district_court_dockets
 
-Or, to run and drop to the Python debugger if it fails:
+Or, to run and drop to the Python debugger if it fails, but you must install `nost` to have `nosetests`:
 
   nosetests -v --pdb tests/test_pacer.py:DocketParseTest.test_district_court_dockets
 

--- a/juriscraper/lib/log_tools.py
+++ b/juriscraper/lib/log_tools.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import getpass
 import logging.handlers
 import traceback
@@ -6,6 +8,8 @@ import sys
 
 LOG_FILENAME = '/var/log/juriscraper/debug.log'
 
+def errprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)
 
 def make_default_logger(file_path=LOG_FILENAME):
     """Boilerplate and testing code to create a logger. If we run into an
@@ -26,27 +30,27 @@ def make_default_logger(file_path=LOG_FILENAME):
             )
         except IOError as e:
             if e.errno == 2:
-                print("\nWarning: %s: %s. " \
+                errprint("\nWarning: %s: %s. " \
                       "Have you created the directory for the log?" % (
                           e.strerror,
                           file_path,
                       ))
             elif e.errno == 13:
-                print("\nWarning: %s: %s. " \
+                errprint("\nWarning: %s: %s. " \
                       "Cannot access file as user: %s" % (
                           e.strerror,
                           file_path,
                           getpass.getuser(),
                       ))
             else:
-                print("\nIOError [%s]: %s\n%s" % (
+                errprint("\nIOError [%s]: %s\n%s" % (
                     e.errno,
                     e.strerror,
                     traceback.format_exc()
                 ))
-            print("Juriscraper will continue to run, and all logs will be "
-                  "sent to stdout.")
-            handler = logging.StreamHandler(sys.stdout)
+            errprint("Juriscraper will continue to run, and all logs will be "
+                  "sent to stderr.")
+            handler = logging.StreamHandler(sys.stderr)
         handler.setFormatter(
             logging.Formatter('%(asctime)s - %(levelname)s: %(message)s')
         )

--- a/juriscraper/pacerdocket.py
+++ b/juriscraper/pacerdocket.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+#
+#  Takes an .html file on the command line, parses it using the PACER
+#  Docket Report parser, and outputs json to stdout.
+
+import jsondate as json
+import sys
+
+from juriscraper.pacer.http import PacerSession
+from juriscraper.pacer import DocketReport
+
+pacer_session = PacerSession(username='tr1234',
+                             password='Pass!234')
+report = DocketReport('psc', pacer_session)
+
+for path in sys.argv[1:]:
+    with open(path, 'r') as f:
+        report._parse_text(f.read().decode('utf-8'))
+    data = report.data
+    print json.dumps(data, indent=2, sort_keys=True, separators=(',', ': '))

--- a/tests/examples/pacer/dockets/fake-rss/dcd.html
+++ b/tests/examples/pacer/dockets/fake-rss/dcd.html
@@ -1,0 +1,8 @@
+<h3>THIS IS A FAKED UP DOCKET VIA RSS THROUGH recapupload.py<br>
+1:17-cr-00201-ABJ-2</h3>
+<table><td>Date Filed:</table>
+<table><tr><td>Date Filed</td><th>#</th><td>Docket Text</td></tr>
+<tr><td>12/28/2017</td>
+<td><a href="https://ecf.dcd.uscourts.gov/doc1/04506365997?caseid=190598&de_seq_num=519">120</td>
+<td>MOTION to Modify Conditions of Release for Limited Purposes to Attend New Year's Events by RICHARD W. GATES, III</td></tr>
+</tbody></table>

--- a/tests/examples/pacer/dockets/fake-rss/dcd.html
+++ b/tests/examples/pacer/dockets/fake-rss/dcd.html
@@ -1,3 +1,6 @@
+<!-- This comes via recapupload, part of Big Cases
+  https://github.com/johnhawkinson/Big-Cases/blob/38d0238b6d0101ac6335636e13faa39d0628c5ea/recapupload.py
+-->
 <h3>THIS IS A FAKED UP DOCKET VIA RSS THROUGH recapupload.py<br>
 1:17-cr-00201-ABJ-2</h3>
 <table><td>Date Filed:</table>

--- a/tests/examples/pacer/dockets/fake-rss/dcd.json
+++ b/tests/examples/pacer/dockets/fake-rss/dcd.json
@@ -1,0 +1,25 @@
+{
+  "assigned_to_str": "", 
+  "case_name": "Unknown Case Title", 
+  "cause": "", 
+  "court_id": "dcd", 
+  "date_converted": null, 
+  "date_discharged": null, 
+  "date_filed": null, 
+  "date_terminated": null, 
+  "demand": "", 
+  "docket_entries": [
+    {
+      "date_filed": "2017-12-28", 
+      "description": "MOTION to Modify Conditions of Release for Limited Purposes to Attend New Year's Events by RICHARD W. GATES, III", 
+      "document_number": "120", 
+      "pacer_doc_id": "04506365997"
+    }
+  ], 
+  "docket_number": "1:17-cr-00201", 
+  "jurisdiction": "", 
+  "jury_demand": "", 
+  "nature_of_suit": "", 
+  "parties": [], 
+  "referred_to_str": ""
+}

--- a/tests/examples/pacer/dockets/fake-rss/mad.html
+++ b/tests/examples/pacer/dockets/fake-rss/mad.html
@@ -1,0 +1,8 @@
+<h3>THIS IS A FAKED UP DOCKET VIA RSS THROUGH recapupload.py<br>
+1:17-cv-12580-FDS</h3>
+<table><td><br>Narvaez v. Berryhill<td>Date Filed:</table>
+<table><tr><td>Date Filed</td><th>#</th><td>Docket Text</td></tr>
+<tr><td>12/28/2017</td>
+<td><a href="https://ecf.mad.uscourts.gov/doc1/09518456790?caseid=194728&xde_seq_num=111">13</td>
+<td>ORDER - The Joint Motion to Change Venue, ECF No. 10 , filed by the parties, is granted.</td></tr>
+</tbody></table>

--- a/tests/examples/pacer/dockets/fake-rss/mad.html
+++ b/tests/examples/pacer/dockets/fake-rss/mad.html
@@ -1,3 +1,6 @@
+<!-- This comes via recapupload, part of Big Cases
+  https://github.com/johnhawkinson/Big-Cases/blob/38d0238b6d0101ac6335636e13faa39d0628c5ea/recapupload.py
+-->
 <h3>THIS IS A FAKED UP DOCKET VIA RSS THROUGH recapupload.py<br>
 1:17-cv-12580-FDS</h3>
 <table><td><br>Narvaez v. Berryhill<td>Date Filed:</table>

--- a/tests/examples/pacer/dockets/fake-rss/mad.json
+++ b/tests/examples/pacer/dockets/fake-rss/mad.json
@@ -1,0 +1,25 @@
+{
+  "assigned_to_str": "",
+  "case_name": "Narvaez v. Berryhill",
+  "cause": "",
+  "court_id": "mad",
+  "date_converted": null,
+  "date_discharged": null,
+  "date_filed": null,
+  "date_terminated": null,
+  "demand": "",
+  "docket_entries": [
+    {
+      "date_filed": "2017-12-28",
+      "description": "ORDER - The Joint Motion to Change Venue, ECF No. 10, filed by the parties, is granted.",
+      "document_number": "13",
+      "pacer_doc_id": "09508456790"
+    }
+  ],
+  "docket_number": "1:17-cv-12580",
+  "jurisdiction": "",
+  "jury_demand": "",
+  "nature_of_suit": "",
+  "parties": [],
+  "referred_to_str": ""
+}

--- a/tests/test_pacer.py
+++ b/tests/test_pacer.py
@@ -544,7 +544,8 @@ class DocketParseTest(unittest.TestCase):
         self.maxDiff = 200000
 
     def run_parsers_on_path(self, path_root,
-    requiredFields = ['date_filed', 'case_name', 'docket_number']):
+                            required_fields=[
+                                'date_filed', 'case_name', 'docket_number']):
         """Test all the parsers, faking the network query."""
         paths = []
         for root, dirnames, filenames in os.walk(path_root):
@@ -568,7 +569,7 @@ class DocketParseTest(unittest.TestCase):
             if data != {}:
                 # If the docket is a valid docket, make sure some required
                 # fields are populated.
-                for field in requiredFields:
+                for field in required_fields:
                     self.assertTrue(
                         data[field],
                         msg="Unable to find truthy value for field %s" % field,
@@ -638,8 +639,10 @@ class DocketParseTest(unittest.TestCase):
         path_root = os.path.join(TESTS_ROOT, 'examples', 'pacer', 'dockets',
                                  'fake-rss')
         self.run_parsers_on_path(path_root,
-                                 requiredFields = ['case_name', 'docket_number']
-                             )
+                                 required_fields=[
+                                     'case_name',
+                                     'docket_number',
+                                 ])
 
     def test_specialty_court_dockets(self):
         path_root = os.path.join(TESTS_ROOT, 'examples', 'pacer', 'dockets',

--- a/tests/test_pacer.py
+++ b/tests/test_pacer.py
@@ -543,7 +543,8 @@ class DocketParseTest(unittest.TestCase):
     def setUp(self):
         self.maxDiff = 200000
 
-    def run_parsers_on_path(self, path_root):
+    def run_parsers_on_path(self, path_root,
+    requiredFields = ['date_filed', 'case_name', 'docket_number']):
         """Test all the parsers, faking the network query."""
         paths = []
         for root, dirnames, filenames in os.walk(path_root):
@@ -567,8 +568,7 @@ class DocketParseTest(unittest.TestCase):
             if data != {}:
                 # If the docket is a valid docket, make sure some required
                 # fields are populated.
-                fields = ['date_filed', 'case_name', 'docket_number']
-                for field in fields:
+                for field in requiredFields:
                     self.assertTrue(
                         data[field],
                         msg="Unable to find truthy value for field %s" % field,

--- a/tests/test_pacer.py
+++ b/tests/test_pacer.py
@@ -635,7 +635,7 @@ class DocketParseTest(unittest.TestCase):
                                  'district')
         self.run_parsers_on_path(path_root)
 
-    def test_district_court_dockets(self):
+    def test_fakerss_court_dockets(self):
         path_root = os.path.join(TESTS_ROOT, 'examples', 'pacer', 'dockets',
                                  'fake-rss')
         self.run_parsers_on_path(path_root,

--- a/tests/test_pacer.py
+++ b/tests/test_pacer.py
@@ -634,6 +634,13 @@ class DocketParseTest(unittest.TestCase):
                                  'district')
         self.run_parsers_on_path(path_root)
 
+    def test_district_court_dockets(self):
+        path_root = os.path.join(TESTS_ROOT, 'examples', 'pacer', 'dockets',
+                                 'fake-rss')
+        self.run_parsers_on_path(path_root,
+                                 requiredFields = ['case_name', 'docket_number']
+                             )
+
     def test_specialty_court_dockets(self):
         path_root = os.path.join(TESTS_ROOT, 'examples', 'pacer', 'dockets',
                                  'special')


### PR DESCRIPTION
* Some improvements to README.rst w/r/t running without installation.
* Two tests for faked-up RSS (cf. https://github.com/bdheath/Big-Cases/pull/3)
* An (example?) driver for running district court dockets frm the command-line. Very helpful for iterative parser testing cycles.