### PR TITLE
rss_feeds.py: Allow input from stdin

### DIFF
--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -210,9 +210,10 @@ sorry if that was your filename.''')
         feed.parse()
     else:
         if not args.bankruptcy:
-            feed = PacerRssFeed('fake')
+            feed = PacerRssFeed('fake_district_court_id')
         else:
-            feed = PacerRssFeed('fakb')  # final 'b' char means bankruptcy
+            # final 'b' char is interpretted as bankruptcy
+            feed = PacerRssFeed('fake_bankruptcy_court_id_b')
         if args.court_or_file == '-':
             print("Faking up RSS feed from stdin as %s" % feed.court_id)
             f = sys.stdin

--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -184,19 +184,31 @@ class PacerRssFeed(DocketReport):
 
 def _main():
     if len(sys.argv) < 2:
-        print("Usage: python -m juriscraper.pacer.rss_feeds [pacer_court_id] "
+        print("Usage: "
+              "python -m juriscraper.pacer.rss_feeds [pacer_court_id] "
               "[verbose]")
         print("Please provide a valid PACER court id as your only argument")
         sys.exit(1)
+    if sys.argv[1] == '-':
+        # Let's use stdin!
+
+        # Not a court, not 4 chars, will confuse bankruptcy check.
+        feed = PacerRssFeed('stdin')
+        print("Faking up RSS feed from stdin")
+        # "not url: (%s,%s,%s)" % (__package__, __file__, feed.url)
+        f = sys.stdin
+        feed._parse_text(f.read().decode('utf-8'))
+    else:
         feed = PacerRssFeed(sys.argv[1])
         print("Querying RSS feed at: %s" % feed.url)
         feed.query()
         print("Parsing RSS feed for %s" % feed.court_id)
         feed.parse()
-        print("Got %s items" % len(feed.data))
-        if len(sys.argv) == 3 and sys.argv[2] == 'verbose':
-            print("Here they are:\n")
-            pprint.pprint(feed.data, indent=2)
+
+    print("Got %s items" % len(feed.data))
+    if len(sys.argv) == 3 and sys.argv[2] == 'verbose':
+        print("Here they are:\n")
+        pprint.pprint(feed.data, indent=2)
 
 
 if __name__ == "__main__":

--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -190,6 +190,8 @@ def _main():
         prog="python -m %s.%s" %
         (__package__,
          os.path.splitext(os.path.basename(sys.argv[0]))[0]))
+    parser.add_argument('-b', '--bankruptcy', action='store_true',
+                        help='Use bankruptcy parser variant.')
     parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument('court_or_file', nargs='?', default='-',
                         help='''
@@ -207,12 +209,16 @@ sorry if that was your filename.''')
         print("Parsing RSS feed for %s" % feed.court_id)
         feed.parse()
     else:
-        feed = PacerRssFeed('stdin')
-        if args.court_or_file=='-':
-            print("Faking up RSS feed from stdin")
+        if not args.bankruptcy:
+            feed = PacerRssFeed('fake')
+        else:
+            feed = PacerRssFeed('fakb')  # final 'b' char means bankruptcy
+        if args.court_or_file == '-':
+            print("Faking up RSS feed from stdin as %s" % feed.court_id)
             f = sys.stdin
         else:
-            print("Reading RSS feed from %s" % args.court_or_file)
+            print("Reading RSS feed from %s as %s" %
+                  (args.court_or_file, feed.court_id))
             f = open(args.court_or_file)
         feed._parse_text(f.read().decode('utf-8'))
 

--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -202,7 +202,7 @@ sorry if that was your filename.''')
     args = parser.parse_args()
 
     arg_len = len(args.court_or_file)
-    if arg_len >= 3 and arg_len <= 4:
+    if 3 <= arg_len <= 4:
         feed = PacerRssFeed(args.court_or_file)
         print("Querying RSS feed at: %s" % feed.url)
         feed.query()

--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -182,18 +182,22 @@ class PacerRssFeed(DocketReport):
         return case_name
 
 
-if __name__ == "__main__":
+def _main():
     if len(sys.argv) < 2:
         print("Usage: python -m juriscraper.pacer.rss_feeds [pacer_court_id] "
               "[verbose]")
         print("Please provide a valid PACER court id as your only argument")
         sys.exit(1)
-    feed = PacerRssFeed(sys.argv[1])
-    print("Querying RSS feed at: %s" % feed.url)
-    feed.query()
-    print("Parsing RSS feed for %s" % feed.court_id)
-    feed.parse()
-    print("Got %s items" % len(feed.data))
-    if len(sys.argv) == 3 and sys.argv[2] == 'verbose':
-        print("Here they are:\n")
-        pprint.pprint(feed.data, indent=2)
+        feed = PacerRssFeed(sys.argv[1])
+        print("Querying RSS feed at: %s" % feed.url)
+        feed.query()
+        print("Parsing RSS feed for %s" % feed.court_id)
+        feed.parse()
+        print("Got %s items" % len(feed.data))
+        if len(sys.argv) == 3 and sys.argv[2] == 'verbose':
+            print("Here they are:\n")
+            pprint.pprint(feed.data, indent=2)
+
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
This is important to being able to debug the parser without repeatedly
pounding on the server, as well as being able to give it XML that the
server would never produce, exactly (e.g. a limited set with a single
specific entry, or maybe a specific type of entry)

This was really helpful for fixing freelawproject/recap#248