### PR TITLE
rss_feeds.py: doc+ docket_entries() & broaden short_desc_regex

### DIFF
--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -151,7 +151,7 @@ class PacerRssFeed(DocketReport):
                 self._get_value(self.short_desc_regex, entry.summary)),
         }
         doc1_url = self._get_value(self.doc1_url_regex, entry.summary)
-        if not all([doc1_url.strip(), de['document_number']]):
+        if not all([doc1_url.strip(), de[u'document_number']]):
             return []
 
         de[u'pacer_doc_id'] = get_pacer_doc_id_from_doc1_url(doc1_url)

--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -44,7 +44,7 @@ class PacerRssFeed(DocketReport):
     # We use three simple matches rather than a complex one with three groups.
     document_number_regex = re.compile(r'">(\d+)</a>')
     doc1_url_regex = re.compile(r'href="(.*)"')
-    short_desc_regex = re.compile(r'\[(.*?)\] \(')
+    short_desc_regex = re.compile(r'\[(.*?)\]')
 
     PATH = 'cgi-bin/rss_outside.pl'
 

--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -35,9 +35,16 @@ I reached out to all of these jurisdictions and heard back the following:
 
 
 class PacerRssFeed(DocketReport):
+    # The entries are HTML entity-coded, and these matches are run AFTER
+    # decoding. A typical entry is of the form:
+    #   [short_description] (<a href="doc1_url">document_mumber</a>)
+    # Or a literal example (line breaks added):
+    #   [Scheduling Order] (<a href="https://ecf.mad.uscourts.gov/doc1/
+    #   09518690740?caseid=186403&de_seq_num=98">39</a>)
+    # We use three simple matches rather than a complex one with three groups.
     document_number_regex = re.compile(r'">(\d+)</a>')
     doc1_url_regex = re.compile(r'href="(.*)"')
-    short_desc_regex = re.compile(r'\[(.*?)\] \(')  # Matches 'foo': [ foo ] (
+    short_desc_regex = re.compile(r'\[(.*?)\] \(')
 
     PATH = 'cgi-bin/rss_outside.pl'
 
@@ -141,7 +148,13 @@ class PacerRssFeed(DocketReport):
         raise NotImplementedError("No parties for RSS feeds.")
 
     def docket_entries(self, entry):
-        """Parse the RSS item to get back a docket entry-like object"""
+        """Parse the RSS item to get back a docket entry-like object.
+        Although there is only one, return it as a list.
+
+        We do not return paperless or so-called "minute orders" that
+        lack attached documents (such minute orders may have entry
+        numbers).
+        """
         de = {
             u'date_filed': date(*entry.published_parsed[:3]),
             u'document_number': self._get_value(self.document_number_regex,


### PR DESCRIPTION
Yet another outgrowth of  freelawproject/recap#248 work.

First, favor the prevailing style and use `u''` strings.

Substantially improve the documentation of `docket_entries()` and the regexs it uses at the top of the class. In the abstract, it's really tough to debug and figure out what's going on without this kind of thing.

Further, clarify the docstring of docket_entries() and the nonobvious peculiarity that it does not return minute orders without attached documents.

Next, broaden the `short_desc_regex` so it does not magically skip entries with no attached document. The choice is made explicit with `if not all([doc1_url.strip(), de[u'document_number']]):` and it's not productive to bury a restriction like that hidden in the regex. Especially because it is a bad restriction that should go away, but that requires CL schema changes (and other things too, I imagine), so it is likely not safe to just do it here.

**_Or is it?_**