### PR TITLE
In Appellate parser, parse the party HTML information rather than including it raw.

### DIFF
--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -23,9 +23,7 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
     and provide it in our output. There are some exceptions:
 
      1. We don't parse the Prior/Current Cases table.
-     1. When parsing HTML, we cheat on the parties attribute and just return
-        HTML rather than structured data.
-     1. We don't handle bankruptcy appellate panel dockets (yet)
+     2. We don't handle bankruptcy appellate panel dockets (yet)
     """
 
     docket_number_dist_regex = re.compile(

--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -304,6 +304,11 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
             <p>b</p>
             <p>c</p>
           </foo>
+
+        :param target_element: An lxml HtmlElement that will be redelimited
+        :param delimiter_re: a re pattern matching the tag to replace, e.g.
+            r'(?i)<br ?/?>' for a <br> tag (with optional space and optional /)
+        :returns: The redelimited HtmlElement.
         """
         html_text = tostring(target_element, encoding='unicode')
         html_text = re.sub(r'(?i)^(<[^>]*>)', r'\1<p>', html_text)

--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -465,6 +465,8 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
             party[u'attorneys'] = attorneys
             parties.append(party)
 
+        parties = self._normalize_see_above_attorneys(parties)
+
         self._parties = parties
         return parties
 

--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -307,7 +307,7 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
 
         :param target_element: An lxml HtmlElement that will be redelimited
         :param delimiter_re: a re pattern matching the tag to replace, e.g.
-            r'(?i)<br ?/?>' for a <br> tag (with optional space and optional /)
+            r'(?i)<br\s*/?>' for a <br> (with optional space and optional /)
         :returns: The redelimited HtmlElement.
         """
         html_text = tostring(target_element, encoding='unicode')
@@ -362,7 +362,7 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
             #  <B>Terminated: </B>07/31/2017<BR>
             #  Respondent
 
-            name_role = self.redelimit_p(cells[0], r'(?i)<br/?>')
+            name_role = self.redelimit_p(cells[0], r'(?i)<br\s*/?>')
             count = len(name_role)
             assert count >= 2, \
                 "Expecting 2+ <br>-delimited portions of first cell."
@@ -445,7 +445,8 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
 
             # We fixup the raw HTML by separating attorneys into <p>
             # elements, replacing <br><br> pairs.
-            attorney_rows = self.redelimit_p(attorneys, r'(?i)<br/?><br/?>')
+            attorney_rows = self.redelimit_p(attorneys,
+                                             r'(?i)<br\s*/?><br\s*/?>')
             attorneys = []
             for attorney_row in attorney_rows:
                 attorney = {}

--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -221,7 +221,7 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
             <input name="servlet" value="ShowDoc" type="hidden">
             <input name="CSRF" value="csrf_-7746865752981737651" type="hidden">
             <input name="incPdfHeader" value="N" type="hidden">
-            <input name="incPdfHeaderDisp" value="Y" checked="" type="checkbox"> Show PDF Header
+            <input name="incPdfHeaderDisp" value="Y" checked="" type="checkbox">Show PDF Header
             <input name="dls_id" value="00116008873" type="hidden">
             <input name="caseId" value="30442" type="hidden">
             <input name="recp" value="" type="hidden"><input name="pacer" value="t" type="hidden">
@@ -244,6 +244,7 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
         Note that although the recp parameter is created by the JS, and so you
         might think it's important, it doesn't seem to do anything that we've
         identified and so is ignored below.
+        # noqa
         """
         assert self.session is not None, \
             u'session attribute of AppellateDocketReport cannot be None.'
@@ -281,7 +282,8 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
             u'date_filed': self._get_tail_by_regex('Docketed', True),
             u'date_terminated': self._get_tail_by_regex('Termed', True),
             u'case_type_information': self._get_case_type_info(),
-            u'originating_court_information': self._get_originating_court_info(),
+            u'originating_court_information':
+                self._get_originating_court_info(),
         }
         data = clean_pacer_object(data)
         self._metadata = data
@@ -347,7 +349,7 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
         return docket_entries
 
     @staticmethod
-    def _get_document_number( cell):
+    def _get_document_number(cell):
         """Get the document number"""
         text_nodes = cell.xpath('.//text()[not(parent::font)]')
         text_nodes = map(clean_string, text_nodes)
@@ -403,7 +405,9 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
     def _get_originating_court_info(self):
         """Get all of the originating type information as a dict."""
         try:
-            ogc_table = self.tree.re_xpath('//*[re:match(text(), "Originating Court Information")]/ancestor::table[1]')[0]
+            ogc_table = self.tree.re_xpath(
+                '//*[re:match(text(), "Originating Court Information")]/ancestor::table[1]' # noqa
+            )[0]
         except IndexError:
             # No originating court info.
             return {}
@@ -434,13 +438,15 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
 
         ogc_info[u'court_reporter'] = self._get_tail_by_regex('Court Reporter')
         ogc_info[u'date_filed'] = self._get_tail_by_regex('Date Filed', True)
-        ogc_info[u'date_disposed'] = self._get_tail_by_regex('Date Disposed', True)
+        ogc_info[u'date_disposed'] = self._get_tail_by_regex(
+            'Date Disposed', True)
         ogc_info[u'disposition'] = self._get_tail_by_regex('Disposition')
 
         trial_judge_str = self._get_tail_by_regex('Trial Judge')
         ogc_info[u'assigned_to'] = normalize_judge_string(trial_judge_str)[0]
         order_judge_str = self._get_tail_by_regex('Ordering Judge')
-        ogc_info[u'ordering_judge'] = normalize_judge_string(order_judge_str)[0]
+        ogc_info[u'ordering_judge'] = normalize_judge_string(
+            order_judge_str)[0]
 
         date_labels = ogc_table.xpath('.//tr[last() - 1]/td//text()')
         dates = ogc_table.xpath('.//tr[last()]/td//text()')

--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -366,7 +366,10 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
 
             # Name is first, Role is last
             party[u'name'] = force_unicode(name_role[0].text_content().strip())
-            party[u'type'] = name_role[count-1].text_content().strip()
+            role = name_role[count-1].text_content().strip()
+            # Strip terminal comma, if present.
+            role = re.sub(r',$', '', role)
+            party[u'type'] = role
 
             unparsed = []
             for i in range(1, count-1):

--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -144,6 +144,20 @@ class BaseDocketReport(object):
                     return d.date()
                 return d
 
+    @staticmethod
+    def _br_split(element):
+        """Split the text of an element on the BRs.
+
+        :param element: Any HTML element
+        :return: A list of text nodes from that element split on BRs.
+        """
+        sep = u'FLP_SEPARATOR'
+        html_text = tostring(element, encoding='unicode')
+        html_text = re.sub(r'<br/?>', sep, html_text, flags=re.I)
+        element = fromstring(html_text)
+        text = force_unicode(' '.join(s for s in element.xpath('.//text()')))
+        return [s.strip() for s in text.split(sep) if s]
+
 
 class DocketReport(BaseDocketReport, BaseReport):
     case_name_str = r"(?:Case\s+title:\s+)?(.*\bv\.?\s.*)"
@@ -1039,21 +1053,6 @@ class DocketReport(BaseDocketReport, BaseReport):
                 return ''
             judge_str = judge_str.split('to:')[1]
             return normalize_judge_string(judge_str)[0]
-
-    @staticmethod
-    def _br_split(element):
-        """Split the text of an element on the BRs.
-
-        :param element: Any HTML element
-        :return: A list of text nodes from that element split on BRs.
-        """
-        sep = u'FLP_SEPARATOR'
-        html_text = tostring(element, encoding='unicode')
-        html_text = re.sub(r'<br/?>', sep, html_text, flags=re.I)
-        element = fromstring(html_text)
-        text = force_unicode(' '.join(s for s in element.xpath('.//text()')))
-        return [s.strip() for s in text.split(sep) if s]
-
 
 if __name__ == "__main__":
     if len(sys.argv) != 2:

--- a/tests/examples/pacer/dockets/appellate/ca1.json
+++ b/tests/examples/pacer/dockets/appellate/ca1.json
@@ -121,5 +121,52 @@
     "ordering_judge": "Rya W. Zobel"
   }, 
   "panel": [], 
-  "parties": "<table cellpadding=\"0\" width=\"100%\" border=\"1\">\n<tbody>\n<tr><td>\n\t<table cellpadding=\"4\" width=\"100%\" border=\"0\" cellspacing=\"0\">\n<tbody>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">GIFTY R. SAMUELS<br>\n\nAppellant\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid G. Baker<br>Direct: 617-367-4260<br>Fax: 866-661-5328<br>[COR NTC Retained]<br>236 Huntington Ave<br>Boston, MA 02115-4701</td>\n</tr>\n<tr><td colspan=\"2\">v.<br><br>\n</td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">DEUTSCHE BANK NATIONAL TRUST COMPANY, as Trustee of the Argent Securities, Inc., Asset-Backed Pass-Through Certificates, Series 2005-W3<br>\n\nAppellee\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRichard A. Oetheimer<br>Direct: 617-570-1259<br>Fax: 617-523-1231<br>[COR NTC Retained]<br>Goodwin Procter LLP<br>100 Northern Ave<br>Boston, MA 02210<br><br>\nMatthew J. Thaler<br>Direct: 617-570-1000<br>[COR NTC Retained]<br>Goodwin Procter LLP<br>100 Northern Ave<br>Boston, MA 02210</td>\n</tr>\n<tr><td colspan=\"2\">------------------------------<br><br>\n</td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">JOHN FITZGERALD, Assistant U.S. Trustee<br>\n\nInterested\u00a0Party\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nJohn Fitzgerald<br>[NTC Pro Se]<br>Thomas P.'Neill Jr., Federal Bldg.<br>10 Causeway St.<br>Region 1<br>Boston, MA 02222-0000</td>\n</tr>\n</tbody>\n</table>\n</td></tr>\n</tbody>\n</table>\n"
+  "parties": [
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 617-367-4260\nFax: 866-661-5328\n236 Huntington Ave\nBoston, MA 02115-4701", 
+          "name": "David G. Baker", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "GIFTY R. SAMUELS", 
+      "type": "Appellant"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 617-570-1259\nFax: 617-523-1231\nGoodwin Procter LLP\n100 Northern Ave\nBoston, MA 02210", 
+          "name": "Richard A. Oetheimer", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Ave\nBoston, MA 02210", 
+          "name": "Matthew J. Thaler", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "DEUTSCHE BANK NATIONAL TRUST COMPANY, as Trustee of the Argent Securities, Inc., Asset-Backed Pass-Through Certificates, Series 2005-W3", 
+      "type": "Appellee"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Thomas P.'Neill Jr., Federal Bldg.\n10 Causeway St.\nRegion 1\nBoston, MA 02222-0000", 
+          "name": "John Fitzgerald", 
+          "roles": [
+            "NTC Pro Se"
+          ]
+        }
+      ], 
+      "name": "JOHN FITZGERALD, Assistant U.S. Trustee", 
+      "type": "Interested\u00a0Party"
+    }
+  ]
 }

--- a/tests/examples/pacer/dockets/appellate/ca11_1.json
+++ b/tests/examples/pacer/dockets/appellate/ca11_1.json
@@ -57,5 +57,5 @@
     "ordering_judge": ""
   }, 
   "panel": [], 
-  "parties": ""
+  "parties": []
 }

--- a/tests/examples/pacer/dockets/appellate/ca11_2.json
+++ b/tests/examples/pacer/dockets/appellate/ca11_2.json
@@ -57,5 +57,67 @@
     "ordering_judge": ""
   }, 
   "panel": [], 
-  "parties": "<table cellpadding=\"0\" width=\"100%\" border=\"1\">\n<tbody>\n<tr><td>\n\t<table cellpadding=\"4\" width=\"100%\" border=\"0\" cellspacing=\"0\">\n<tbody>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">THEODORE D'APUZZO, P.A.<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Petitioner\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nNicole Giuliano<br>Direct: 954-848-2940<br>[COR LD NTC Retained]<br>Giuliano Law, PA<br>500 E BROWARD BLVD STE 1710<br>FT LAUDERDALE, FL 33394<br><br>\nMorgan L. Weinstein<br>[COR NTC Retained]<br>Law Office of Morgan L. Weinstein<br>Firm: 954-540-2755<br>5216 VAN BUREN ST<br>HOLLYWOOD, FL 33021</td>\n</tr>\n<tr><td colspan=\"2\">versus<br><br>\n</td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">UNITED STATES OF AMERICA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Respondent\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nJoshua Marc Salzman<br>Direct: 202-532-4747<br>[COR LD NTC US Attorney]<br>U.S. Department of Justice<br>RM 7258<br>950 CONSTITUTION AVE NW<br>WASHINGTON, DC 20530-0001<br><br>\nCharles W. Scarborough<br>Direct: 202-514-1927<br>[COR NTC U.S. Government]<br>U.S. Attorney General's Office<br>950 PENNSYLVANIA AVE NW<br>WASHINGTON, DC 20530-001<br><br>\nEmily M. Smachetti<br>[NTC US Attorney]<br>U.S. Attorney's Office<br>Firm: 305-961-9295<br>99 NE 4TH ST STE 523<br>MIAMI, FL 33132<br><br>\n U.S. Attorney Service - Southern District of Florida<br>[NTC US Attorney]<br>U.S. Attorney's Office<br>Firm: 305-961-9295<br>99 NE 4TH ST STE 523<br>MIAMI, FL 33132<br><br>\nAlicia Hayley Welch<br>Direct: 305-961-9370<br>[NTC US Attorney]<br>U.S. Attorney's Office<br>Firm: 305-961-9295<br>99 NE 4TH ST STE 523<br>MIAMI, FL 33132</td>\n</tr>\n</tbody>\n</table>\n</td></tr>\n</tbody>\n</table>\n"
+  "parties": [
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 954-848-2940\nGiuliano Law, PA\n500 E BROWARD BLVD STE 1710\nFT LAUDERDALE, FL 33394", 
+          "name": "Nicole Giuliano", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Law Office of Morgan L. Weinstein\nFirm: 954-540-2755\n5216 VAN BUREN ST\nHOLLYWOOD, FL 33021", 
+          "name": "Morgan L. Weinstein", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "THEODORE D'APUZZO, P.A.", 
+      "type": "Petitioner"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-532-4747\nU.S. Department of Justice\nRM 7258\n950 CONSTITUTION AVE NW\nWASHINGTON, DC 20530-0001", 
+          "name": "Joshua Marc Salzman", 
+          "roles": [
+            "COR LD NTC US Attorney"
+          ]
+        }, 
+        {
+          "contact": "Direct: 202-514-1927\nU.S. Attorney General's Office\n950 PENNSYLVANIA AVE NW\nWASHINGTON, DC 20530-001", 
+          "name": "Charles W. Scarborough", 
+          "roles": [
+            "COR NTC U.S. Government"
+          ]
+        }, 
+        {
+          "contact": "U.S. Attorney's Office\nFirm: 305-961-9295\n99 NE 4TH ST STE 523\nMIAMI, FL 33132", 
+          "name": "Emily M. Smachetti", 
+          "roles": [
+            "NTC US Attorney"
+          ]
+        }, 
+        {
+          "contact": "U.S. Attorney's Office\nFirm: 305-961-9295\n99 NE 4TH ST STE 523\nMIAMI, FL 33132", 
+          "name": "U.S. Attorney Service - Southern District of Florida", 
+          "roles": [
+            "NTC US Attorney"
+          ]
+        }, 
+        {
+          "contact": "Direct: 305-961-9370\nU.S. Attorney's Office\nFirm: 305-961-9295\n99 NE 4TH ST STE 523\nMIAMI, FL 33132", 
+          "name": "Alicia Hayley Welch", 
+          "roles": [
+            "NTC US Attorney"
+          ]
+        }
+      ], 
+      "name": "UNITED STATES OF AMERICA", 
+      "type": "Respondent"
+    }
+  ]
 }

--- a/tests/examples/pacer/dockets/appellate/ca1_2.json
+++ b/tests/examples/pacer/dockets/appellate/ca1_2.json
@@ -221,6 +221,7 @@
   "fee_status": "filing fee paid", 
   "nature_of_suit": "", 
   "originating_court_information": {
+    "RESTRICTED_ALIEN_NUMBER": "A096-416-756", 
     "assigned_to": "", 
     "court_id": "", 
     "court_reporter": "", 
@@ -228,7 +229,6 @@
     "date_filed": "2016-01-06", 
     "date_received_coa": "2016-01-06", 
     "disposition": "", 
-    "docket_number": "A096-416-756", 
     "ordering_judge": ""
   }, 
   "panel": [
@@ -236,5 +236,72 @@
     "KVL", 
     "RT"
   ], 
-  "parties": "<table cellpadding=\"0\" width=\"100%\" border=\"1\">\n<tbody>\n<tr><td>\n\t<table cellpadding=\"4\" width=\"100%\" border=\"0\" cellspacing=\"0\">\n<tbody>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">WESCLEY FONSECA PEREIRA<br>\n\nPetitioner\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nJeffrey Brian Rubin<br>Direct: 617-367-0077<br>Fax: 617-367-0071<br>[COR NTC Retained]<br>Rubin Pomerleau PC<br>Three Center Plaza<br>Suite 400<br>Boston, MA 02135-0000</td>\n</tr>\n<tr><td colspan=\"2\">v.<br><br>\n</td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">LORETTA E. LYNCH, Attorney General<br><b>Terminated: </b>07/31/2017<br>\n\nRespondent\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">JEFFERSON B. SESSIONS, III, Attorney General<br>\n\nRespondent\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nLaTia N. Bing<br>[NTC Federal Government]<br>US Dept of Justice<br>Office of Immigration Litigation<br>PO Box 878<br>Ben Franklin Station<br>Washington, DC 20044-0878<br><br>\nJesse David Lorenz<br>[COR NTC Federal Government]<br>US Dept of Justice<br>Office of Immigration Litigation<br>PO Box 878<br>Ben Franklin Station<br>Washington, DC 20044-0878<br><br>\nBenjamin C. Mizer<br>[On Brief]<br>US Dept of Justice<br>950 Pennsylvania Ave NW<br>Washington, DC 20530-0001<br><br>\nSarah Pergolizzi<br>[NTC Government - Other]<br>US Dept of Justice<br>Office of Immigration Litigation<br>PO Box 878<br>Ben Franklin Station<br>Washington, DC 20044-0878<br><br>\nKohsei Ugumori<br>[NTC Federal Government]<br>US Dept of Justice<br>Office of Immigration Litigation<br>PO Box 878<br>Ben Franklin Station<br>Washington, DC 20044-0878</td>\n</tr>\n</tbody>\n</table>\n</td></tr>\n</tbody>\n</table>\n"
+  "parties": [
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 617-367-0077\nFax: 617-367-0071\nRubin Pomerleau PC\nThree Center Plaza\nSuite 400\nBoston, MA 02135-0000", 
+          "name": "Jeffrey Brian Rubin", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "WESCLEY FONSECA PEREIRA", 
+      "type": "Petitioner"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "", 
+          "name": "", 
+          "roles": []
+        }
+      ], 
+      "date_terminated": "07/31/2017", 
+      "name": "LORETTA E. LYNCH, Attorney General", 
+      "type": "Respondent"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "US Dept of Justice\nOffice of Immigration Litigation\nPO Box 878\nBen Franklin Station\nWashington, DC 20044-0878", 
+          "name": "LaTia N. Bing", 
+          "roles": [
+            "NTC Federal Government"
+          ]
+        }, 
+        {
+          "contact": "US Dept of Justice\nOffice of Immigration Litigation\nPO Box 878\nBen Franklin Station\nWashington, DC 20044-0878", 
+          "name": "Jesse David Lorenz", 
+          "roles": [
+            "COR NTC Federal Government"
+          ]
+        }, 
+        {
+          "contact": "US Dept of Justice\n950 Pennsylvania Ave NW\nWashington, DC 20530-0001", 
+          "name": "Benjamin C. Mizer", 
+          "roles": [
+            "On Brief"
+          ]
+        }, 
+        {
+          "contact": "US Dept of Justice\nOffice of Immigration Litigation\nPO Box 878\nBen Franklin Station\nWashington, DC 20044-0878", 
+          "name": "Sarah Pergolizzi", 
+          "roles": [
+            "NTC Government - Other"
+          ]
+        }, 
+        {
+          "contact": "US Dept of Justice\nOffice of Immigration Litigation\nPO Box 878\nBen Franklin Station\nWashington, DC 20044-0878", 
+          "name": "Kohsei Ugumori", 
+          "roles": [
+            "NTC Federal Government"
+          ]
+        }
+      ], 
+      "name": "JEFFERSON B. SESSIONS, III, Attorney General", 
+      "type": "Respondent"
+    }
+  ]
 }

--- a/tests/examples/pacer/dockets/appellate/ca1_3.json
+++ b/tests/examples/pacer/dockets/appellate/ca1_3.json
@@ -11,5 +11,5 @@
   "nature_of_suit": "3422 Appeal 28 USC 158", 
   "originating_court_information": {}, 
   "panel": [], 
-  "parties": ""
+  "parties": []
 }

--- a/tests/examples/pacer/dockets/appellate/ca9_1.json
+++ b/tests/examples/pacer/dockets/appellate/ca9_1.json
@@ -85,5 +85,5 @@
     "ordering_judge": ""
   }, 
   "panel": [], 
-  "parties": ""
+  "parties": []
 }

--- a/tests/examples/pacer/dockets/appellate/ca9_2.json
+++ b/tests/examples/pacer/dockets/appellate/ca9_2.json
@@ -109,5 +109,2663 @@
     "ordering_judge": ""
   }, 
   "panel": [], 
-  "parties": "<table cellpadding=\"0\" width=\"100%\" border=\"1\">\n<tbody>\n<tr><td>\n\t<table cellpadding=\"4\" width=\"100%\" border=\"0\" cellspacing=\"0\">\n<tbody>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF HAWAII<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Plaintiff\u00a0-\u00a0Appellee,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDonna H. Kalama<br>[COR LD NTC Dep State Aty Gen]<br>AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL<br>Firm: 808-568-1180<br>425 Queen Street<br>Honolulu, HI 96813<br><br>\nNeal Kumar Katyal<br>[COR LD NTC Retained]<br>Hogan Lovells US LLP<br>Firm: 202-637-5600<br>555 Thirteenth Street, NW<br>Washington, DC 20004<br><br>\nColleen Sinzdak<br>[COR LD NTC Retained]<br>Hogan Lovells US LLP<br>Firm: 202-637-5600<br>555 Thirteenth Street, NW<br>Washington, DC 20004<br><br>\nAlexander Biays Bowerman<br>[COR NTC Retained]<br>Hogan Lovells US LLP<br>1735 Market Street<br>23rd Floor<br>Philadelphia, PA 19103<br><br>\nDouglas Chin, Esquire, Attorney General<br>[COR NTC Dep State Aty Gen]<br>AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL<br>Firm: 808-568-1180<br>425 Queen Street<br>Honolulu, HI 96813<br><br>\nKimberly Tsumoto Guidry<br>[COR NTC Dep State Aty Gen]<br>AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL<br>Firm: 808-568-1180<br>425 Queen Street<br>Honolulu, HI 96813<br><br>\nElizabeth Hagerty<br>[COR NTC Retained]<br>Hogan Lovells US LLP<br>Firm: 202-637-5600<br>555 Thirteenth Street, NW<br>Washington, DC 20004<br><br>\nDeirdre Marie-Iha, Esquire<br>[COR NTC Dep State Aty Gen]<br>AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL<br>Firm: 808-568-1180<br>425 Queen Street<br>Honolulu, HI 96813<br><br>\nRobert Tadao Nakatsuji, Esquire<br>[COR NTC Dep State Aty Gen]<br>AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL<br>Firm: 808-568-1180<br>425 Queen Street<br>Honolulu, HI 96813<br><br>\nMitchell Reich<br>[COR NTC Retained]<br>Hogan Lovells US LLP<br>Firm: 202-637-5600<br>555 Thirteenth Street, NW<br>Washington, DC 20004<br><br>\nThomas Schmidt, Associate<br>[COR NTC Retained]<br>Hogan Lovells US LLP<br>Firm: 212-918-3000<br>875 Third Avenue<br>New York, NY 10022<br><br>\nSara Solow<br>[COR NTC Retained]<br>Hogan Lovells US LLP<br>1735 Market Street<br>23rd Floor<br>Philadelphia, PA 19103<br><br>\nClyde James Wadsworth<br>[COR NTC Dep State Aty Gen]<br>AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL<br>Firm: 808-568-1180<br>425 Queen Street<br>Honolulu, HI 96813</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ISMAIL ELSHIKH<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Plaintiff\u00a0-\u00a0Appellee,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDouglas Chin, Esquire, Attorney General<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n<br><br>\nKimberly Tsumoto Guidry<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n<br><br>\nDonna H. Kalama<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n<br><br>\nNeal Kumar Katyal<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nDeirdre Marie-Iha, Esquire<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n<br><br>\nRobert Tadao Nakatsuji, Esquire<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n<br><br>\nColleen Sinzdak<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nClyde James Wadsworth<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n<br><br>\nAlexander Biays Bowerman<br>[COR NTC Retained]<br>(see above)\n<br><br>\nElizabeth Hagerty<br>[COR NTC Retained]<br>(see above)\n<br><br>\nMitchell Reich<br>[COR NTC Retained]<br>(see above)\n<br><br>\nThomas Schmidt, Associate<br>[COR NTC Retained]<br>(see above)\n<br><br>\nSara Solow<br>[COR NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ALI PLAINTIFFS<br><b>Terminated: </b>04/21/2017<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Intervenor\u00a0-\u00a0Pending,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">JOSEPH DOE<br><b>Terminated: </b>04/21/2017<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Intervenor\u00a0-\u00a0Pending,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">JAMES DOE<br><b>Terminated: </b>04/21/2017<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Intervenor\u00a0-\u00a0Pending,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">EPISCOPAL DIOCESE OF OLYMPIA<br><b>Terminated: </b>04/21/2017<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Intervenor\u00a0-\u00a0Pending,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\n</td>\n</tr>\n<tr><td colspan=\"2\">\u00a0\u00a0\u00a0v.<br><br>\n</td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">DONALD J. TRUMP, in his official capacity as President of the United States<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Defendant\u00a0-\u00a0Appellant,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nH. Thomas Byron, III, Attorney<br>[COR LD NTC Assist US Attorney]<br>DOJ - U.S. Department of Justice<br>950 Pennsylvania Ave., N.W.<br>Washington, DC 20530<br><br>\nAnne Murphy, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>DOJ - U.S. Department of Justice<br>950 Pennsylvania Ave., N.W.<br>Washington, DC 20530<br><br>\nBrad Prescott Rosenberg, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>DOJ - U.S. DEPARTMENT OF JUSTICE<br>Civil Division<br>P.O. Box 883<br>Washington, DC 20044<br><br>\nLowell Sturgill, Jr., Attorney<br>[COR LD NTC Assist US Attorney]<br>DOJ - U.S. Department of Justice<br>950 Pennsylvania Ave., N.W.<br>Washington, DC 20530<br><br>\nSharon Swingle<br>[COR LD NTC Assist US Attorney]<br>DOJ - U.S. Department of Justice<br>950 Pennsylvania Ave., N.W.<br>Washington, DC 20530<br><br>\nJeffrey Bryan Wall, Attorney<br>[COR LD NTC Assist US Attorney]<br>DOJ - U.S. Department of Justice<br>950 Pennsylvania Ave., N.W.<br>Washington, DC 20530</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">U.S. DEPARTMENT OF HOMELAND SECURITY<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Defendant\u00a0-\u00a0Appellant,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nH. Thomas Byron, III, Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nAnne Murphy, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nBrad Prescott Rosenberg, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nLowell Sturgill, Jr., Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nSharon Swingle<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nJeffrey Bryan Wall, Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">JOHN F. KELLY, in his official capacity as Secretary of Homeland Security<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Defendant\u00a0-\u00a0Appellant,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nH. Thomas Byron, III, Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nAnne Murphy, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nBrad Prescott Rosenberg, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nLowell Sturgill, Jr., Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nSharon Swingle<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nJeffrey Bryan Wall, Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">U.S. DEPARTMENT OF STATE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Defendant\u00a0-\u00a0Appellant,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nH. Thomas Byron, III, Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nAnne Murphy, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nBrad Prescott Rosenberg, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nLowell Sturgill, Jr., Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nSharon Swingle<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nJeffrey Bryan Wall, Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">REX W. TILLERSON, in his official capacity as Secretary of State<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Defendant\u00a0-\u00a0Appellant,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nH. Thomas Byron, III, Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nAnne Murphy, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nBrad Prescott Rosenberg, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nLowell Sturgill, Jr., Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nSharon Swingle<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nJeffrey Bryan Wall, Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">UNITED STATES OF AMERICA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Defendant\u00a0-\u00a0Appellant,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nH. Thomas Byron, III, Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nAnne Murphy, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nBrad Prescott Rosenberg, Trial Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nLowell Sturgill, Jr., Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nSharon Swingle<br>[COR LD NTC Assist US Attorney]<br>(see above)\n<br><br>\nJeffrey Bryan Wall, Attorney<br>[COR LD NTC Assist US Attorney]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\">------------------------------<br><br>\n</td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">PHIL BRYANT, Governor of the State of Mississippi<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>Office of Attorney General<br>7th Floor (MC-059)<br>P.O. Box 12548<br>Austin, TX 78711-2548</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF ALABAMA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">RODERICK AND SOLANGE MACARTHUR JUSTICE CENTER<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAmir Ali<br>Direct: 202-869-3434<br>[COR LD NTC Retained]<br>Roderick &amp; Solange MacArthur Justice Center<br>718 7th Street NW<br>Washington, DC 20001</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF ARIZONA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">INTERFAITH COALITION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRobert D. Fram, Esquire<br>Direct: 415-591-7025<br>[COR LD NTC Retained]<br>Covington &amp; Burling, LLP<br>35th Floor<br>One Front Street<br>San Francisco, CA 94111</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF ARKANSAS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">FOUNDATION FOR THE CHILDREN OF IRAN<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nKevin Paul Martin, Attorney<br>Direct: 617-570-1000<br>[COR LD NTC Retained]<br>Goodwin Procter LLP<br>100 Northern Avenue<br>Boston, MA 02210<br><br>\nWilliam B. Brady<br>Direct: 617-570-1000<br>[COR NTC Retained]<br>Goodwin Procter LLP<br>100 Northern Avenue<br>Boston, MA 02210<br><br>\nJoshua M. Daniels, Attorney<br>Direct: 617-942-2190<br>[COR NTC Retained]<br>The Law Office of Joshua M. Daniels<br>P.O. Box 300765<br>Jamaica Plain, MA 02130<br><br>\nNicholas Mitrokostas<br>Direct: 617-570-1000<br>[COR NTC Retained]<br>Goodwin Procter LLP<br>100 Northern Avenue<br>Boston, MA 02210<br><br>\nEileen Morrison<br>Direct: 617-570-1000<br>[COR NTC Retained]<br>Goodwin Procter LLP<br>100 Northern Avenue<br>Boston, MA 02210<br><br>\nAlicia Rubio<br>Direct: 617-570-1000<br>[COR NTC Retained]<br>Goodwin Procter LLP<br>100 Northern Avenue<br>Boston, MA 02210</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF FLORIDA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">IRANIAN ALLIANCES ACROSS BORDERS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nKevin Paul Martin, Attorney<br>Direct: 617-570-1000<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nWilliam B. Brady<br>Direct: 617-570-1000<br>[COR NTC Retained]<br>(see above)\n<br><br>\nJoshua M. Daniels, Attorney<br>Direct: 617-942-2190<br>[COR NTC Retained]<br>(see above)\n<br><br>\nNicholas Mitrokostas<br>Direct: 617-570-1000<br>[COR NTC Retained]<br>(see above)\n<br><br>\nEileen Morrison<br>Direct: 617-570-1000<br>[COR NTC Retained]<br>(see above)\n<br><br>\nAlicia Rubio<br>Direct: 617-570-1000<br>[COR NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF KANSAS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">EPISCOPAL BISHOPS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nMichael Ramsey Scott, Attorney<br>Direct: 206-623-1745<br>[COR LD NTC Retained]<br>Hillis Clark Martin &amp; Peterson, P.S.<br>Suite 500<br>999 Third Avenue<br>Seattle, WA 98104</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF LOUISIANA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">KHIZR KHAN<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDaniel E. Jackson, Esquire, Attorney<br>Direct: 415-391-5400<br>[COR LD NTC Retained]<br>Keker, Van Nest &amp; Peters LLP<br>633 Battery Street<br>San Francisco, CA 94111</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF MONTANA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NEW YORK UNIVERSITY<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nLary Alan Rappaport<br>Direct: 310-557-2900<br>[COR LD NTC Retained]<br>Proskauer Rose LLP<br>Suite 3200<br>2049 Century Park East<br>Los Angeles, CA 90067-3206</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF NORTH DAKOTA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">INTERNATIONAL LAW SCHOLARS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nJonathan Hafetz, Attorney<br>Direct: 917-355-6896<br>[COR LD NTC Retained]<br>169 Hicks Street<br>Brooklyn, NY 11201<br><br>\nMichelle L. Maley<br>Direct: 206-359-3308<br>[COR LD NTC Retained]<br>Perkins Coie LLP<br>1201 Third Avenue<br>Suite 4900<br>Seattle, WA 98101<br><br>\nJoseph M. McMillan, Esquire, Attorney<br>Direct: 206-359-6354<br>[COR LD NTC Retained]<br>Perkins Coie LLP<br>1201 Third Avenue<br>Suite 4900<br>Seattle, WA 98101<br><br>\nAaron Fellmeth<br>Direct: 480-241-8414<br>[COR NTC Retained]<br>Sandra Day O'Connor College of Law<br>Arizona State University<br>111 E. Taylor Street<br>MC 9520<br>Phoenix, AZ 85021</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF OKLAHOMA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NONGOVERNMENTAL ORGANIZATIONS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nJonathan Hafetz, Attorney<br>Direct: 917-355-6896<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nMichelle L. Maley<br>Direct: 206-359-3308<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nJoseph M. McMillan, Esquire, Attorney<br>Direct: 206-359-6354<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF SOUTH CAROLINA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">COLLEGES AND UNIVERSITIES<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nLindsay Harrison, Attorney<br>Direct: 202-661-4956<br>[COR LD NTC Retained]<br>Jenner &amp; Block LLP<br>Firm: 202-639-6000<br>1099 New York Avenue, NW<br>Suite 900<br>Washington, DC 20001-4412</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF SOUTH DAKOTA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AMERICAN PROFESSIONAL SOCIETY ON THE ABUSE OF CHILDREN<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nMary Kelly Persyn, Attorney<br>Direct: 628-400-1254<br>[COR LD NTC Retained]<br>Persyn Law &amp; Policy<br>912 Cole Street<br>Suite 124<br>San Francisco, CA 94117</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF TENNESSEE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">FORMER NATIONAL SECURITY OFFICIALS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nJonathan Freiman<br>Direct: 203-498-4584<br>[COR LD NTC Retained]<br>WIGGIN &amp; DANA<br>PO Box 1832<br>New Haven, CT 06508-1832</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF TEXAS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">SCHOLARS OF AMERICAN RELIGIOUS HISTORY AND LAW<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAnna-Rose Mathieson<br>Direct: 415-649-6700<br>[COR LD NTC Retained]<br>California Appellate Law Group<br>96 Jessie Street<br>San Francisco, CA 94105</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF WEST VIRGINIA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott A. Keller, Attorney<br>Direct: 512-936-1700<br>[COR LD NTC State Atty General]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">T. A., a U.S. Citizen of Yemeni Descent<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRichard Bernstein, Attorney<br>Direct: 202-303-1108<br>[COR LD NTC Retained]<br>Willkie Farr &amp; Gallagher LLP<br>1875 \"K\" St. NW<br>Washington, DC 20006</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CONSTITUTIONAL LAW SCHOLARS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nJoshua Adam Matz, Associate<br>Direct: 845-893-9402<br>[COR LD NTC Retained]<br>Gupta Wessler PLLC<br>1900 L Street, NW<br>Suite 312<br>Washington, DC 20036</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">INTERFAITH GROUP OF RELIGIOUS AND INTERRELIGIOUS ORGANIZATIONS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nMarc A. Hearron<br>[COR LD NTC Retained]<br>Morrison &amp; Foerster LLP<br>Firm: 202-887-1500<br>2000 Pennsylvania Avenue, NW<br>Washington, DC 20006</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">MUSLIM ADVOCATES<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAnton A. Ware<br>Direct: 415-471-3100<br>[COR LD NTC Retained]<br>Arnold &amp; Porter Kaye Scholer LLP<br>Three Embarcadero Center<br>10th Floor<br>San Francisco, CA 94111-4024</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AMERICAN MUSLIM HEALTH PROFESSIONALS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAnton A. Ware<br>Direct: 415-471-3100<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">MUPPIES, INC.<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAnton A. Ware<br>Direct: 415-471-3100<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NATIONAL ARAB AMERICAN MEDICAL ASSOCIATION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAnton A. Ware<br>Direct: 415-471-3100<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NETWORK OF ARAB-AMERICAN PROFESSIONALS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAnton A. Ware<br>Direct: 415-471-3100<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF ILLINOIS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>OFFICE OF THE ATTORNEY GENERAL<br>12th Floor<br>100 West Randolph Street<br>Chicago, IL 60601</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF CALIFORNIA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF CONNECTICUT<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF DELAWARE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF IOWA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF MAINE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF MARYLAND<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF MASSACHUSETTS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF NEW MEXICO<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF NEW YORK<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF NORTH CAROLINA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF OREGON<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF RHODE ISLAND<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF VERMONT<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF VIRGINIA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">STATE OF WASHINGTON<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">DISTRICT OF COLUMBIA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nDavid Franklin, Solicitor General<br>Direct: 312-814-5376<br>[COR LD NTC Dep State Aty Gen]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">SOUTHEASTERN LEGAL FOUNDATION, INC.<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nWilliam Consovoy<br>Direct: 703-423-9423<br>[COR LD NTC Retained]<br>Consovoy McCarthy Park PLLC<br>3033 Wilson Boulevard<br>Suite 700<br>Arlington, VA 22201</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AMERICAN CENTER FOR LAW AND JUSTICE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nEdward Lawrence White<br>Direct: 734-680-8007<br>[COR NTC Retained]<br>American Center for Law &amp; Justice<br>3001 Plymouth Road<br>Suite 203<br>Ann Arbor, MI 48105</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">FRED T. KOREMATSU CENTER FOR LAW AND EQUALITY<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPratik A. Shah, Attorney<br>Direct: 202-887-4210<br>[COR LD NTC Retained]<br>Akin Gump Strauss Hauer &amp; Feld LLP<br>1333 New Hampshire Avenue, N.W.<br>Washington, DC 20036</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">JAY HIRABAYASHI<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPratik A. Shah, Attorney<br>Direct: 202-887-4210<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">HOLLY YASUI<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPratik A. Shah, Attorney<br>Direct: 202-887-4210<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">KAREN KOREMATSU<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPratik A. Shah, Attorney<br>Direct: 202-887-4210<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CIVIL RIGHTS ORGANIZATIONS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPratik A. Shah, Attorney<br>Direct: 202-887-4210<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NATIONAL BAR ASSOCIATIONS OF COLOR<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPratik A. Shah, Attorney<br>Direct: 202-887-4210<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">MEMBERS OF THE CLERGY<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRichard Brian Katskee, Counsel<br>Direct: 202-466-3234<br>[COR LD NTC Retained]<br>Americans United for Separation of Church and State<br>1310 L Street NW<br>Suite 200<br>Washington, DC 20005</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AMERICANS UNITED FOR SEPARATION OF CHURCH AND STATE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRichard Brian Katskee, Counsel<br>Direct: 202-466-3234<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">BEND THE ARC: A JEWISH PARTNERSHIP FOR JUSTICE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRichard Brian Katskee, Counsel<br>Direct: 202-466-3234<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">RIVERSIDE CHURCH IN THE CITY OF NEW YORK<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRichard Brian Katskee, Counsel<br>Direct: 202-466-3234<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">SOUTHERN POVERTY LAW CENTER<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRichard Brian Katskee, Counsel<br>Direct: 202-466-3234<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CITY OF CHICAGO<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nBenna Ruth Solomon, Deputy Corporation Counsel<br>Direct: 312-744-7764<br>[COR LD NTC Retained]<br>City of Chicago Law Department<br>Appeals Division<br>30 North LaSalle Street<br>Suite 800<br>Chicago, IL 60602</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CITY OF LOS ANGELES<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nBenna Ruth Solomon, Deputy Corporation Counsel<br>Direct: 312-744-7764<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CITY OF NEW YORK<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nBenna Ruth Solomon, Deputy Corporation Counsel<br>Direct: 312-744-7764<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CITY OF PHILADELPHIA, and OTHER MAJOR CITIES AND COUNTIES<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nBenna Ruth Solomon, Deputy Corporation Counsel<br>Direct: 312-744-7764<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">IMMIGRATION REFORM LAW INSTITUTE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nChristopher Hajec<br>Direct: 202-833-8400<br>[COR LD NTC Retained]<br>CENTER FOR INDIVIDUAL RIGHTS<br>Suite 300<br>1233 20th St. NW<br>Washington, DC 20036</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AMERICAN BAR ASSOCIATION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nLinda A. Klein<br>Direct: 404-221-6530<br>[COR NTC Retained]<br>Baker, Donelson, Bearman, Caldwell &amp; Berkowitz, PC<br>Suite 1600<br>3414 Peachtree Rd. NE<br>Atlanta, GA 30326</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ALLIANCE DEFENDING FREEDOM<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nJonathan Andrew Scruggs, Esquire, Attorney<br>Direct: 480-388-8007<br>[COR LD NTC Retained]<br>Alliance Defending Freedom<br>Firm: 480-444-0020<br>15100 N. 90th Street<br>Scottsdale, AZ 85260</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">OXFAM AMERICA, INC.<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRichard P. Bress, Attorney<br>Direct: 202-637-2200<br>[COR LD NTC Retained]<br>Latham &amp; Watkins LLP<br>555 Eleventh Street, NW<br>Suite 1000<br>Washington, DC 20004-1304<br><br>\nChristopher J. Mortweet<br>Direct: 650-328-4600<br>[COR NTC Retained]<br>Latham &amp; Watkins LLP<br>140 Scott Drive<br>Menlo Park, CA 94025<br><br>\nElana Nightingale Dawson<br>Direct: 202-637-2200<br>[COR NTC Retained]<br>Latham &amp; Watkins LLP<br>555 Eleventh Street, NW<br>Suite 1000<br>Washington, DC 20004-1304<br><br>\nAlexandra Shechtel<br>Direct: 202-637-2200<br>[COR NTC Retained]<br>Latham &amp; Watkins LLP<br>555 Eleventh Street, NW<br>Suite 1000<br>Washington, DC 20004-1304</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">HIAS, INC.<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nG. Eric Brunstad, Jr., Esquire<br>[COR LD NTC Retained]<br>Dechert LLP<br>90 State House Square<br>Hartford, CT 06103</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">INTERNATIONAL RESCUE COMMITTEE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nG. Eric Brunstad, Jr., Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">U.S. COMMITTEE FOR REFUGEES AND IMMIGRANTS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nG. Eric Brunstad, Jr., Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">SERVICE EMPLOYEES INTERNATIONAL UNION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nSteve Berman, Attorney<br>[COR LD NTC Retained]<br>Hagens Berman<br>1918 Eighth Avenue<br>Seattle, WA 98101</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AMERICAN FEDERATION OF STATE, COUNTY AND MUNICIPAL EMPLOYEES<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nSteve Berman, Attorney<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AMERICAN FEDERATION OF TEACHERS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nSteve Berman, Attorney<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CATO INSTITUTE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPeter Jaffe<br>Direct: 202-777-4551<br>[COR LD NTC Retained]<br>Freshfields Bruckhaus Deringer US LLP<br>700 13th Street NW<br>10th Floor<br>Washington, DC 20005</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AMERICAN CIVIL RIGHTS UNION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nKenneth Alan Klukowski, Attorney<br>Direct: 623-261-9249<br>[COR LD NTC Retained]<br>Kenneth A. Klukowski, Esq.<br>Firm: 623-261-9249<br>12915 Wood Crescent Circle<br>Herndon, VA 20171</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">MEMBERS OF CONGRESS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPeter Karanjia<br>Direct: 202-973-4256<br>[COR LD NTC Retained]<br>Davis Wright Tremaine LLP<br>Suite # 800<br>Firm: 202-973-4200<br>1919 Pennsylvania Avenue NW<br>Washington, DC 20006-3401<br><br>\nElizabeth B. Wydra, Chief Counsel<br>[COR LD NTC Retained]<br>Constitutional Accountability Center<br>1200 18th Street NW<br>Washington, DC 20036</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">FORMER FEDERAL IMMIGRATION AND HOMELAND SECURITY OFFICIALS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nMichael Gottlieb, Attorney<br>Direct: 202-237-9617<br>[COR LD NTC Retained]<br>Boies, Schiller &amp; Flexner LLP<br>Suite 1100<br>1401 New York Avenue, NW<br>Washington, DC 20005<br><br>\nJames Wells Harrell, Attorney<br>Direct: 202-274-1164<br>[COR LD NTC Retained]<br>Boies, Schiller &amp; Flexner LLP<br>1401 New York Avenue, NW<br>Washington, DC 20005</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">TECHNOLOGY COMPANIES<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPaul Whitfield Hughes<br>Direct: 202-263-3147<br>[COR LD NTC Retained]<br>Mayer Brown LLP<br>1999 K Street, NW<br>Washington, DC 20006<br><br>\nAndrew John Pincus<br>Direct: 202-263-3220<br>[COR LD NTC Retained]<br>Mayer Brown LLP<br>1999 K Street, NW<br>Washington, DC 20006</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NATIONAL IMMIGRANT JUSTICE CENTER<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRobert N. Hochman, Attorney<br>Direct: 312-853-7000<br>[COR LD NTC Retained]<br>Sidley Austin LLP<br>1 South Dearborn Street<br>Chicago, IL 60603<br><br>\nNathaniel C. Love, Attorney<br>Direct: 312-853-7000<br>[COR NTC Retained]<br>Sidley Austin LLP<br>1 South Dearborn Street<br>Chicago, IL 60603</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ASISTA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRobert N. Hochman, Attorney<br>Direct: 312-853-7000<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nNathaniel C. Love, Attorney<br>Direct: 312-853-7000<br>[COR NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AMERICANS FOR IMMIGRANT JUSTICE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRobert N. Hochman, Attorney<br>Direct: 312-853-7000<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nNathaniel C. Love, Attorney<br>Direct: 312-853-7000<br>[COR NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">FUTURES WITHOUT VIOLENCE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRobert N. Hochman, Attorney<br>Direct: 312-853-7000<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nNathaniel C. Love, Attorney<br>Direct: 312-853-7000<br>[COR NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">FREEDOM NETWORK USA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRobert N. Hochman, Attorney<br>Direct: 312-853-7000<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nNathaniel C. Love, Attorney<br>Direct: 312-853-7000<br>[COR NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NORTH CAROLINA COALITION AGAINST DOMESTIC VIOLENCE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nRobert N. Hochman, Attorney<br>Direct: 312-853-7000<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nNathaniel C. Love, Attorney<br>Direct: 312-853-7000<br>[COR NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">VICTOR K. WILLIAMS, Professor<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nVictor K. Williams<br>Direct: 301-951-9045<br>[NTC Pro Se]<br>America First Lawyers Association<br>5209 Baltimore Avenue<br>Bethesda, MD 20816</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">TAHIRIH JUSTICE CENTER<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott L. Winkelman<br>Direct: 202-624-2972<br>[COR LD NTC Retained]<br>Crowell &amp; Moring LLP<br>1001 Pennsylvania Avenue, N.W.<br>Washington, DC 20004</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ASIAN PACIFIC INSTITUTE ON GENDER-BASED VIOLENCE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott L. Winkelman<br>Direct: 202-624-2972<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CASA DE ESPERANZA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott L. Winkelman<br>Direct: 202-624-2972<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NATIONAL DOMESTIC VIOLENCE HOTLINE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nScott L. Winkelman<br>Direct: 202-624-2972<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ASSOCIATION OF ART MUSEUM DIRECTORS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAbraham Shein Gesser<br>Direct: 646-621-6518<br>[COR LD NTC Retained]<br>Davis Polk &amp; Wardwell, LLP<br>450 Lexington Avenue<br>New York, NY 10017</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AMERICAN ALLIANCE OF MUSEUMS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAbraham Shein Gesser<br>Direct: 646-621-6518<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ASSOCIATION OF ACADEMIC MUSEUMS AND GALLERIES<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAbraham Shein Gesser<br>Direct: 646-621-6518<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">COLLEGE ART ASSOCIATION, and 101 ART MUSEUMS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAbraham Shein Gesser<br>Direct: 646-621-6518<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">UNITED STATES JUSTICE FOUNDATION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>William J. Olson, P.C.<br>370 Maple Ave. W<br>Suite 4<br>Vienna, VA 22180-5615</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CITIZENS UNITED<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CITIZENS UNITED FOUNDATION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ENGLISH FIRST FOUNDATION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ENGLISH FIRST<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">PUBLIC ADVOCATE OF THE UNITED STATES<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">GUN OWNERS FOUNDATION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">GUN OWNERS OF AMERICA, INC.<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CONSERVATIVE LEGAL DEFENSE AND EDUCATION FUND<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">U.S. BORDER CONTROL FOUNDATION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">POLICY ANALYSIS CENTER<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nHerbert W. Titus, Esquire<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">MUSLIM JUSTICE LEAGUE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nBenjamin G. Shatz, Attorney<br>[COR LD NTC Retained]<br>Manatt, Phelps &amp; Phillips, LLP<br>11355 West Olympic Boulevard<br>Los Angeles, CA 90064</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ISLAMIC CIRCLE OF NORTH AMERICA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nBenjamin G. Shatz, Attorney<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">COUNCIL ON AMERICAN-ISLAMIC RELATIONS, CALIFORNIA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nBenjamin G. Shatz, Attorney<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NATIONAL ASIAN PACIFIC AMERICAN BAR ASSOCIATION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nJames Wayne Kim<br>Direct: 202-756-8386<br>[COR LD NTC Retained]<br>McDermott Will &amp; Emery<br>500 N. Capitol Street NW<br>Washington, DC 20001</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">MUSLIM CIVIL RIGHTS ACTIVISTS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nLena F. Masri<br>Direct: 202-488-8787<br>[COR LD NTC Retained]<br>Council on American-Islamic Relations<br>453 New Jersey Avenue, S.E.<br>Washington, DC 20003</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NATIONAL IMMIGRATION LAW CENTER<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nEsther Sung<br>Direct: 213-639-3900<br>[COR LD NTC Retained]<br>National Immigration Law Center<br>3450 Wilshire Boulevard<br>Suite 108-62<br>Los Angeles, CA 90010</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">INTERNATIONAL REFUGEE ASSISTANCE PROJECT<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nEsther Sung<br>Direct: 213-639-3900<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ANTI-DEFAMATION LEAGUE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nNicole Y. Altman<br>Direct: 808-547-5730<br>[COR LD NTC Retained]<br>Goodsill Anderson Quinn &amp; Stifel LLP<br>Firm: 808-547-5600<br>999 Bishop Street<br>First Hawaiian Center, Suite 1600<br>Honolulu, HI 96813</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">UNION FOR REFORM JUDAISM<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nNicole Y. Altman<br>Direct: 808-547-5730<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CENTRAL CONFERENCE OF AMERICAN RABBIS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nNicole Y. Altman<br>Direct: 808-547-5730<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">WOMEN OF REFORM JUDAISM<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nNicole Y. Altman<br>Direct: 808-547-5730<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">JEWISH COUNCIL FOR PUBLIC AFFAIRS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nNicole Y. Altman<br>Direct: 808-547-5730<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">HUMAN RIGHTS FIRST<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAlan C. Turner, Attorney<br>Direct: 212-455-2472<br>[COR LD NTC Retained]<br>Simpson Thacher &amp; Bartlett LLP<br>425 Lexington Avenue<br>New York, NY 10017-3954</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">KIDS IN NEED OF DEFENSE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAlan C. Turner, Attorney<br>Direct: 212-455-2472<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CITY BAR JUSTICE CENTER<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAlan C. Turner, Attorney<br>Direct: 212-455-2472<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">COMMUNITY LEGAL SERVICES IN EAST PALO ALTO<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAlan C. Turner, Attorney<br>Direct: 212-455-2472<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">CATHOLIC MIGRATION SERVICES<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAlan C. Turner, Attorney<br>Direct: 212-455-2472<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">DOOR'S LEGAL SERVICES CENTER<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAlan C. Turner, Attorney<br>Direct: 212-455-2472<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">SAFE PASSAGE PROJECT<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAlan C. Turner, Attorney<br>Direct: 212-455-2472<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">SANCTUARY FOR FAMILIES<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nAlan C. Turner, Attorney<br>Direct: 212-455-2472<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">IMMIGRATION EQUALITY<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nMatthew E. Sloan, Esquire, Counsel<br>Direct: 213-687-5276<br>[COR LD NTC Retained]<br>Skadden, Arps, Slate, Meagher &amp; Flom LLP<br>Suite 3600<br>300 South Grand Avenue<br>Los Angeles, CA 90071<br><br>\nAlyssa Clover<br>Direct: 213-687-5537<br>[COR NTC Retained]<br>Skadden, Arps, Slate, Meagher &amp; Flom LLP<br>Suite 3400<br>300 South Grand Avenue<br>Los Angeles, CA 90071<br><br>\nEric J. Gorman<br>Direct: 312-407-0700<br>[COR NTC Retained]<br>Skadden, Arps, Slate, Meagher &amp; Flom LLP<br>Suite 2700<br>155 North Wacker Drive<br>Chicago, IL 60606<br><br>\nAllison Barrett Holcombe, Esquire, Attorney<br>Direct: 213-687-5574<br>[COR NTC Retained]<br>Skadden, Arps, Slate, Meagher &amp; Flom LLP<br>Suite 3400<br>300 South Grand Avenue<br>Los Angeles, CA 90071<br><br>\nNoelle M. Reed<br>Direct: 713-655-5122<br>[COR NTC Retained]<br>Skadden, Arps, Slate, Meagher &amp; Flom LLP<br>Suite 6800<br>1000 Louisiana Street<br>Houston, TX 77002<br><br>\nRichard Adam Schwartz, Trial Attorney<br>Direct: 213-687-5000<br>[COR NTC Retained]<br>Skadden, Arps, Slate, Meagher &amp; Flom LLP<br>Suite # 3400<br>300 South Grand Avenue<br>Los Angeles, CA 90071</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NEW YORK CITY GAY AND LESBIAN ANTI-VIOLENCE PROJECT<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nMatthew E. Sloan, Esquire, Counsel<br>Direct: 213-687-5276<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nAlyssa Clover<br>Direct: 213-687-5537<br>[COR NTC Retained]<br>(see above)\n<br><br>\nEric J. Gorman<br>Direct: 312-407-0700<br>[COR NTC Retained]<br>(see above)\n<br><br>\nAllison Barrett Holcombe, Esquire, Attorney<br>Direct: 213-687-5574<br>[COR NTC Retained]<br>(see above)\n<br><br>\nNoelle M. Reed<br>Direct: 713-655-5122<br>[COR NTC Retained]<br>(see above)\n<br><br>\nRichard Adam Schwartz, Trial Attorney<br>Direct: 213-687-5000<br>[COR NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">NATIONAL QUEER ASIAN PACIFIC ISLANDER ALLIANCE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nMatthew E. Sloan, Esquire, Counsel<br>Direct: 213-687-5276<br>[COR LD NTC Retained]<br>(see above)\n<br><br>\nAlyssa Clover<br>Direct: 213-687-5537<br>[COR NTC Retained]<br>(see above)\n<br><br>\nEric J. Gorman<br>Direct: 312-407-0700<br>[COR NTC Retained]<br>(see above)\n<br><br>\nAllison Barrett Holcombe, Esquire, Attorney<br>Direct: 213-687-5574<br>[COR NTC Retained]<br>(see above)\n<br><br>\nNoelle M. Reed<br>Direct: 713-655-5122<br>[COR NTC Retained]<br>(see above)\n<br><br>\nRichard Adam Schwartz, Trial Attorney<br>Direct: 213-687-5000<br>[COR NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">MASSACHUSETTS TECHNOLOGY LEADERSHIP COUNCIL, INC.<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nBrett R. Tobin, Esquire, Attorney<br>Direct: 808-547-5600<br>[COR LD NTC Retained]<br>Goodsill Anderson Quinn &amp; Stifel LLP<br>Firm: 808-547-5600<br>999 Bishop Street<br>First Hawaiian Center, Suite 1600<br>Honolulu, HI 96813</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">JOSEPH DOE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nLynn Lincoln Sarko, Attorney<br>[COR LD NTC Retained]<br>Keller Rohrback LLP<br>1201 Third Avenue<br>Suite 3200<br>Seattle, WA 98101</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">JAMES DOE<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nLynn Lincoln Sarko, Attorney<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">EPISCOPAL DIOCESE OF OLYMPIA<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nLynn Lincoln Sarko, Attorney<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">ONE MILLION KIDS FOR EQUALITY<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPatricia S. Rose, Attorney<br>Direct: 206-622-8964<br>[COR LD NTC Retained]<br>Law Office of Patricia S. Rose<br>P.O. Box 31892<br>Seattle, WA 98103</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">AFRICAN HUMAN RIGHTS COALITION<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nPatricia S. Rose, Attorney<br>Direct: 206-622-8964<br>[COR LD NTC Retained]<br>(see above)\n</td>\n</tr>\n<tr><td colspan=\"2\"></td></tr>\n\t<tr>\n<td width=\"50%\" valign=\"top\">LAW PROFESSORS<br>\n\n\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0\u00a0Amicus\u00a0Curiae,\n\n</td>\n\t\t<td width=\"50%\" valign=\"top\">\nClaire Loebs Davis, Esquire, Attorney<br>Direct: 206-223-7060<br>[COR LD NTC Retained]<br>Lane Powell PC<br>Suite 4200<br>1420 Fifth Avenue<br>P.O. Box 91302<br>Seattle, WA 98111-9402</td>\n</tr>\n</tbody>\n</table>\n</td></tr>\n</tbody>\n</table>\n"
+  "parties": [
+    {
+      "attorneys": [
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Donna H. Kalama", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\nFirm: 202-637-5600\n555 Thirteenth Street, NW\nWashington, DC 20004", 
+          "name": "Neal Kumar Katyal", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\nFirm: 202-637-5600\n555 Thirteenth Street, NW\nWashington, DC 20004", 
+          "name": "Colleen Sinzdak", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\n1735 Market Street\n23rd Floor\nPhiladelphia, PA 19103", 
+          "name": "Alexander Biays Bowerman", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Douglas Chin, Esquire, Attorney General", 
+          "roles": [
+            "COR NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Kimberly Tsumoto Guidry", 
+          "roles": [
+            "COR NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\nFirm: 202-637-5600\n555 Thirteenth Street, NW\nWashington, DC 20004", 
+          "name": "Elizabeth Hagerty", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Deirdre Marie-Iha, Esquire", 
+          "roles": [
+            "COR NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Robert Tadao Nakatsuji, Esquire", 
+          "roles": [
+            "COR NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\nFirm: 202-637-5600\n555 Thirteenth Street, NW\nWashington, DC 20004", 
+          "name": "Mitchell Reich", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\nFirm: 212-918-3000\n875 Third Avenue\nNew York, NY 10022", 
+          "name": "Thomas Schmidt, Associate", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\n1735 Market Street\n23rd Floor\nPhiladelphia, PA 19103", 
+          "name": "Sara Solow", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Clyde James Wadsworth", 
+          "roles": [
+            "COR NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF HAWAII", 
+      "type": "Plaintiff\u00a0-\u00a0Appellee"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Douglas Chin, Esquire, Attorney General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Kimberly Tsumoto Guidry", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Donna H. Kalama", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\nFirm: 202-637-5600\n555 Thirteenth Street, NW\nWashington, DC 20004", 
+          "name": "Neal Kumar Katyal", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Deirdre Marie-Iha, Esquire", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Robert Tadao Nakatsuji, Esquire", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\nFirm: 202-637-5600\n555 Thirteenth Street, NW\nWashington, DC 20004", 
+          "name": "Colleen Sinzdak", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "AGHI - OFFICE OF THE HAWAII ATTORNEY GENERAL\nFirm: 808-568-1180\n425 Queen Street\nHonolulu, HI 96813", 
+          "name": "Clyde James Wadsworth", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\n1735 Market Street\n23rd Floor\nPhiladelphia, PA 19103", 
+          "name": "Alexander Biays Bowerman", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\nFirm: 202-637-5600\n555 Thirteenth Street, NW\nWashington, DC 20004", 
+          "name": "Elizabeth Hagerty", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\nFirm: 202-637-5600\n555 Thirteenth Street, NW\nWashington, DC 20004", 
+          "name": "Mitchell Reich", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\nFirm: 212-918-3000\n875 Third Avenue\nNew York, NY 10022", 
+          "name": "Thomas Schmidt, Associate", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Hogan Lovells US LLP\n1735 Market Street\n23rd Floor\nPhiladelphia, PA 19103", 
+          "name": "Sara Solow", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ISMAIL ELSHIKH", 
+      "type": "Plaintiff\u00a0-\u00a0Appellee"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "", 
+          "name": "", 
+          "roles": []
+        }
+      ], 
+      "date_terminated": "04/21/2017", 
+      "name": "ALI PLAINTIFFS", 
+      "type": "Intervenor\u00a0-\u00a0Pending"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "", 
+          "name": "", 
+          "roles": []
+        }
+      ], 
+      "date_terminated": "04/21/2017", 
+      "name": "JOSEPH DOE", 
+      "type": "Intervenor\u00a0-\u00a0Pending"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "", 
+          "name": "", 
+          "roles": []
+        }
+      ], 
+      "date_terminated": "04/21/2017", 
+      "name": "JAMES DOE", 
+      "type": "Intervenor\u00a0-\u00a0Pending"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "", 
+          "name": "", 
+          "roles": []
+        }
+      ], 
+      "date_terminated": "04/21/2017", 
+      "name": "EPISCOPAL DIOCESE OF OLYMPIA", 
+      "type": "Intervenor\u00a0-\u00a0Pending"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "H. Thomas Byron, III, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Anne Murphy, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. DEPARTMENT OF JUSTICE\nCivil Division\nP.O. Box 883\nWashington, DC 20044", 
+          "name": "Brad Prescott Rosenberg, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Lowell Sturgill, Jr., Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Sharon Swingle", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Jeffrey Bryan Wall, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }
+      ], 
+      "name": "DONALD J. TRUMP, in his official capacity as President of the United States", 
+      "type": "Defendant\u00a0-\u00a0Appellant"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "H. Thomas Byron, III, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Anne Murphy, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. DEPARTMENT OF JUSTICE\nCivil Division\nP.O. Box 883\nWashington, DC 20044", 
+          "name": "Brad Prescott Rosenberg, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Lowell Sturgill, Jr., Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Sharon Swingle", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Jeffrey Bryan Wall, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }
+      ], 
+      "name": "U.S. DEPARTMENT OF HOMELAND SECURITY", 
+      "type": "Defendant\u00a0-\u00a0Appellant"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "H. Thomas Byron, III, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Anne Murphy, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. DEPARTMENT OF JUSTICE\nCivil Division\nP.O. Box 883\nWashington, DC 20044", 
+          "name": "Brad Prescott Rosenberg, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Lowell Sturgill, Jr., Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Sharon Swingle", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Jeffrey Bryan Wall, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }
+      ], 
+      "name": "JOHN F. KELLY, in his official capacity as Secretary of Homeland Security", 
+      "type": "Defendant\u00a0-\u00a0Appellant"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "H. Thomas Byron, III, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Anne Murphy, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. DEPARTMENT OF JUSTICE\nCivil Division\nP.O. Box 883\nWashington, DC 20044", 
+          "name": "Brad Prescott Rosenberg, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Lowell Sturgill, Jr., Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Sharon Swingle", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Jeffrey Bryan Wall, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }
+      ], 
+      "name": "U.S. DEPARTMENT OF STATE", 
+      "type": "Defendant\u00a0-\u00a0Appellant"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "H. Thomas Byron, III, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Anne Murphy, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. DEPARTMENT OF JUSTICE\nCivil Division\nP.O. Box 883\nWashington, DC 20044", 
+          "name": "Brad Prescott Rosenberg, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Lowell Sturgill, Jr., Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Sharon Swingle", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Jeffrey Bryan Wall, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }
+      ], 
+      "name": "REX W. TILLERSON, in his official capacity as Secretary of State", 
+      "type": "Defendant\u00a0-\u00a0Appellant"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "H. Thomas Byron, III, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Anne Murphy, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. DEPARTMENT OF JUSTICE\nCivil Division\nP.O. Box 883\nWashington, DC 20044", 
+          "name": "Brad Prescott Rosenberg, Trial Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Lowell Sturgill, Jr., Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Sharon Swingle", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }, 
+        {
+          "contact": "DOJ - U.S. Department of Justice\n950 Pennsylvania Ave., N.W.\nWashington, DC 20530", 
+          "name": "Jeffrey Bryan Wall, Attorney", 
+          "roles": [
+            "COR LD NTC Assist US Attorney"
+          ]
+        }
+      ], 
+      "name": "UNITED STATES OF AMERICA", 
+      "type": "Defendant\u00a0-\u00a0Appellant"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "PHIL BRYANT, Governor of the State of Mississippi", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF ALABAMA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-869-3434\nRoderick & Solange MacArthur Justice Center\n718 7th Street NW\nWashington, DC 20001", 
+          "name": "Amir Ali", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "RODERICK AND SOLANGE MACARTHUR JUSTICE CENTER", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF ARIZONA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 415-591-7025\nCovington & Burling, LLP\n35th Floor\nOne Front Street\nSan Francisco, CA 94111", 
+          "name": "Robert D. Fram, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "INTERFAITH COALITION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF ARKANSAS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Avenue\nBoston, MA 02210", 
+          "name": "Kevin Paul Martin, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Avenue\nBoston, MA 02210", 
+          "name": "William B. Brady", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-942-2190\nThe Law Office of Joshua M. Daniels\nP.O. Box 300765\nJamaica Plain, MA 02130", 
+          "name": "Joshua M. Daniels, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Avenue\nBoston, MA 02210", 
+          "name": "Nicholas Mitrokostas", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Avenue\nBoston, MA 02210", 
+          "name": "Eileen Morrison", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Avenue\nBoston, MA 02210", 
+          "name": "Alicia Rubio", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "FOUNDATION FOR THE CHILDREN OF IRAN", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF FLORIDA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Avenue\nBoston, MA 02210", 
+          "name": "Kevin Paul Martin, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Avenue\nBoston, MA 02210", 
+          "name": "William B. Brady", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-942-2190\nThe Law Office of Joshua M. Daniels\nP.O. Box 300765\nJamaica Plain, MA 02130", 
+          "name": "Joshua M. Daniels, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Avenue\nBoston, MA 02210", 
+          "name": "Nicholas Mitrokostas", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Avenue\nBoston, MA 02210", 
+          "name": "Eileen Morrison", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 617-570-1000\nGoodwin Procter LLP\n100 Northern Avenue\nBoston, MA 02210", 
+          "name": "Alicia Rubio", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "IRANIAN ALLIANCES ACROSS BORDERS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF KANSAS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 206-623-1745\nHillis Clark Martin & Peterson, P.S.\nSuite 500\n999 Third Avenue\nSeattle, WA 98104", 
+          "name": "Michael Ramsey Scott, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "EPISCOPAL BISHOPS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF LOUISIANA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 415-391-5400\nKeker, Van Nest & Peters LLP\n633 Battery Street\nSan Francisco, CA 94111", 
+          "name": "Daniel E. Jackson, Esquire, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "KHIZR KHAN", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF MONTANA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 310-557-2900\nProskauer Rose LLP\nSuite 3200\n2049 Century Park East\nLos Angeles, CA 90067-3206", 
+          "name": "Lary Alan Rappaport", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NEW YORK UNIVERSITY", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF NORTH DAKOTA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 917-355-6896\n169 Hicks Street\nBrooklyn, NY 11201", 
+          "name": "Jonathan Hafetz, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 206-359-3308\nPerkins Coie LLP\n1201 Third Avenue\nSuite 4900\nSeattle, WA 98101", 
+          "name": "Michelle L. Maley", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 206-359-6354\nPerkins Coie LLP\n1201 Third Avenue\nSuite 4900\nSeattle, WA 98101", 
+          "name": "Joseph M. McMillan, Esquire, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 480-241-8414\nSandra Day O'Connor College of Law\nArizona State University\n111 E. Taylor Street\nMC 9520\nPhoenix, AZ 85021", 
+          "name": "Aaron Fellmeth", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "INTERNATIONAL LAW SCHOLARS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF OKLAHOMA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 917-355-6896\n169 Hicks Street\nBrooklyn, NY 11201", 
+          "name": "Jonathan Hafetz, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 206-359-3308\nPerkins Coie LLP\n1201 Third Avenue\nSuite 4900\nSeattle, WA 98101", 
+          "name": "Michelle L. Maley", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 206-359-6354\nPerkins Coie LLP\n1201 Third Avenue\nSuite 4900\nSeattle, WA 98101", 
+          "name": "Joseph M. McMillan, Esquire, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NONGOVERNMENTAL ORGANIZATIONS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF SOUTH CAROLINA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-661-4956\nJenner & Block LLP\nFirm: 202-639-6000\n1099 New York Avenue, NW\nSuite 900\nWashington, DC 20001-4412", 
+          "name": "Lindsay Harrison, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "COLLEGES AND UNIVERSITIES", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF SOUTH DAKOTA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 628-400-1254\nPersyn Law & Policy\n912 Cole Street\nSuite 124\nSan Francisco, CA 94117", 
+          "name": "Mary Kelly Persyn, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AMERICAN PROFESSIONAL SOCIETY ON THE ABUSE OF CHILDREN", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF TENNESSEE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 203-498-4584\nWIGGIN & DANA\nPO Box 1832\nNew Haven, CT 06508-1832", 
+          "name": "Jonathan Freiman", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "FORMER NATIONAL SECURITY OFFICIALS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF TEXAS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 415-649-6700\nCalifornia Appellate Law Group\n96 Jessie Street\nSan Francisco, CA 94105", 
+          "name": "Anna-Rose Mathieson", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "SCHOLARS OF AMERICAN RELIGIOUS HISTORY AND LAW", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 512-936-1700\nOffice of Attorney General\n7th Floor (MC-059)\nP.O. Box 12548\nAustin, TX 78711-2548", 
+          "name": "Scott A. Keller, Attorney", 
+          "roles": [
+            "COR LD NTC State Atty General"
+          ]
+        }
+      ], 
+      "name": "STATE OF WEST VIRGINIA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-303-1108\nWillkie Farr & Gallagher LLP\n1875 \"K\" St. NW\nWashington, DC 20006", 
+          "name": "Richard Bernstein, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "T. A., a U.S. Citizen of Yemeni Descent", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 845-893-9402\nGupta Wessler PLLC\n1900 L Street, NW\nSuite 312\nWashington, DC 20036", 
+          "name": "Joshua Adam Matz, Associate", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CONSTITUTIONAL LAW SCHOLARS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Morrison & Foerster LLP\nFirm: 202-887-1500\n2000 Pennsylvania Avenue, NW\nWashington, DC 20006", 
+          "name": "Marc A. Hearron", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "INTERFAITH GROUP OF RELIGIOUS AND INTERRELIGIOUS ORGANIZATIONS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 415-471-3100\nArnold & Porter Kaye Scholer LLP\nThree Embarcadero Center\n10th Floor\nSan Francisco, CA 94111-4024", 
+          "name": "Anton A. Ware", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "MUSLIM ADVOCATES", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 415-471-3100\nArnold & Porter Kaye Scholer LLP\nThree Embarcadero Center\n10th Floor\nSan Francisco, CA 94111-4024", 
+          "name": "Anton A. Ware", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AMERICAN MUSLIM HEALTH PROFESSIONALS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 415-471-3100\nArnold & Porter Kaye Scholer LLP\nThree Embarcadero Center\n10th Floor\nSan Francisco, CA 94111-4024", 
+          "name": "Anton A. Ware", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "MUPPIES, INC.", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 415-471-3100\nArnold & Porter Kaye Scholer LLP\nThree Embarcadero Center\n10th Floor\nSan Francisco, CA 94111-4024", 
+          "name": "Anton A. Ware", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NATIONAL ARAB AMERICAN MEDICAL ASSOCIATION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 415-471-3100\nArnold & Porter Kaye Scholer LLP\nThree Embarcadero Center\n10th Floor\nSan Francisco, CA 94111-4024", 
+          "name": "Anton A. Ware", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NETWORK OF ARAB-AMERICAN PROFESSIONALS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF ILLINOIS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF CALIFORNIA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF CONNECTICUT", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF DELAWARE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF IOWA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF MAINE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF MARYLAND", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF MASSACHUSETTS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF NEW MEXICO", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF NEW YORK", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF NORTH CAROLINA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF OREGON", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF RHODE ISLAND", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF VERMONT", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF VIRGINIA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "STATE OF WASHINGTON", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-814-5376\nOFFICE OF THE ATTORNEY GENERAL\n12th Floor\n100 West Randolph Street\nChicago, IL 60601", 
+          "name": "David Franklin, Solicitor General", 
+          "roles": [
+            "COR LD NTC Dep State Aty Gen"
+          ]
+        }
+      ], 
+      "name": "DISTRICT OF COLUMBIA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 703-423-9423\nConsovoy McCarthy Park PLLC\n3033 Wilson Boulevard\nSuite 700\nArlington, VA 22201", 
+          "name": "William Consovoy", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "SOUTHEASTERN LEGAL FOUNDATION, INC.", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 734-680-8007\nAmerican Center for Law & Justice\n3001 Plymouth Road\nSuite 203\nAnn Arbor, MI 48105", 
+          "name": "Edward Lawrence White", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AMERICAN CENTER FOR LAW AND JUSTICE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-887-4210\nAkin Gump Strauss Hauer & Feld LLP\n1333 New Hampshire Avenue, N.W.\nWashington, DC 20036", 
+          "name": "Pratik A. Shah, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "FRED T. KOREMATSU CENTER FOR LAW AND EQUALITY", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-887-4210\nAkin Gump Strauss Hauer & Feld LLP\n1333 New Hampshire Avenue, N.W.\nWashington, DC 20036", 
+          "name": "Pratik A. Shah, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "JAY HIRABAYASHI", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-887-4210\nAkin Gump Strauss Hauer & Feld LLP\n1333 New Hampshire Avenue, N.W.\nWashington, DC 20036", 
+          "name": "Pratik A. Shah, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "HOLLY YASUI", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-887-4210\nAkin Gump Strauss Hauer & Feld LLP\n1333 New Hampshire Avenue, N.W.\nWashington, DC 20036", 
+          "name": "Pratik A. Shah, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "KAREN KOREMATSU", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-887-4210\nAkin Gump Strauss Hauer & Feld LLP\n1333 New Hampshire Avenue, N.W.\nWashington, DC 20036", 
+          "name": "Pratik A. Shah, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CIVIL RIGHTS ORGANIZATIONS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-887-4210\nAkin Gump Strauss Hauer & Feld LLP\n1333 New Hampshire Avenue, N.W.\nWashington, DC 20036", 
+          "name": "Pratik A. Shah, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NATIONAL BAR ASSOCIATIONS OF COLOR", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-466-3234\nAmericans United for Separation of Church and State\n1310 L Street NW\nSuite 200\nWashington, DC 20005", 
+          "name": "Richard Brian Katskee, Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "MEMBERS OF THE CLERGY", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-466-3234\nAmericans United for Separation of Church and State\n1310 L Street NW\nSuite 200\nWashington, DC 20005", 
+          "name": "Richard Brian Katskee, Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AMERICANS UNITED FOR SEPARATION OF CHURCH AND STATE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-466-3234\nAmericans United for Separation of Church and State\n1310 L Street NW\nSuite 200\nWashington, DC 20005", 
+          "name": "Richard Brian Katskee, Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "BEND THE ARC: A JEWISH PARTNERSHIP FOR JUSTICE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-466-3234\nAmericans United for Separation of Church and State\n1310 L Street NW\nSuite 200\nWashington, DC 20005", 
+          "name": "Richard Brian Katskee, Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "RIVERSIDE CHURCH IN THE CITY OF NEW YORK", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-466-3234\nAmericans United for Separation of Church and State\n1310 L Street NW\nSuite 200\nWashington, DC 20005", 
+          "name": "Richard Brian Katskee, Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "SOUTHERN POVERTY LAW CENTER", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-744-7764\nCity of Chicago Law Department\nAppeals Division\n30 North LaSalle Street\nSuite 800\nChicago, IL 60602", 
+          "name": "Benna Ruth Solomon, Deputy Corporation Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CITY OF CHICAGO", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-744-7764\nCity of Chicago Law Department\nAppeals Division\n30 North LaSalle Street\nSuite 800\nChicago, IL 60602", 
+          "name": "Benna Ruth Solomon, Deputy Corporation Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CITY OF LOS ANGELES", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-744-7764\nCity of Chicago Law Department\nAppeals Division\n30 North LaSalle Street\nSuite 800\nChicago, IL 60602", 
+          "name": "Benna Ruth Solomon, Deputy Corporation Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CITY OF NEW YORK", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-744-7764\nCity of Chicago Law Department\nAppeals Division\n30 North LaSalle Street\nSuite 800\nChicago, IL 60602", 
+          "name": "Benna Ruth Solomon, Deputy Corporation Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CITY OF PHILADELPHIA, and OTHER MAJOR CITIES AND COUNTIES", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-833-8400\nCENTER FOR INDIVIDUAL RIGHTS\nSuite 300\n1233 20th St. NW\nWashington, DC 20036", 
+          "name": "Christopher Hajec", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "IMMIGRATION REFORM LAW INSTITUTE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 404-221-6530\nBaker, Donelson, Bearman, Caldwell & Berkowitz, PC\nSuite 1600\n3414 Peachtree Rd. NE\nAtlanta, GA 30326", 
+          "name": "Linda A. Klein", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AMERICAN BAR ASSOCIATION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 480-388-8007\nAlliance Defending Freedom\nFirm: 480-444-0020\n15100 N. 90th Street\nScottsdale, AZ 85260", 
+          "name": "Jonathan Andrew Scruggs, Esquire, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ALLIANCE DEFENDING FREEDOM", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-637-2200\nLatham & Watkins LLP\n555 Eleventh Street, NW\nSuite 1000\nWashington, DC 20004-1304", 
+          "name": "Richard P. Bress, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 650-328-4600\nLatham & Watkins LLP\n140 Scott Drive\nMenlo Park, CA 94025", 
+          "name": "Christopher J. Mortweet", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 202-637-2200\nLatham & Watkins LLP\n555 Eleventh Street, NW\nSuite 1000\nWashington, DC 20004-1304", 
+          "name": "Elana Nightingale Dawson", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 202-637-2200\nLatham & Watkins LLP\n555 Eleventh Street, NW\nSuite 1000\nWashington, DC 20004-1304", 
+          "name": "Alexandra Shechtel", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "OXFAM AMERICA, INC.", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Dechert LLP\n90 State House Square\nHartford, CT 06103", 
+          "name": "G. Eric Brunstad, Jr., Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "HIAS, INC.", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Dechert LLP\n90 State House Square\nHartford, CT 06103", 
+          "name": "G. Eric Brunstad, Jr., Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "INTERNATIONAL RESCUE COMMITTEE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Dechert LLP\n90 State House Square\nHartford, CT 06103", 
+          "name": "G. Eric Brunstad, Jr., Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "U.S. COMMITTEE FOR REFUGEES AND IMMIGRANTS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Hagens Berman\n1918 Eighth Avenue\nSeattle, WA 98101", 
+          "name": "Steve Berman, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "SERVICE EMPLOYEES INTERNATIONAL UNION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Hagens Berman\n1918 Eighth Avenue\nSeattle, WA 98101", 
+          "name": "Steve Berman, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AMERICAN FEDERATION OF STATE, COUNTY AND MUNICIPAL EMPLOYEES", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Hagens Berman\n1918 Eighth Avenue\nSeattle, WA 98101", 
+          "name": "Steve Berman, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AMERICAN FEDERATION OF TEACHERS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-777-4551\nFreshfields Bruckhaus Deringer US LLP\n700 13th Street NW\n10th Floor\nWashington, DC 20005", 
+          "name": "Peter Jaffe", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CATO INSTITUTE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 623-261-9249\nKenneth A. Klukowski, Esq.\nFirm: 623-261-9249\n12915 Wood Crescent Circle\nHerndon, VA 20171", 
+          "name": "Kenneth Alan Klukowski, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AMERICAN CIVIL RIGHTS UNION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-973-4256\nDavis Wright Tremaine LLP\nSuite # 800\nFirm: 202-973-4200\n1919 Pennsylvania Avenue NW\nWashington, DC 20006-3401", 
+          "name": "Peter Karanjia", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Constitutional Accountability Center\n1200 18th Street NW\nWashington, DC 20036", 
+          "name": "Elizabeth B. Wydra, Chief Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "MEMBERS OF CONGRESS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-237-9617\nBoies, Schiller & Flexner LLP\nSuite 1100\n1401 New York Avenue, NW\nWashington, DC 20005", 
+          "name": "Michael Gottlieb, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 202-274-1164\nBoies, Schiller & Flexner LLP\n1401 New York Avenue, NW\nWashington, DC 20005", 
+          "name": "James Wells Harrell, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "FORMER FEDERAL IMMIGRATION AND HOMELAND SECURITY OFFICIALS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-263-3147\nMayer Brown LLP\n1999 K Street, NW\nWashington, DC 20006", 
+          "name": "Paul Whitfield Hughes", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 202-263-3220\nMayer Brown LLP\n1999 K Street, NW\nWashington, DC 20006", 
+          "name": "Andrew John Pincus", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "TECHNOLOGY COMPANIES", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Robert N. Hochman, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Nathaniel C. Love, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NATIONAL IMMIGRANT JUSTICE CENTER", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Robert N. Hochman, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Nathaniel C. Love, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ASISTA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Robert N. Hochman, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Nathaniel C. Love, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AMERICANS FOR IMMIGRANT JUSTICE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Robert N. Hochman, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Nathaniel C. Love, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "FUTURES WITHOUT VIOLENCE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Robert N. Hochman, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Nathaniel C. Love, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "FREEDOM NETWORK USA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Robert N. Hochman, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 312-853-7000\nSidley Austin LLP\n1 South Dearborn Street\nChicago, IL 60603", 
+          "name": "Nathaniel C. Love, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NORTH CAROLINA COALITION AGAINST DOMESTIC VIOLENCE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 301-951-9045\nAmerica First Lawyers Association\n5209 Baltimore Avenue\nBethesda, MD 20816", 
+          "name": "Victor K. Williams", 
+          "roles": [
+            "NTC Pro Se"
+          ]
+        }
+      ], 
+      "name": "VICTOR K. WILLIAMS, Professor", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-624-2972\nCrowell & Moring LLP\n1001 Pennsylvania Avenue, N.W.\nWashington, DC 20004", 
+          "name": "Scott L. Winkelman", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "TAHIRIH JUSTICE CENTER", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-624-2972\nCrowell & Moring LLP\n1001 Pennsylvania Avenue, N.W.\nWashington, DC 20004", 
+          "name": "Scott L. Winkelman", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ASIAN PACIFIC INSTITUTE ON GENDER-BASED VIOLENCE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-624-2972\nCrowell & Moring LLP\n1001 Pennsylvania Avenue, N.W.\nWashington, DC 20004", 
+          "name": "Scott L. Winkelman", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CASA DE ESPERANZA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-624-2972\nCrowell & Moring LLP\n1001 Pennsylvania Avenue, N.W.\nWashington, DC 20004", 
+          "name": "Scott L. Winkelman", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NATIONAL DOMESTIC VIOLENCE HOTLINE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 646-621-6518\nDavis Polk & Wardwell, LLP\n450 Lexington Avenue\nNew York, NY 10017", 
+          "name": "Abraham Shein Gesser", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ASSOCIATION OF ART MUSEUM DIRECTORS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 646-621-6518\nDavis Polk & Wardwell, LLP\n450 Lexington Avenue\nNew York, NY 10017", 
+          "name": "Abraham Shein Gesser", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AMERICAN ALLIANCE OF MUSEUMS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 646-621-6518\nDavis Polk & Wardwell, LLP\n450 Lexington Avenue\nNew York, NY 10017", 
+          "name": "Abraham Shein Gesser", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ASSOCIATION OF ACADEMIC MUSEUMS AND GALLERIES", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 646-621-6518\nDavis Polk & Wardwell, LLP\n450 Lexington Avenue\nNew York, NY 10017", 
+          "name": "Abraham Shein Gesser", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "COLLEGE ART ASSOCIATION, and 101 ART MUSEUMS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "UNITED STATES JUSTICE FOUNDATION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CITIZENS UNITED", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CITIZENS UNITED FOUNDATION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ENGLISH FIRST FOUNDATION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ENGLISH FIRST", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "PUBLIC ADVOCATE OF THE UNITED STATES", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "GUN OWNERS FOUNDATION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "GUN OWNERS OF AMERICA, INC.", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CONSERVATIVE LEGAL DEFENSE AND EDUCATION FUND", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "U.S. BORDER CONTROL FOUNDATION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "William J. Olson, P.C.\n370 Maple Ave. W\nSuite 4\nVienna, VA 22180-5615", 
+          "name": "Herbert W. Titus, Esquire", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "POLICY ANALYSIS CENTER", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Manatt, Phelps & Phillips, LLP\n11355 West Olympic Boulevard\nLos Angeles, CA 90064", 
+          "name": "Benjamin G. Shatz, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "MUSLIM JUSTICE LEAGUE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Manatt, Phelps & Phillips, LLP\n11355 West Olympic Boulevard\nLos Angeles, CA 90064", 
+          "name": "Benjamin G. Shatz, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ISLAMIC CIRCLE OF NORTH AMERICA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Manatt, Phelps & Phillips, LLP\n11355 West Olympic Boulevard\nLos Angeles, CA 90064", 
+          "name": "Benjamin G. Shatz, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "COUNCIL ON AMERICAN-ISLAMIC RELATIONS, CALIFORNIA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-756-8386\nMcDermott Will & Emery\n500 N. Capitol Street NW\nWashington, DC 20001", 
+          "name": "James Wayne Kim", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NATIONAL ASIAN PACIFIC AMERICAN BAR ASSOCIATION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 202-488-8787\nCouncil on American-Islamic Relations\n453 New Jersey Avenue, S.E.\nWashington, DC 20003", 
+          "name": "Lena F. Masri", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "MUSLIM CIVIL RIGHTS ACTIVISTS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 213-639-3900\nNational Immigration Law Center\n3450 Wilshire Boulevard\nSuite 108-62\nLos Angeles, CA 90010", 
+          "name": "Esther Sung", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NATIONAL IMMIGRATION LAW CENTER", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 213-639-3900\nNational Immigration Law Center\n3450 Wilshire Boulevard\nSuite 108-62\nLos Angeles, CA 90010", 
+          "name": "Esther Sung", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "INTERNATIONAL REFUGEE ASSISTANCE PROJECT", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 808-547-5730\nGoodsill Anderson Quinn & Stifel LLP\nFirm: 808-547-5600\n999 Bishop Street\nFirst Hawaiian Center, Suite 1600\nHonolulu, HI 96813", 
+          "name": "Nicole Y. Altman", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ANTI-DEFAMATION LEAGUE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 808-547-5730\nGoodsill Anderson Quinn & Stifel LLP\nFirm: 808-547-5600\n999 Bishop Street\nFirst Hawaiian Center, Suite 1600\nHonolulu, HI 96813", 
+          "name": "Nicole Y. Altman", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "UNION FOR REFORM JUDAISM", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 808-547-5730\nGoodsill Anderson Quinn & Stifel LLP\nFirm: 808-547-5600\n999 Bishop Street\nFirst Hawaiian Center, Suite 1600\nHonolulu, HI 96813", 
+          "name": "Nicole Y. Altman", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CENTRAL CONFERENCE OF AMERICAN RABBIS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 808-547-5730\nGoodsill Anderson Quinn & Stifel LLP\nFirm: 808-547-5600\n999 Bishop Street\nFirst Hawaiian Center, Suite 1600\nHonolulu, HI 96813", 
+          "name": "Nicole Y. Altman", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "WOMEN OF REFORM JUDAISM", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 808-547-5730\nGoodsill Anderson Quinn & Stifel LLP\nFirm: 808-547-5600\n999 Bishop Street\nFirst Hawaiian Center, Suite 1600\nHonolulu, HI 96813", 
+          "name": "Nicole Y. Altman", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "JEWISH COUNCIL FOR PUBLIC AFFAIRS", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 212-455-2472\nSimpson Thacher & Bartlett LLP\n425 Lexington Avenue\nNew York, NY 10017-3954", 
+          "name": "Alan C. Turner, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "HUMAN RIGHTS FIRST", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 212-455-2472\nSimpson Thacher & Bartlett LLP\n425 Lexington Avenue\nNew York, NY 10017-3954", 
+          "name": "Alan C. Turner, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "KIDS IN NEED OF DEFENSE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 212-455-2472\nSimpson Thacher & Bartlett LLP\n425 Lexington Avenue\nNew York, NY 10017-3954", 
+          "name": "Alan C. Turner, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CITY BAR JUSTICE CENTER", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 212-455-2472\nSimpson Thacher & Bartlett LLP\n425 Lexington Avenue\nNew York, NY 10017-3954", 
+          "name": "Alan C. Turner, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "COMMUNITY LEGAL SERVICES IN EAST PALO ALTO", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 212-455-2472\nSimpson Thacher & Bartlett LLP\n425 Lexington Avenue\nNew York, NY 10017-3954", 
+          "name": "Alan C. Turner, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "CATHOLIC MIGRATION SERVICES", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 212-455-2472\nSimpson Thacher & Bartlett LLP\n425 Lexington Avenue\nNew York, NY 10017-3954", 
+          "name": "Alan C. Turner, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "DOOR'S LEGAL SERVICES CENTER", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 212-455-2472\nSimpson Thacher & Bartlett LLP\n425 Lexington Avenue\nNew York, NY 10017-3954", 
+          "name": "Alan C. Turner, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "SAFE PASSAGE PROJECT", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 212-455-2472\nSimpson Thacher & Bartlett LLP\n425 Lexington Avenue\nNew York, NY 10017-3954", 
+          "name": "Alan C. Turner, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "SANCTUARY FOR FAMILIES", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 213-687-5276\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 3600\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Matthew E. Sloan, Esquire, Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 213-687-5537\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 3400\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Alyssa Clover", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 312-407-0700\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 2700\n155 North Wacker Drive\nChicago, IL 60606", 
+          "name": "Eric J. Gorman", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 213-687-5574\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 3400\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Allison Barrett Holcombe, Esquire, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 713-655-5122\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 6800\n1000 Louisiana Street\nHouston, TX 77002", 
+          "name": "Noelle M. Reed", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 213-687-5000\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite # 3400\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Richard Adam Schwartz, Trial Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "IMMIGRATION EQUALITY", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 213-687-5276\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 3600\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Matthew E. Sloan, Esquire, Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 213-687-5537\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 3400\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Alyssa Clover", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 312-407-0700\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 2700\n155 North Wacker Drive\nChicago, IL 60606", 
+          "name": "Eric J. Gorman", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 213-687-5574\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 3400\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Allison Barrett Holcombe, Esquire, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 713-655-5122\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 6800\n1000 Louisiana Street\nHouston, TX 77002", 
+          "name": "Noelle M. Reed", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 213-687-5000\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite # 3400\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Richard Adam Schwartz, Trial Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NEW YORK CITY GAY AND LESBIAN ANTI-VIOLENCE PROJECT", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 213-687-5276\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 3600\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Matthew E. Sloan, Esquire, Counsel", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 213-687-5537\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 3400\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Alyssa Clover", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 312-407-0700\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 2700\n155 North Wacker Drive\nChicago, IL 60606", 
+          "name": "Eric J. Gorman", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 213-687-5574\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 3400\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Allison Barrett Holcombe, Esquire, Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 713-655-5122\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite 6800\n1000 Louisiana Street\nHouston, TX 77002", 
+          "name": "Noelle M. Reed", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }, 
+        {
+          "contact": "Direct: 213-687-5000\nSkadden, Arps, Slate, Meagher & Flom LLP\nSuite # 3400\n300 South Grand Avenue\nLos Angeles, CA 90071", 
+          "name": "Richard Adam Schwartz, Trial Attorney", 
+          "roles": [
+            "COR NTC Retained"
+          ]
+        }
+      ], 
+      "name": "NATIONAL QUEER ASIAN PACIFIC ISLANDER ALLIANCE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 808-547-5600\nGoodsill Anderson Quinn & Stifel LLP\nFirm: 808-547-5600\n999 Bishop Street\nFirst Hawaiian Center, Suite 1600\nHonolulu, HI 96813", 
+          "name": "Brett R. Tobin, Esquire, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "MASSACHUSETTS TECHNOLOGY LEADERSHIP COUNCIL, INC.", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Keller Rohrback LLP\n1201 Third Avenue\nSuite 3200\nSeattle, WA 98101", 
+          "name": "Lynn Lincoln Sarko, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "JOSEPH DOE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Keller Rohrback LLP\n1201 Third Avenue\nSuite 3200\nSeattle, WA 98101", 
+          "name": "Lynn Lincoln Sarko, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "JAMES DOE", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Keller Rohrback LLP\n1201 Third Avenue\nSuite 3200\nSeattle, WA 98101", 
+          "name": "Lynn Lincoln Sarko, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "EPISCOPAL DIOCESE OF OLYMPIA", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 206-622-8964\nLaw Office of Patricia S. Rose\nP.O. Box 31892\nSeattle, WA 98103", 
+          "name": "Patricia S. Rose, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "ONE MILLION KIDS FOR EQUALITY", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 206-622-8964\nLaw Office of Patricia S. Rose\nP.O. Box 31892\nSeattle, WA 98103", 
+          "name": "Patricia S. Rose, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "AFRICAN HUMAN RIGHTS COALITION", 
+      "type": "Amicus\u00a0Curiae"
+    }, 
+    {
+      "attorneys": [
+        {
+          "contact": "Direct: 206-223-7060\nLane Powell PC\nSuite 4200\n1420 Fifth Avenue\nP.O. Box 91302\nSeattle, WA 98111-9402", 
+          "name": "Claire Loebs Davis, Esquire, Attorney", 
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ], 
+      "name": "LAW PROFESSORS", 
+      "type": "Amicus\u00a0Curiae"
+    }
+  ]
 }


### PR DESCRIPTION
Dont't squash the first 2 commits. Do you want them in a separate PR?

* Move the `_br_split()` function to BaseDocketReport so other subclasses can use it. Although I had originally used it more, I ended up switching most but not all to `redelimit_p()` instead, because `_br_split()` only returns text content and can't parse more structured stuff. (This suggests it is poorly named.)

* PEP8 fixes as reported by flake8

* And then all the rest: Parse HTML parties, plus a few more cleanups later.

* Update tests.