### PR TITLE
html_utils.py:clean_html() Remove alleged "fix" for </br>

### DIFF
--- a/juriscraper/lib/html_utils.py
+++ b/juriscraper/lib/html_utils.py
@@ -120,9 +120,6 @@ def clean_html(text):
     if isinstance(text, text_type):
         text = re.sub(r'^\s*<\?xml\s+.*?\?>', '', text)
 
-    # Fix </br>
-    text = re.sub('</br>', '<br/>', text)
-
     # Fix invalid bytes in XML (http://stackoverflow.com/questions/8733233/)
     # Note that this won't work completely on narrow builds of Python, which
     # existed prior to Py3. Thus, we check if it's a narrow build, and adjust


### PR DESCRIPTION
Stop converting `</br>` into `<br/>`

As noted in my comment in #219: https://github.com/freelawproject/juriscraper/pull/219/files/e92373e61b8751b9482bba8668aa41212f16f35c#r191602446

`</br>` is not the same as `<br/>`.

The only valid HTML choice is `<br>`.

In XML or XHTML, all tags need to be closed, so that is normally
`<br/>`, but sometimes `<br />` and on much rarer occasions (but sometimes
seen in CMECF), it is `<br></br>`.

Transforming `</br>` into `<br/>` turns `<br></br>` into` <br><br/>` aka `<br><br>`.

That is, this transformation doubles each `<br>`, and thus doubles the
vertical space. That's especially troubling in appellate where a
double `<br>` is actually a semantic delimiter (in party parsing).

So anyhow, just cut it out.

For the tests that run for me, this fix actually _fixes_ tests that don't run properly (vcr tests of 

```
  File "tests/test_pacer.py", line 757, in test_queries
   msg="Didn't get terminated party info when it was "
AssertionError: Didn't get terminated party info when it was requested.
```

) but I'm not sure that my development environment is running those tests properly, and of coursee it's totally reasonable that there is some code in juriscraper that is depending on this doubling of `<br>`s (shudder!). 