### PR TITLE
Properly parse date fields in appellate party info

### DIFF
--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -315,6 +315,10 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
         html_text = re.sub(delimiter_re, r'<p>', html_text)
         return fromstring(html_text)
 
+    # Fields that need to be converted with convert_date_str()
+    PARTY_DATE_FIELDS = [
+        u'Terminated'
+    ]
     # Translation table from Appellate CMECF party fields schema to
     # juriscaper schema.
     PARTY_FIELDS = {
@@ -388,7 +392,10 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
                         field = self.PARTY_FIELDS[raw_field]
                     else:
                         field = raw_field
+
                     value = bold.tail
+                    if raw_field in self.PARTY_DATE_FIELDS:
+                        value = convert_date_string(value)
                     party[field] = force_unicode(value)
                 else:
                     s = ''.join(

--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -380,12 +380,14 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
                 #  <B>Terminated: </B>07/31/2017<BR>
                 bold = element.find('b')
                 if bold is not None:
-                    field = bold.text_content().strip()
+                    raw_field = bold.text_content().strip()
                     # Remove terminal colon
-                    field = re.sub(r':$', '', field)
+                    raw_field = re.sub(r':$', '', raw_field)
                     # Translate field name to Juriscraper schema, if it exists
-                    if field in self.PARTY_FIELDS:
-                        field = self.PARTY_FIELDS[field]
+                    if raw_field in self.PARTY_FIELDS:
+                        field = self.PARTY_FIELDS[raw_field]
+                    else:
+                        field = raw_field
                     value = bold.tail
                     party[field] = force_unicode(value)
                 else:


### PR DESCRIPTION
First commit makes the second commit unreadable IMNSHO, hence the separation and the nonsquash preference.
(Private conversation lead to this fixup PR, sorry for the brevity herein).