### PR TITLE
2018.08.08.appellate cavc

### DIFF
--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -2,7 +2,7 @@ import pprint
 import re
 import sys
 
-from lxml.html import tostring, fromstring
+from lxml.html import tostring
 
 from .docket_report import BaseDocketReport
 from .reports import BaseReport

--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -552,9 +552,17 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
 
     def _get_case_name(self):
         """Get the case name."""
-        # The text of a cell that doesn't have bold text.
-        path = '//table[contains(., "Court of Appeals Docket") or ' \
-               'contains(., "Bankruptcy Appellate Panel Docket")]//td[not(.//b)]'
+
+        # 1: Find the comment defining this section of the report
+        # 2: On its following-sibling axis, take the next table descendant,
+        # 3: as long as there is boldface in the first row of the table.
+        # 4: Within that table, take the 2nd row.
+
+        path = ('//comment()[contains(., "NEW SECTION - Case Stub")]/'  # 1
+                'following-sibling::*//table[1]'  # 2
+                '[.//tr[1]//b]//'  # 3
+                'tr[2]')  # 4
+
         case_name = self.tree.xpath(path)[0].text_content()
         return clean_string(harmonize(case_name))
 


### PR DESCRIPTION
1. Linting cleanups.

2. AppellateDocket:_get_case_name() Broaden xpath

Be far less specific in the XPath to get the case name. Don't look for
fixed strings that are highl court-dependent, instead use the NEW
SECTION comment markers.

After we find the comment, take the next descendant table that has
boldface in its first row, and return its second row.

This fixes cavc parsing.

3. Needs tests.