### PR TITLE
use phantomjs path from ansible config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,8 +52,7 @@ First step: Install Python 2.7.x, then:
     # On Ubuntu/Debian Linux
         wget https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-x86_64.tar.bz2
         tar -x -f phantomjs-1.9.7-linux-x86_64.tar.bz2
-        sudo mkdir -p /usr/local/phantomjs
-        sudo mv phantomjs-1.9.7-linux-x86_64/bin/phantomjs /usr/local/phantomjs
+        sudo mv phantomjs-1.9.7-linux-x86_64/bin/phantomjs /usr/local/bin
         rm -r phantomjs-1.9.7*  # Cleanup
     # On macOS with Homebrew:
         brew install phantomjs

--- a/juriscraper/AbstractSite.py
+++ b/juriscraper/AbstractSite.py
@@ -1,3 +1,4 @@
+import os
 import hashlib
 import json
 from datetime import date, datetime
@@ -19,6 +20,12 @@ from juriscraper.lib.test_utils import MockRequest
 
 logger = make_default_logger()
 phantomjs_executable_path = '/usr/local/bin/phantomjs'
+_legacy_path = "/usr/local/phantomjs/phantomjs"
+if os.path.isfile(_legacy_path) and os.access(_legacy_path, os.X_OK):
+    phantomjs_executable_path = _legacy_path
+    # Alternatively, we could also possibly perform os.rename
+    # to /usr/local/bin if user is in "staff" group.
+    # Not sure of the best way to handle this; too many ways to skin the cat.
 
 
 class AbstractSite(object):

--- a/juriscraper/AbstractSite.py
+++ b/juriscraper/AbstractSite.py
@@ -18,6 +18,7 @@ from juriscraper.lib.string_utils import (CaseNameTweaker, clean_string,
 from juriscraper.lib.test_utils import MockRequest
 
 logger = make_default_logger()
+phantomjs_executable_path = '/usr/local/bin/phantomjs'
 
 
 class AbstractSite(object):

--- a/juriscraper/AbstractSite.py
+++ b/juriscraper/AbstractSite.py
@@ -23,9 +23,9 @@ phantomjs_executable_path = '/usr/local/bin/phantomjs'
 _legacy_path = "/usr/local/phantomjs/phantomjs"
 if os.path.isfile(_legacy_path) and os.access(_legacy_path, os.X_OK):
     phantomjs_executable_path = _legacy_path
-    # Alternatively, we could also possibly perform os.rename
-    # to /usr/local/bin if user is in "staff" group.
-    # Not sure of the best way to handle this; too many ways to skin the cat.
+    msg = """Please place phantomjs executable in /usr/local/bin.
+    See https://github.com/freelawproject/juriscraper/pull/241"""
+    raise DeprecationWarning(msg)
 
 
 class AbstractSite(object):

--- a/juriscraper/opinions/united_states/federal_special/tax.py
+++ b/juriscraper/opinions/united_states/federal_special/tax.py
@@ -14,7 +14,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
-from juriscraper.AbstractSite import logger
+from juriscraper.AbstractSite import logger, phantomjs_executable_path
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.html_utils import fix_links_but_keep_anchors
 
@@ -42,7 +42,7 @@ class Site(OpinionSite):
             return super(Site, self)._download(request_dict=request_dict)
 
         driver = webdriver.PhantomJS(
-            executable_path='/usr/local/phantomjs/phantomjs',
+            executable_path=phantomjs_executable_path,
             service_log_path=os.path.devnull,  # Disable ghostdriver.log
         )
         driver.implicitly_wait(30)

--- a/juriscraper/opinions/united_states/state/mdag.py
+++ b/juriscraper/opinions/united_states/state/mdag.py
@@ -11,6 +11,7 @@ from lxml import html
 from selenium import webdriver
 from selenium.common.exceptions import NoSuchElementException
 
+from juriscraper.AbstractSite import logger, phantomjs_executable_path
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.string_utils import convert_date_string
 
@@ -53,7 +54,7 @@ class Site(OpinionSite):
     def get_dynamic_html_trees(self):
         # Initialize driver
         driver = webdriver.PhantomJS(
-            executable_path='/usr/local/phantomjs/phantomjs',
+            executable_path=phantomjs_executable_path,
             service_log_path=os.path.devnull,  # Disable ghostdriver.log
         )
         driver.get(self.url)

--- a/juriscraper/opinions/united_states/state/nyappterm_1st.py
+++ b/juriscraper/opinions/united_states/state/nyappterm_1st.py
@@ -16,7 +16,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
-from juriscraper.AbstractSite import logger
+from juriscraper.AbstractSite import logger, phantomjs_executable_path
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.cookie_utils import normalize_cookies
 from juriscraper.lib.network_utils import add_delay
@@ -175,7 +175,7 @@ class Site(OpinionSite):
         logger.info("Running Selenium browser PhantomJS to get the cookies...")
         add_delay(20, 5)
         driver = webdriver.PhantomJS(
-            executable_path='/usr/local/phantomjs/phantomjs',
+            executable_path=phantomjs_executable_path,
             service_log_path=os.path.devnull,  # Disable ghostdriver.log
         )
 

--- a/juriscraper/opinions/united_states/state/ohio.py
+++ b/juriscraper/opinions/united_states/state/ohio.py
@@ -16,7 +16,7 @@ from lxml import html
 from lxml.html import tostring
 from selenium import webdriver
 
-from juriscraper.AbstractSite import logger
+from juriscraper.AbstractSite import logger, phantomjs_executable_path
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.html_utils import fix_links_in_lxml_tree
 from juriscraper.lib.string_utils import clean_if_py3
@@ -46,7 +46,7 @@ class Site(OpinionSite):
             return super(Site, self)._download(request_dict=request_dict)
 
         driver = webdriver.PhantomJS(
-            executable_path='/usr/local/phantomjs/phantomjs',
+            executable_path=phantomjs_executable_path,
             service_log_path=os.path.devnull,  # Disable ghostdriver.log
         )
         driver.implicitly_wait(30)

--- a/juriscraper/opinions/united_states/state/sd.py
+++ b/juriscraper/opinions/united_states/state/sd.py
@@ -10,7 +10,7 @@ import re
 from lxml import html
 from selenium import webdriver
 
-from juriscraper.AbstractSite import logger
+from juriscraper.AbstractSite import logger, phantomjs_executable_path
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.html_utils import fix_links_in_lxml_tree
 from juriscraper.lib.string_utils import convert_date_string, titlecase
@@ -80,7 +80,7 @@ class Site(OpinionSite):
     def _download_backwards(self, page_year):
         logger.info("Running PhantomJS with params: %s" % (page_year,))
         driver = webdriver.PhantomJS(
-            executable_path='/usr/local/phantomjs/phantomjs',
+            executable_path=phantomjs_executable_path,
             service_log_path=os.path.devnull,  # Disable ghostdriver.log
         )
         driver.implicitly_wait(30)

--- a/juriscraper/opinions/united_states/state/tex.py
+++ b/juriscraper/opinions/united_states/state/tex.py
@@ -27,7 +27,7 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 
-from juriscraper.AbstractSite import logger
+from juriscraper.AbstractSite import logger, phantomjs_executable_path
 from juriscraper.DeferringList import DeferringList
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.cookie_utils import normalize_cookies
@@ -67,7 +67,7 @@ class Site(OpinionSite):
         else:
             logger.info("Running Selenium browser PhantomJS...")
             driver = webdriver.PhantomJS(
-                executable_path='/usr/local/phantomjs/phantomjs',
+                executable_path=phantomjs_executable_path,
                 service_log_path=os.path.devnull,  # Disable ghostdriver.log
             )
 

--- a/juriscraper/opinions/united_states_backscrapers/federal_appellate/ca5.py
+++ b/juriscraper/opinions/united_states_backscrapers/federal_appellate/ca5.py
@@ -8,7 +8,7 @@ from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from juriscraper.AbstractSite import logger
+from juriscraper.AbstractSite import logger, phantomjs_executable_path
 from juriscraper.OpinionSite import OpinionSite
 from juriscraper.lib.cookie_utils import normalize_cookies
 
@@ -39,7 +39,7 @@ class Site(OpinionSite):
         else:
             logger.info("Running Selenium browser PhantomJS...")
             driver = webdriver.PhantomJS(
-                executable_path='/usr/local/phantomjs/phantomjs',
+                executable_path=phantomjs_executable_path,
                 service_log_path=os.path.devnull,  # Disable ghostdriver.log
             )
 


### PR DESCRIPTION
I changed the readme to instruct the developer to install phantomjs into /usr/local/bin.  The "executable_path" parameter is possibly not necessary if phantomjs is already in $PATH.  I hardcoded the executable_path in AbstractSite module, so that there is only one place to replace the path if there are people still using ```/usr/local/phantomjs/phantomjs```.  If we require and presume that phantomjs is installed into a ```PATH``` directory, much of this and older code could possibly be removed entirely.

