### PR TITLE
added cssselect to reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ argparse
 cchardet>=1.1.2
 certifi>=2017.4.17
 chardet<3.1.0,>=3.0.2
+cssselect
 feedparser
 geonamescache==0.20
 html5lib


### PR DESCRIPTION
I found where BeautifulSoup is mentioned in the juriscraper code.  It was mentioned in a docstring for one of the AbstractSite methods, where it was contemplated that it might be used by other developers.  I found the docstring when I was working on the oral argument scrapers for Mississippi.

In a previous discussion concerning the potential addition of bs4 as a requirement of the juriscraper package, I found that even the tree objects in the lxml.xpath elements could be used in a similar way to the example of bad practice that was presented to me (i.e. one can easily use ```el.getnext().getnext()...```.

I stated that I also didn't like using bs4 in that manner, but preferred the css selector syntax over the xpath syntax.  This was mostly due to familiarity and xpath seems to be very powerful even though I'm not as familiar with that.  Yet, for those developers who may desire to create or update a scraper, and is more familiar with the css selector syntax, the cssselect package integrates with lxml and could be useful, and helpful, with a larger audience of developers who may be interested in helping to maintain the pieces that they are most interested in handling.

Providing the ability to use either selection syntax, while not allowing the type of coding that is discouraged may be useful to the project, hence this PR.