### PR TITLE
Collect stats on sample_caller runs and optionally report them

### DIFF
--- a/juriscraper/report.py
+++ b/juriscraper/report.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-import pickle
 
 import jinja2
 
@@ -11,16 +10,20 @@ def generate_scraper_report(file_path, results):
   with_zero_results = []
   with_global_failure = []
   for name, scraper in results.items():
+    has_error = False
     if scraper['global_failure']:
       with_global_failure.append(name)
+      has_error = True
     scrape = scraper['scrape']
     if scrape.get('count') == 0:
       with_zero_results.append(name)
+      has_error = True
     for exc in scrape.get('exceptions', []):
       if len(exc) > 0:
         with_error.append(name)
+        has_error = True
         break
-    else:
+    if not has_error:
       no_error.append(name)
 
   display = {

--- a/juriscraper/report.py
+++ b/juriscraper/report.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+import pickle
+
+import jinja2
+
+from juriscraper.templates import env as jinja_env
+
+def generate_scraper_report(file_path, results):
+  no_error = []
+  with_errors = []
+  with_zero_results = []
+  with_global_failure = []
+  for name, scraper in results.items():
+    if scraper['global_failure']:
+      with_global_failure.append(name)
+    scrape = scraper['scrape']
+    if scrape.get('count') == 0:
+      with_zero_results.append(name)
+    for exc in scrape.get('exceptions', []):
+      if len(exc) > 0:
+        with_error.append(name)
+        break
+    else:
+      no_error.append(name)
+
+  display = {
+    'generated_on': datetime.now().strftime('%a, %B %d %Y %H:%M:%S'),
+    'count': len(results),
+    'no_error': no_error,
+    'with_errors': with_errors,
+    'with_zero_results': with_zero_results,
+    'with_global_failure': with_global_failure,
+    'total_errors': len(with_errors) + len(with_zero_results) + len(with_global_failure),
+  }
+  template = jinja_env.get_template('report.html.jinja2')
+  with open(file_path, 'w') as f:
+    f.write(template.render(display))

--- a/juriscraper/templates/__init__.py
+++ b/juriscraper/templates/__init__.py
@@ -1,0 +1,4 @@
+from jinja2 import Environment, PackageLoader, select_autoescape
+
+env = Environment(loader=PackageLoader('juriscraper', 'templates'),
+                  autoescape=select_autoescape(['html', 'xml']))

--- a/juriscraper/templates/report.html.jinja2
+++ b/juriscraper/templates/report.html.jinja2
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Juriscraper Status Report</title>
+  <style>
+    .error-tally {
+      margin-left: 2rem;
+    }
+
+    .error-detail {
+      margin-left: 1.5rem;
+    }
+
+    .scraper {
+      background-color: #CCC;
+      margin-top: .5rem;
+      padding: .2rem;
+    }
+
+    .error-header {
+      pointer: cursor;
+    }
+  </style>
+</head>
+<body>
+  <h1>Status Report</h1>
+  <h2>{{ count }} total scrapers run</h2>
+  <h2 style="color: {{'red' if total_errors > 0 else 'green'}}">{{ total_errors }} total errors</h2>
+  <div class="error-tally">
+
+    <h3 id="zero" class="error-header">- {{ with_zero_results | length }} scrapers with zero downloaded results</h3>
+    <div class="error-detail zero-detail">
+    {% for name in with_zero_results %}
+      <div class="scraper">{{ name }}</div>
+    {% endfor %}
+    </div>
+
+    <h3 id="binary" class="error-header">- {{ with_errors | length }} scrapers with binary download errors</h3>
+    <div class="error-detail binary-detail">
+    {% for name in with_errors %}
+      <div class="scraper">{{ name }}</div>
+    {% endfor %}
+    </div>
+
+    <h3 id="total" class="error-header">- {{ with_global_failure | length }} scrapers with "total" failure ("CRAWLER DOWN")</h3>
+    <div class="error-detail total-detail">
+    {% for name in with_global_failure %}
+      <div class="scraper">{{ name }}</div>
+    {% endfor %}
+    </div>
+
+  </div>
+
+  <h2 id="none" class="error-header">- {{ no_error | length }} scrapers completed successfully</h2>
+  <div class="error-tally">
+    <div class="error-detail none-detail">
+    {% for name in no_error %}
+      <div class="scraper">{{ name }}</div>
+    {% endfor %}
+    </div>
+  </div>
+
+  <p>Generated on {{ generated_on }}</p>
+
+  <script
+    src="https://code.jquery.com/jquery-3.4.1.js"
+    integrity="sha256-WpOohJOqMqqyKL9FccASB9O0KwACQJpFTUBLTYOVvVU="
+    crossorigin="anonymous"></script>
+  <script>
+    $('.error-header').click(function() {
+      $('.' + this.id + '-detail').toggle();
+      if ($(this).text().indexOf('+') !== -1) {
+        $(this).text($(this).text().replace('+', '-'));
+      } else {
+        $(this).text($(this).text().replace('-', '+'));
+      }     
+    });
+  </script>
+</body>
+</html>

--- a/juriscraper/templates/report.html.jinja2
+++ b/juriscraper/templates/report.html.jinja2
@@ -18,12 +18,14 @@
     }
 
     .error-header {
-      pointer: cursor;
+      cursor: pointer;
     }
   </style>
 </head>
 <body>
   <h1>Status Report</h1>
+  <p>Generated on {{ generated_on }}</p>
+
   <h2>{{ count }} total scrapers run</h2>
   <h2 style="color: {{'red' if total_errors > 0 else 'green'}}">{{ total_errors }} total errors</h2>
   <div class="error-tally">
@@ -48,7 +50,6 @@
       <div class="scraper">{{ name }}</div>
     {% endfor %}
     </div>
-
   </div>
 
   <h2 id="none" class="error-header">- {{ no_error | length }} scrapers completed successfully</h2>
@@ -59,8 +60,6 @@
     {% endfor %}
     </div>
   </div>
-
-  <p>Generated on {{ generated_on }}</p>
 
   <script
     src="https://code.jquery.com/jquery-3.4.1.js"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ mock
 vcrpy
 twine
 tox
+jinja2


### PR DESCRIPTION
This PR adds light instrumentation to the sample_caller runs, where exceptions and total items scraped are counted for each scraper ('module_string'). At the end of the run, if the`--report` option is enabled, a `report.html` file is created in the project root directory.

An example of a real report that this generates is [here](https://juriscraper.netlify.com/)

I believe this adds obvious value over trying to run sample_caller one scraper at a time and "see" if it failed or not.

Also jinja2 is added only as a dev dependency.