### PR TITLE
283 text parsing

### DIFF
--- a/juriscraper/lib/models.py
+++ b/juriscraper/lib/models.py
@@ -1,5 +1,3 @@
-
-
 citation_types = {
     "FEDERAL": 1,
     "STATE": 2,
@@ -8,5 +6,5 @@ citation_types = {
     "SCOTUS_EARLY": 5,
     "LEXIS": 6,
     "WEST": 7,
-    "NEUTRAL": 8
+    "NEUTRAL": 8,
 }

--- a/juriscraper/opinions/united_states/federal_special/tax.py
+++ b/juriscraper/opinions/united_states/federal_special/tax.py
@@ -14,6 +14,7 @@ from juriscraper.OpinionSiteWebDriven import OpinionSiteWebDriven
 from juriscraper.lib.html_utils import fix_links_but_keep_anchors
 from juriscraper.lib.models import citation_types
 
+
 class Site(OpinionSiteWebDriven):
     def __init__(self, *args, **kwargs):
         super(Site, self).__init__(*args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,8 @@ import os
 import sys
 import unittest
 
-
-try:  # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError:  # for pip <= 9.0.3
-    from pip.req import parse_requirements
-
 from setuptools import setup, find_packages
 from setuptools.command.install import install
-
 
 VERSION = "1.26.26"
 AUTHOR = "Free Law Project"
@@ -59,11 +52,6 @@ class VerifyVersion(install):
             )
             sys.exit(message.format(tag, VERSION))
 
-
-requirements = [
-    str(r.req) for r in parse_requirements("requirements.txt", session=False)
-]
-
 setup(
     name="juriscraper",
     description="An API to scrape American court websites for metadata.",
@@ -95,7 +83,22 @@ setup(
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
-    install_requires=requirements,
+    install_requires=[
+        'six',
+        'argparse',
+        "cchardet>=1.1.2",
+        "certifi>=2017.4.17",
+        "chardet<3.1.0,>=3.0.2",
+        "cssselect",
+        "feedparser",
+        "geonamescache==0.20",
+        "html5lib",
+        "lxml==3.5.0",
+        "python-dateutil==2.5.0",
+        "requests==2.20.0",
+        "selenium==2.53.6",
+        "tldextract",
+    ],
     tests_require=["jsondate", "mock", "vcrpy"],
     include_package_data=True,
     test_suite="tests.test_local",

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ class VerifyVersion(install):
             )
             sys.exit(message.format(tag, VERSION))
 
+
 setup(
     name="juriscraper",
     description="An API to scrape American court websites for metadata.",
@@ -84,8 +85,8 @@ setup(
         "Topic :: Software Development :: Libraries :: Python Modules",
     ],
     install_requires=[
-        'six',
-        'argparse',
+        "six",
+        "argparse",
         "cchardet>=1.1.2",
         "certifi>=2017.4.17",
         "chardet<3.1.0,>=3.0.2",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import unittest
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "1.26.26"
+VERSION = "1.26.27"
 AUTHOR = "Free Law Project"
 EMAIL = "info@free.law"
 HERE = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
This PR bumps the version to 1.26.27.

It moves a brand new function back into CL.
It adds a lib.models.py file.
Fixes the text extraction metadata dictionary for the tax court.

Also updates the setup.py file to work better with pip installations.  