### PR TITLE
Re-login triggered by text file return

### DIFF
--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -6,7 +6,7 @@ from requests.packages.urllib3 import exceptions
 from ..lib.exceptions import PacerLoginException
 from ..lib.html_utils import get_html_parsed_text, get_xml_parsed_text
 from ..lib.log_tools import make_default_logger
-from ..pacer.utils import is_pdf
+from ..pacer.utils import is_pdf, is_text
 
 logger = make_default_logger()
 

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -393,7 +393,7 @@ class PacerSession(requests.Session):
         """
         if is_pdf(r):
             return False
-        
+
         if is_text(r):
             return False
 

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -393,6 +393,9 @@ class PacerSession(requests.Session):
         """
         if is_pdf(r):
             return False
+        
+        if is_text(r):
+            return False
 
         logged_in = check_if_logged_in_page(r.text)
         if logged_in:

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -164,7 +164,7 @@ def is_pdf(response):
 
 def is_text(response):
     """Determines whether the item downloaded is a text file or something else."""
-    if ".txt" in response.headers.get("content-type"):
+    if ".txt" in response.headers.get("content-type", ""):
         return True
     return False
 

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -161,11 +161,13 @@ def is_pdf(response):
         return True
     return False
 
+
 def is_text(response):
     """Determines whether the item downloaded is a text file or something else."""
-    if '.txt' in response.headers.get("content-type"):
+    if ".txt" in response.headers.get("content-type"):
         return True
     return False
+
 
 def get_nonce_from_form(r):
     """Get a nonce value from a HTML response. Returns the first nonce that is

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -161,6 +161,11 @@ def is_pdf(response):
         return True
     return False
 
+def is_text(response):
+    """Determines whether the item downloaded is a text file or something else."""
+    if '.txt' in response.headers.get("content-type"):
+        return True
+    return False
 
 def get_nonce_from_form(r):
     """Get a nonce value from a HTML response. Returns the first nonce that is


### PR DESCRIPTION
As discussed in #311, fixes re-login logic to catch cases where the PACER request returns a text file. When a text file was returned the existing session login check couldn't parse that it was a text file and an unnecessary re-login would be triggered.