### PR TITLE
Min Req for Requests, add Badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,9 @@
+|Linting| image:: https://github.com/freelawproject/juriscraper/workflows/Lint/badge.svg?branch=master
+       :target: https://github.com/freelawproject/juriscraper/actions?query=workflow%3ALint
+
+|Testing| image:: https://github.com/freelawproject/juriscraper/workflows/Tests/badge.svg
+:target: https://github.com/freelawproject/juriscraper/actions?query=workflow%3ATests
+
 What is This?
 =============
 
@@ -352,3 +358,6 @@ License
 =======
 
 Juriscraper is licensed under the permissive BSD license.
+
+|forthebadge made-with-python| image:: http://ForTheBadge.com/images/badges/made-with-python.svg
+   :target: https://www.python.org/

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,12 @@
-|Linting| image:: https://github.com/freelawproject/juriscraper/workflows/Lint/badge.svg?branch=master
-       :target: https://github.com/freelawproject/juriscraper/actions?query=workflow%3ALint
++---------------+---------------------+-------------------+
+| |Lint Badge|  | |Test Badge|        |  |Version Badge|  |
++---------------+---------------------+-------------------+
 
-|Testing| image:: https://github.com/freelawproject/juriscraper/workflows/Tests/badge.svg
-:target: https://github.com/freelawproject/juriscraper/actions?query=workflow%3ATests
+
+.. |Lint Badge| image:: https://github.com/freelawproject/juriscraper/workflows/Lint/badge.svg
+.. |Test Badge| image:: https://github.com/freelawproject/juriscraper/workflows/Tests/badge.svg
+.. |Version Badge| image:: https://badge.fury.io/py/juriscraper.svg
+
 
 What is This?
 =============
@@ -359,5 +363,7 @@ License
 
 Juriscraper is licensed under the permissive BSD license.
 
-|forthebadge made-with-python| image:: http://ForTheBadge.com/images/badges/made-with-python.svg
-   :target: https://www.python.org/
+|forthebadge made-with-python|
+
+.. |forthebadge made-with-python| image:: http://ForTheBadge.com/images/badges/made-with-python.svg
+    :target: https://www.python.org/

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ geonamescache==0.20
 html5lib
 lxml~=4.0
 python-dateutil==2.8.1
-requests==2.20.0
+requests>=2.20.0
 selenium~=3.0
 tldextract


### PR DESCRIPTION
- the `requests==2.20.0` req should be a `>=`. Projects using a strict lock file (i.e pipenv or poetry) can end up with unlockable requirements based on not allowing higher versions of requests.
- adds badges back to the README.