### PR TITLE
fix(pypi.yml): Use freelawproject/deploy-pypi@v1

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: casperdcl/deploy-pypi@v1
+      - uses: freelawproject/deploy-pypi@v1
         with:
           password: ${{ secrets.pypi_token }}
           build: true


### PR DESCRIPTION
Use our forked deploy pypi
This was viewed as a security risk.

This PR should also trigger a release of v.2.0.3