### PR TITLE
fix(pacer/docket_report.py): python3 support on command-line

### DIFF
--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -1281,6 +1281,6 @@ if __name__ == "__main__":
     filepath = sys.argv[1]
     print("Parsing HTML file at %s" % filepath)
     with open(filepath, "r") as f:
-        text = f.read().decode("utf-8")
+        text = f.read()
     report._parse_text(text)
     pprint.pprint(report.data, indent=2)


### PR DESCRIPTION
When run from the command-line, as python -m
juriscraper.pacer.docket_report, we read the file and must no longer
call .decode() as of Python3.

Fixes:

  File "/Users/jhawk/src/juriscraper/juriscraper/pacer/docket_report.py", line 1284, in <module>
    text = f.read().decode("utf-8")
AttributeError: 'str' object has no attribute 'decode'