### PR TITLE
feat(backscraper-maine): Add simple backscraper for 2016-2020 opinions

### DIFF
--- a/juriscraper/opinions/united_states_backscrapers/state/me.py
+++ b/juriscraper/opinions/united_states_backscrapers/state/me.py
@@ -1,0 +1,17 @@
+"""Backscraper for Supreme Court of Maine 2021 redux
+CourtID: me
+Court Short Name: Me.
+Author: William E. Palin
+Date created: March 31, 2021
+"""
+
+from juriscraper.opinions.united_states.state import me
+
+
+class Site(me.Site):
+    def __init__(self, *args, **kwargs):
+        super(Site, self).__init__(*args, **kwargs)
+        self.court_id = self.__module__
+
+    def _download_backwards(self, year):
+        self.url = f"https://www.courts.maine.gov/courts/sjc/lawcourt/{year}/index.html"

--- a/juriscraper/opinions/united_states_backscrapers/state/me.py
+++ b/juriscraper/opinions/united_states_backscrapers/state/me.py
@@ -12,6 +12,8 @@ class Site(me.Site):
     def __init__(self, *args, **kwargs):
         super(Site, self).__init__(*args, **kwargs)
         self.court_id = self.__module__
+        self.back_scrape_iterable = [2020, 2019, 2018, 2017]
 
     def _download_backwards(self, year):
         self.url = f"https://www.courts.maine.gov/courts/sjc/lawcourt/{year}/index.html"
+        self.html = self._download()


### PR DESCRIPTION
PR adds backslapper for years 2016 to 2020 for Maine SJC

Maine was briefly down - but that extended into last year.  So I added a simple backscraper to handle these older cases.