### PR TITLE
fix(maine): Update url for scraping

### DIFF
--- a/juriscraper/opinions/united_states/state/me.py
+++ b/juriscraper/opinions/united_states/state/me.py
@@ -21,7 +21,7 @@ class Site(OpinionSite):
     def __init__(self, *args, **kwargs):
         super(Site, self).__init__(*args, **kwargs)
         self.court_id = self.__module__
-        self.url = "http://www.courts.maine.gov/opinions_orders/supreme/publishedopinions.shtml"
+        self.url = "https://www.courts.maine.gov/courts/sjc/opinions.html"
         self.path_root = '//table[contains(.//th[1], "Opinion")]'
 
     def _get_cell_path(self, cell_number: int, subpath: str = "") -> str:


### PR DESCRIPTION
PR addresses bug in Maine scraper. #372 

The old url redirects to the current page,
 but because of the redirect the
 download filepaths are still failing
 Update url to new landing page