### PR TITLE
Added exception when server response doesn't return a valid HTML page to scrap free opinions

### DIFF
--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -197,7 +197,13 @@ def get_nonce_from_form(r):
     :returns A nonce object that can be used to query PACER or None, if no
     nonce can be found.
     """
-    tree = html.fromstring(r.text)
+    try:
+        tree = html.fromstring(r.text)
+    except ValueError:
+        # This usually happens when we are blocked from a court.
+        raise ParsingException(
+            "Got XML when expecting HTML and cannot parse it."
+        )
     form_attrs = tree.xpath("//form//@action")
     for attr in form_attrs:
         # The action attr will be a value like:


### PR DESCRIPTION
Added exception when server response doesn't return a valid HTML page to scrap free opinions.
Some court's servers block requests to scrap free opinion documents. But if the returned page is not a proper HTML page, the parse fails and this error it's not properly cought.

Closes: #418 