### PR TITLE
Updated XML structure for opinions from the Court of Appeals for the Tenth Circuit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,10 +12,26 @@ Releases are also tagged in git, if that's helpful.
 
 ## Current
 
-- 2.3.3, 2020-11-24 - Fix remote selenium connection code
+- 2.3.19, 2021-11-16 - Fix PA, IL. Update PACER to use new auth API. Update geonames cache with latest population data. Throw exception in Free Opinions report when IP address on blocklist.
 
 ## Past
 
+- 2.3.18, 2021-10-18 - Fix GA, CA9, CA10 Oral args
+- 2.3.17, 2021-08-17 - Add anonymizing function for PACER dockets
+- 2.3.16 - Yanked
+- 2.3.15, 2021-07-19 - Fix PACER downloaders
+- 2.3.14 - Yanked
+- 2.3.13, 2021-06-18 - Fix typing
+- 2.3.12, 2021-06-18 - Add PACER email parsers
+- 2.3.11, 2021-05-02 - Fix PACER auth function
+- 2.3.10, 2021-04-13 - Simplify harmonize function
+- 2.3.9, 2021-04-12 - Simplify case name cleanup util
+- 2.3.8, 2021-04-01 - More ME fixes
+- 2.3.7, 2021-04-01 - Add backscrapers scrapers for ME
+- 2.3.6, 2021-03-05 - Clean up deprecation warnings
+- 2.3.5, 2021-03-05 - Fix pypi
+- 2.3.4, 2021-02-09 - Fix IA scraper
+- 2.3.3, 2020-11-24 - Fix remote selenium connection code
 - 2.3.2, 2020-11-06 - Remove html_unescape helper method. Replace with calls 
   directly to unescape. This fixes [#354](https://github.com/freelawproject/juriscraper/issues/354).
 - 2.3.1, 2020-11-06 - Fix for connection to Selenium via Firefox
@@ -58,21 +74,21 @@ Releases are also tagged in git, if that's helpful.
 - 1.9.* - Re-organization, simplification, and standardization of PACER classes.
 - 1.8.* - Standardization of string fields in PACER objects so they return the empty string when they have no value instead of returning None sometimes and the empty string others. (This follows Django conventions.)
 - 1.7.* - Adds support for hidden PACER APIs.
--  1.6.* - Adds automatic relogin code to PACER sessions, with reorganization of old login APIs.
--  1.5.* - Adds support for querying and parsing PACER dockets.
--  1.4.* - Python 3 compatibility (this was later dropped due to dependencies).
--  1.3.* - Adds support for scraping some parts of PACER.
--  1.2.* - Continued improvements.
--  1.1.* - Major code reorganization and first release on the Python Package Index (PyPi)
--  1.0 - Support opinions from for all possible federal bankruptcy
+- 1.6.* - Adds automatic relogin code to PACER sessions, with reorganization of old login APIs.
+- 1.5.* - Adds support for querying and parsing PACER dockets.
+- 1.4.* - Python 3 compatibility (this was later dropped due to dependencies).
+- 1.3.* - Adds support for scraping some parts of PACER.
+- 1.2.* - Continued improvements.
+- 1.1.* - Major code reorganization and first release on the Python Package Index (PyPi)
+- 1.0 - Support opinions from for all possible federal bankruptcy
    appellate panels (9th and 10th Cir.)
--  0.9 - Supports all state courts of last resort (typically the
+- 0.9 - Supports all state courts of last resort (typically the
    "Supreme" court)
--  0.8 - Supports oral arguments for all possible Federal Circuit
+- 0.8 - Supports oral arguments for all possible Federal Circuit
    courts.
--  0.2 - Supports opinions from all federal courts of special
+- 0.2 - Supports opinions from all federal courts of special
    jurisdiction (Veterans, Tax, etc.)
--  0.1 - Supports opinions from all 13 Federal Circuit courts and the
+- 0.1 - Supports opinions from all 13 Federal Circuit courts and the
    U.S. Supreme Court
 
 

--- a/juriscraper/opinions/united_states/federal_appellate/ca10.py
+++ b/juriscraper/opinions/united_states/federal_appellate/ca10.py
@@ -23,10 +23,10 @@ class Site(OpinionSite):
                 title_string = p_element.xpath("/p/text()")[0]
                 case_names.append(title_string)
             except:
-                logger.warning(
+                logger.error(f"Error while parsing case name: {title_string}")
+                raise InsanityException(
                     f"Error while parsing case name: {title_string}"
                 )
-                case_names.append(title_string)
         return case_names
 
     def _get_download_urls(self):
@@ -48,9 +48,7 @@ class Site(OpinionSite):
                     )
                 )
             except:
-                logger.critical(
-                    f"Error while parsing case date: {date_string}"
-                )
+                logger.error(f"Error while parsing case date: {date_string}")
                 raise InsanityException(
                     f"Error while parsing case date: {date_string}"
                 )
@@ -59,7 +57,7 @@ class Site(OpinionSite):
     def _get_docket_numbers(self):
         return [
             e.split(" - ")[0].split(":")[1]
-            for e in self.html.xpath("//item/description/text()[1]")
+            for e in self.html.xpath("//item/description/text()")
         ]
 
     def _get_precedential_statuses(self):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import unittest
 from setuptools import setup, find_packages
 from setuptools.command.install import install
 
-VERSION = "2.3.18"
+VERSION = "2.3.19"
 AUTHOR = "Free Law Project"
 EMAIL = "info@free.law"
 HERE = os.path.abspath(os.path.dirname(__file__))

--- a/tests/examples/opinions/united_states/ca10_example.compare.json
+++ b/tests/examples/opinions/united_states/ca10_example.compare.json
@@ -1,57 +1,57 @@
 [
   {
-    "case_dates": "2012-02-24",
-    "case_names": "United States v. Sturm",
-    "download_urls": "http://www.ca10.uscourts.gov/opinions/09/09-1386.pdf",
-    "precedential_statuses": "Published",
-    "blocked_statuses": false,
-    "date_filed_is_approximate": false,
-    "docket_numbers": "09-1386",
-    "lower_courts": "United States District Court for the District of Colorado",
-    "case_name_shorts": "Sturm"
-  },
-  {
-    "case_dates": "2012-02-24",
-    "case_names": "United States v. Mendoza-Lopez",
-    "download_urls": "http://www.ca10.uscourts.gov/opinions/10/10-1499.pdf",
-    "precedential_statuses": "Published",
-    "blocked_statuses": false,
-    "date_filed_is_approximate": false,
-    "docket_numbers": "10-1499",
-    "lower_courts": "United States District Court for the District of Colorado",
-    "case_name_shorts": "Mendoza-Lopez"
-  },
-  {
-    "case_dates": "2012-02-24",
-    "case_names": "United States v. Dayton",
-    "download_urls": "http://www.ca10.uscourts.gov/opinions/09/09-5022.pdf",
-    "precedential_statuses": "Published",
-    "blocked_statuses": false,
-    "date_filed_is_approximate": false,
-    "docket_numbers": "09-5022",
-    "lower_courts": "United States District Court for the Northern District of Oklahoma",
-    "case_name_shorts": "Dayton"
-  },
-  {
-    "case_dates": "2012-02-24",
-    "case_names": "Navigato v. SJ Restaurants, LLC",
-    "download_urls": "http://www.ca10.uscourts.gov/opinions/11/11-3108.pdf",
+    "case_dates": "2021-11-12",
+    "case_names": "United States v. Etuk",
+    "download_urls": "https://www.ca10.uscourts.gov/sites/ca10/files/opinions/010110603775.pdf",
     "precedential_statuses": "Unpublished",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "11-3108",
-    "lower_courts": "United States District Court for the District of Kansas - Kansas City",
-    "case_name_shorts": "Navigato"
+    "docket_numbers": "21-5062",
+    "lower_courts": "United States District Court for the Northern District of Oklahoma - Tulsa",
+    "case_name_shorts": "Etuk"
   },
   {
-    "case_dates": "2012-02-24",
-    "case_names": "Evans v. The Bank of New York",
-    "download_urls": "http://www.ca10.uscourts.gov/opinions/11/11-1096.pdf",
+    "case_dates": "2021-11-12",
+    "case_names": "Powell v. Farris",
+    "download_urls": "https://www.ca10.uscourts.gov/sites/ca10/files/opinions/010110603745.pdf",
     "precedential_statuses": "Unpublished",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "11-1096",
-    "lower_courts": "Bankruptcy Appellate Panel - Colorado",
-    "case_name_shorts": "Evans"
+    "docket_numbers": "21-6089",
+    "lower_courts": "United States District Court for the Western District of Oklahoma - Oklahoma City",
+    "case_name_shorts": "Powell"
+  },
+  {
+    "case_dates": "2021-11-12",
+    "case_names": "Ngo v. Garland",
+    "download_urls": "https://www.ca10.uscourts.gov/sites/ca10/files/opinions/010110603801.pdf",
+    "precedential_statuses": "Unpublished",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "21-9517",
+    "lower_courts": "Board of Immigration Appeals",
+    "case_name_shorts": "Ngo"
+  },
+  {
+    "case_dates": "2021-11-12",
+    "case_names": "Grant v. Crow",
+    "download_urls": "https://www.ca10.uscourts.gov/sites/ca10/files/opinions/010110604402.pdf",
+    "precedential_statuses": "Unpublished",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "21-6139",
+    "lower_courts": "United States District Court for the Western District of Oklahoma - Oklahoma City",
+    "case_name_shorts": "Grant"
+  },
+  {
+    "case_dates": "2021-11-12",
+    "case_names": "Blanco-Valdovinos v. Garland",
+    "download_urls": "https://www.ca10.uscourts.gov/sites/ca10/files/opinions/010110603734.pdf",
+    "precedential_statuses": "Unpublished",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "21-9512",
+    "lower_courts": "Board of Immigration Appeals",
+    "case_name_shorts": "Blanco-Valdovinos"
   }
 ]

--- a/tests/examples/opinions/united_states/ca10_example.xml
+++ b/tests/examples/opinions/united_states/ca10_example.xml
@@ -1,48 +1,54 @@
-<?xml version="1.0"?>
-<rss version="2.0">
-	<channel>
-		<title>Tenth Circuit Daily Decisions</title>
-		<link>http://www.ca10.uscourts.gov/clerk/opinions.php</link>
-		<description>A feed of decisions posted by the United States Court of
-			Appeals for the 10th Circuit</description>
-		<language>en-us</language>
-		<webMaster>webmaster@ca10.uscourts.gov (Webmaster)</webMaster>
-		<pubDate>Fri, 24 Feb 2012 18:00:02 MST</pubDate>
-		<ttl>60</ttl>
-		<item>
-			<title>Navigato v. SJ Restaurants, LLC</title>
-			<pubDate>Fri, 24 Feb 2012 10:09:06 MST</pubDate>
-			<link>http://www.ca10.uscourts.gov/opinions/11/11-3108.pdf</link>
-			<description>Docket#: 11-3108<br><b>United States District Court for the District of Kansas - Kansas City</b><br>Date Issued: 02/24/2012<br>Unpublished Order and Judgment</description>
-			<category>Unpublished</category>
-		</item>
-		<item>
-			<title>Evans v. The Bank of New York</title>
-			<pubDate>Fri, 24 Feb 2012 10:10:04 MST</pubDate>
-			<link>http://www.ca10.uscourts.gov/opinions/11/11-1096.pdf</link>
-			<description>Docket#: 11-1096<br><b>Bankruptcy Appellate Panel - Colorado</b><br>Date Issued: 02/24/2012<br>Unpublished Order and Judgment</description>
-			<category>Unpublished</category>
-		</item>
-		<item>
-			<title>United States v. Sturm</title>
-			<pubDate>Fri, 24 Feb 2012 10:10:46 MST</pubDate>
-			<link>http://www.ca10.uscourts.gov/opinions/09/09-1386.pdf</link>
-			<description><![CDATA[Docket#: 09-1386<br><b>United States District Court for the District of Colorado</b><br>Date Issued: 02/24/2012<br>Published Opinion]]></description>
-			<category>Published</category>
-		</item>
-		<item>
-			<title>United States v. Dayton</title>
-			<pubDate>Fri, 24 Feb 2012 10:11:51 MST</pubDate>
-			<link>http://www.ca10.uscourts.gov/opinions/09/09-5022.pdf</link>
-			<description><![CDATA[Docket#: 09-5022<br><b>United States District Court for the Northern District of Oklahoma</b><br>Date Issued: 02/24/2012<br>Published Opinion]]></description>
-			<category>Published</category>
-		</item>
-		<item>
-			<title>United States v. Mendoza-Lopez</title>
-			<pubDate>Fri, 24 Feb 2012 10:49:59 MST</pubDate>
-			<link>http://www.ca10.uscourts.gov/opinions/10/10-1499.pdf</link>
-			<description><![CDATA[Docket#: 10-1499<br><b>United States District Court for the District of Colorado</b><br>Date Issued: 02/24/2012<br>Published Opinion]]></description>
-			<category>Published</category>
-		</item>
-	</channel>
+<?xml version="1.0" encoding="utf-8" ?><rss version="2.0" xml:base="https://www.ca10.uscourts.gov/opinions-page" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:og="http://ogp.me/ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:sioc="http://rdfs.org/sioc/ns#" xmlns:sioct="http://rdfs.org/sioc/types#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+  <channel>
+    <title>Tenth Circuit Daily Decisions</title>
+    <link>https://www.ca10.uscourts.gov/opinions-page</link>
+    <description>A feed of decisions posted by the United States Court of Appeals for the 10th Circuit</description>
+    <language>en</language>
+     <atom:link href="https://www.ca10.uscourts.gov/opinions/new/daily_decisions.rss" rel="self" type="application/rss+xml" />
+      <item>
+    <title>&lt;p&gt;Powell v. Farris&lt;/p&gt;
+</title>
+    <link>https://www.ca10.uscourts.gov/sites/ca10/files/opinions/010110603745.pdf</link>
+    <description>Docket#: 21-6089 - Date Issued: Fri Nov 12 2021 - Unpublished Order and Judgment</description>
+     <pubDate>&lt;span class=&quot;date-display-single&quot; property=&quot;dc:date&quot; datatype=&quot;xsd:dateTime&quot; content=&quot;2021-11-12T00:00:00-07:00&quot;&gt;Fri Nov 12 2021&lt;/span&gt;</pubDate>
+ <dc:creator>United States District Court for the Western District of Oklahoma - Oklahoma City</dc:creator>
+ <guid isPermaLink="false">10871678</guid>
+  </item>
+  <item>
+    <title>&lt;p&gt;United States v. Etuk&lt;/p&gt;
+</title>
+    <link>https://www.ca10.uscourts.gov/sites/ca10/files/opinions/010110603775.pdf</link>
+    <description>Docket#: 21-5062 - Date Issued: Fri Nov 12 2021 - Unpublished Order and Judgment</description>
+     <pubDate>&lt;span class=&quot;date-display-single&quot; property=&quot;dc:date&quot; datatype=&quot;xsd:dateTime&quot; content=&quot;2021-11-12T00:00:00-07:00&quot;&gt;Fri Nov 12 2021&lt;/span&gt;</pubDate>
+ <dc:creator>United States District Court for the Northern District of Oklahoma - Tulsa</dc:creator>
+ <guid isPermaLink="false">10871699</guid>
+  </item>
+  <item>
+    <title>&lt;p&gt;Ngo v. Garland&lt;/p&gt;
+</title>
+    <link>https://www.ca10.uscourts.gov/sites/ca10/files/opinions/010110603801.pdf</link>
+    <description>Docket#: 21-9517 - Date Issued: Fri Nov 12 2021 - Unpublished Order and Judgment</description>
+     <pubDate>&lt;span class=&quot;date-display-single&quot; property=&quot;dc:date&quot; datatype=&quot;xsd:dateTime&quot; content=&quot;2021-11-12T00:00:00-07:00&quot;&gt;Fri Nov 12 2021&lt;/span&gt;</pubDate>
+ <dc:creator>Board of Immigration Appeals</dc:creator>
+ <guid isPermaLink="false">10871708</guid>
+  </item>
+  <item>
+    <title>&lt;p&gt;Blanco-Valdovinos, et al. v. Garland&lt;/p&gt;
+</title>
+    <link>https://www.ca10.uscourts.gov/sites/ca10/files/opinions/010110603734.pdf</link>
+    <description>Docket#: 21-9512 - Date Issued: Fri Nov 12 2021 - Unpublished Order and Judgment</description>
+     <pubDate>&lt;span class=&quot;date-display-single&quot; property=&quot;dc:date&quot; datatype=&quot;xsd:dateTime&quot; content=&quot;2021-11-12T00:00:00-07:00&quot;&gt;Fri Nov 12 2021&lt;/span&gt;</pubDate>
+ <dc:creator>Board of Immigration Appeals</dc:creator>
+ <guid isPermaLink="false">10871674</guid>
+  </item>
+  <item>
+    <title>&lt;p&gt;Grant, et al. v. Crow, et al.&lt;/p&gt;
+</title>
+    <link>https://www.ca10.uscourts.gov/sites/ca10/files/opinions/010110604402.pdf</link>
+    <description>Docket#: 21-6139 - Date Issued: Fri Nov 12 2021 - Unpublished Order and Judgment</description>
+     <pubDate>&lt;span class=&quot;date-display-single&quot; property=&quot;dc:date&quot; datatype=&quot;xsd:dateTime&quot; content=&quot;2021-11-12T00:00:00-07:00&quot;&gt;Fri Nov 12 2021&lt;/span&gt;</pubDate>
+ <dc:creator>United States District Court for the Western District of Oklahoma - Oklahoma City</dc:creator>
+ <guid isPermaLink="false">10871978</guid>
+  </item>
+  </channel>
 </rss>


### PR DESCRIPTION
The RSS feed changed its XML document structure. The scraper was updated to adapt to the new document structure.
The test case included only has 'Unpublished' examples. It's not possible to search for examples in XML with status 'Published' because the RSS feed is replaced every day.

http://www.ca10.uscourts.gov/opinions/new/daily_decisions.rss

Closes #417 