### PR TITLE
Adds support for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cchardet>=1.1.2
 certifi>=2017.4.17
 chardet<3.1.0,>=3.0.2
 cssselect
-feedparser==6.0.2
+feedparser==6.0.8
 geonamescache==1.3.0
 html5lib
 lxml~=4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ cchardet>=1.1.2
 certifi>=2017.4.17
 chardet<3.1.0,>=3.0.2
 cssselect
-feedparser==5.2.1
+feedparser==6.0.2
 geonamescache==1.3.0
 html5lib
 lxml~=4.0


### PR DESCRIPTION
Library `feedparser` 5.2.1 fails with Python 3.9 and 3.10. Version **6.0.8** works with supported Python versions **3.7 to 3.10**. 


Close: #422 