### PR TITLE
Fixes docket and case name's separator for Connecticut Appellate Court 

### DIFF
--- a/juriscraper/opinions/united_states/state/conn.py
+++ b/juriscraper/opinions/united_states/state/conn.py
@@ -3,23 +3,19 @@ CourtID: conn
 Court Short Name: Conn.
 Author: Asadullah Baig <asadullahbeg@outlook.com>
 History:
-- 2014-07-11: created
-- 2014-08-08, mlr: updated to fix InsanityError on case_dates
-- 2014-09-18, mlr: updated XPath to fix InsanityError on docket_numbers
-- 2015-06-17, mlr: made it more lenient about date formatting
-- 2016-07-21, arderyp: fixed to handle altered site format
-- 2017-01-10, arderyp: restructured to handle new format use case that includes
-        opinions without dates and flagged for 'future' publication
-- 2022-02-02, satsuki-chan: Fixed docket and name separator, changed super
-    class to OpinionSiteLinear
+    - 2014-07-11: created
+    - 2014-08-08, mlr: updated to fix InsanityError on case_dates
+    - 2014-09-18, mlr: updated XPath to fix InsanityError on docket_numbers
+    - 2015-06-17, mlr: made it more lenient about date formatting
+    - 2016-07-21, arderyp: fixed to handle altered site format
+    - 2017-01-10, arderyp: restructured to handle new format use case that includes opinions without dates and flagged for 'future' publication
+    - 2022-02-02, satsuki-chan: Fixed docket and name separator, changed super class to OpinionSiteLinear
 """
 
+import re
 from datetime import date
 
-from lxml import etree
-
-from juriscraper.AbstractSite import logger
-from juriscraper.lib.string_utils import convert_date_string, normalize_dashes
+from juriscraper.lib.string_utils import normalize_dashes
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
@@ -27,71 +23,38 @@ class Site(OpinionSiteLinear):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
-        current_year = date.today().strftime("%y")
-        self.url = f"http://www.jud.ct.gov/external/supapp/archiveAROsup{current_year}.htm"
+        self.year = date.today().strftime("%y")
+        self.url = f"http://www.jud.ct.gov/external/supapp/archiveAROsup{self.year}.htm"
         self.status = "Published"
         self.cases = []
+        self.docket_regex = r"SC\d+"
 
     def _process_html(self) -> None:
         """Process the html and extract out the opinions
 
         :return: None
         """
-        # Strip inconsistently placed <font> and <br>
-        # tags that make stable coverage almost impossible
-        etree.strip_tags(self.html, "font", "br")
-        path = '//table[@id="AutoNumber1"]//ul'
-        for ul in self.html.xpath(path):
-            preceding = ul.xpath("./preceding::*[1]")[0]
-            preceding_text = " ".join(preceding.text_content().split()).strip(
-                ":"
+        date = None
+        for row in self.html.xpath(
+            r"//*[re:match(text(), '.*\d{1,2}/\d{1,2}/\d{2,4}')] | //table[@id='AutoNumber1']//li",
+            namespaces={"re": "http://exslt.org/regular-expressions"},
+        ):
+            dates = re.findall(r"\d{1,2}/\d{1,2}/\d{2,4}", row.text_content())
+            if dates:
+                date = dates[0]
+                continue
+            if not date:
+                continue
+            link_node = row.xpath(".//a")[0]
+            link_text = link_node.text_content().strip()
+            name = normalize_dashes(row.text_content().replace(link_text, ""))
+            name = re.sub(r" - ", "", name).strip()
+            dockets = ", ".join(re.findall(self.docket_regex, link_text))
+            self.cases.append(
+                {
+                    "date": date,
+                    "url": link_node.attrib["href"],
+                    "docket": dockets,
+                    "name": name,
+                }
             )
-            # Skip sections that are marked to be published at future date
-            if preceding_text and not preceding_text.lower().endswith(" date"):
-                # Below will fail if they change up string format
-                date_string = preceding_text.split()[-1]
-                for element in ul.xpath("./li | ./a"):
-                    if element.tag == "li":
-                        text = normalize_dashes(
-                            " ".join(element.text_content().split())
-                        )
-                        if not text:
-                            continue
-                        anchor = element.xpath(".//a")[0]
-                    elif element.tag == "a":
-                        # Malformed html, see connappct_example.html
-                        anchor = element
-                        glued = f"{anchor.text_content()} {anchor.tail}"
-                        text = normalize_dashes(" ".join(glued.split()))
-                    docket = (
-                        text.split("-")[0]
-                        .split("Concurrence")[0]
-                        .split("Dissent")[0]
-                        .split("Appendix")[0]
-                    )
-                    try:
-                        name = text.split("-", 1)[1]
-                    except IndexError:
-                        # Expected link text:
-                        # - "AC44191 Dissent Marshall v. Commissioner of Motor Vehicles"
-                        try:
-                            name = text.split("Dissent", 1)[1]
-                        except IndexError:
-                            try:
-                                name = text.split("Concurrence", 1)[1]
-                            except IndexError:
-                                try:
-                                    name = text.split("Appendix", 1)[1]
-                                except:
-                                    logger.info(
-                                        f"Name not found for case: '{text}'"
-                                    )
-                                    continue
-                    self.cases.append(
-                        {
-                            "date": date_string,
-                            "url": anchor.xpath("./@href")[0],
-                            "docket": docket,
-                            "name": name,
-                        }
-                    )

--- a/juriscraper/opinions/united_states/state/conn.py
+++ b/juriscraper/opinions/united_states/state/conn.py
@@ -2,47 +2,46 @@
 CourtID: conn
 Court Short Name: Conn.
 Author: Asadullah Baig <asadullahbeg@outlook.com>
-
 History:
- - 2014-07-11: created
- - 2014-08-08, mlr: updated to fix InsanityError on case_dates
- - 2014-09-18, mlr: updated XPath to fix InsanityError on docket_numbers
- - 2015-06-17, mlr: made it more lenient about date formatting
- - 2016-07-21, arderyp: fixed to handle altered site format
- - 2017-01-10, arderyp: restructured to handle new format use case that includes
+- 2014-07-11: created
+- 2014-08-08, mlr: updated to fix InsanityError on case_dates
+- 2014-09-18, mlr: updated XPath to fix InsanityError on docket_numbers
+- 2015-06-17, mlr: made it more lenient about date formatting
+- 2016-07-21, arderyp: fixed to handle altered site format
+- 2017-01-10, arderyp: restructured to handle new format use case that includes
         opinions without dates and flagged for 'future' publication
+- 2022-02-02, satsuki-chan: Fixed docket and name separator, changed super
+    class to OpinionSiteLinear
 """
 
 from datetime import date
 
 from lxml import etree
 
+from juriscraper.AbstractSite import logger
 from juriscraper.lib.string_utils import convert_date_string, normalize_dashes
-from juriscraper.OpinionSite import OpinionSite
+from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
-class Site(OpinionSite):
+class Site(OpinionSiteLinear):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.crawl_date = date.today()
-        self.url = "http://www.jud.ct.gov/external/supapp/archiveAROsup{year}.htm".format(
-            year=self.crawl_date.strftime("%y")
-        )
         self.court_id = self.__module__
+        current_year = date.today().strftime("%y")
+        self.url = f"http://www.jud.ct.gov/external/supapp/archiveAROsup{current_year}.htm"
+        self.status = "Published"
         self.cases = []
 
-    def _download(self, request_dict={}):
-        html = super()._download(request_dict)
-        self._extract_cases_from_html(html)
-        return html
+    def _process_html(self) -> None:
+        """Process the html and extract out the opinions
 
-    def _extract_cases_from_html(self, html):
-        """Build list of data dictionaries, one dictionary per case (table row)."""
+        :return: None
+        """
         # Strip inconsistently placed <font> and <br>
         # tags that make stable coverage almost impossible
-        etree.strip_tags(html, "font", "br")
+        etree.strip_tags(self.html, "font", "br")
         path = '//table[@id="AutoNumber1"]//ul'
-        for ul in html.xpath(path):
+        for ul in self.html.xpath(path):
             preceding = ul.xpath("./preceding::*[1]")[0]
             preceding_text = " ".join(preceding.text_content().split()).strip(
                 ":"
@@ -51,7 +50,6 @@ class Site(OpinionSite):
             if preceding_text and not preceding_text.lower().endswith(" date"):
                 # Below will fail if they change up string format
                 date_string = preceding_text.split()[-1]
-                case_date = convert_date_string(date_string)
                 for element in ul.xpath("./li | ./a"):
                     if element.tag == "li":
                         text = normalize_dashes(
@@ -65,28 +63,35 @@ class Site(OpinionSite):
                         anchor = element
                         glued = f"{anchor.text_content()} {anchor.tail}"
                         text = normalize_dashes(" ".join(glued.split()))
+                    docket = (
+                        text.split("-")[0]
+                        .split("Concurrence")[0]
+                        .split("Dissent")[0]
+                        .split("Appendix")[0]
+                    )
+                    try:
+                        name = text.split("-", 1)[1]
+                    except IndexError:
+                        # Expected link text:
+                        # - "AC44191 Dissent Marshall v. Commissioner of Motor Vehicles"
+                        try:
+                            name = text.split("Dissent", 1)[1]
+                        except IndexError:
+                            try:
+                                name = text.split("Concurrence", 1)[1]
+                            except IndexError:
+                                try:
+                                    name = text.split("Appendix", 1)[1]
+                                except:
+                                    logger.info(
+                                        f"Name not found for case: '{text}'"
+                                    )
+                                    continue
                     self.cases.append(
                         {
-                            "date": case_date,
+                            "date": date_string,
                             "url": anchor.xpath("./@href")[0],
-                            "docket": text.split("-")[0]
-                            .replace("Concurrence", "")
-                            .replace("Dissent", ""),
-                            "name": text.split("-", 1)[1],
+                            "docket": docket,
+                            "name": name,
                         }
                     )
-
-    def _get_case_names(self):
-        return [case["name"] for case in self.cases]
-
-    def _get_download_urls(self):
-        return [case["url"] for case in self.cases]
-
-    def _get_case_dates(self):
-        return [case["date"] for case in self.cases]
-
-    def _get_docket_numbers(self):
-        return [case["docket"] for case in self.cases]
-
-    def _get_precedential_statuses(self):
-        return ["Published"] * len(self.cases)

--- a/juriscraper/opinions/united_states/state/connappct.py
+++ b/juriscraper/opinions/united_states/state/connappct.py
@@ -3,6 +3,8 @@ CourtID: connctapp
 Court Short Name: Connappct.
 Author: Asadullah Baig<asadullahbeg@outlook.com>
 Date created: 2014-07-11
+History:
+- 2022-02-02, satsuki-chan: Fixed docket and name separator, changed super class to OpinionSiteLinear
 """
 
 from datetime import date
@@ -13,8 +15,6 @@ from juriscraper.opinions.united_states.state import conn
 class Site(conn.Site):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.crawl_date = date.today()
-        self.url = "http://www.jud.ct.gov/external/supapp/archiveAROap{year}.htm".format(
-            year=self.crawl_date.strftime("%y")
-        )
         self.court_id = self.__module__
+        current_year = date.today().strftime("%y")
+        self.url = f"http://www.jud.ct.gov/external/supapp/archiveAROap{current_year}.htm"

--- a/juriscraper/opinions/united_states/state/connappct.py
+++ b/juriscraper/opinions/united_states/state/connappct.py
@@ -4,10 +4,8 @@ Court Short Name: Connappct.
 Author: Asadullah Baig<asadullahbeg@outlook.com>
 Date created: 2014-07-11
 History:
-- 2022-02-02, satsuki-chan: Fixed docket and name separator, changed super class to OpinionSiteLinear
+    - 2022-02-02, satsuki-chan: Fixed docket and name separator, changed super class to OpinionSiteLinear
 """
-
-from datetime import date
 
 from juriscraper.opinions.united_states.state import conn
 
@@ -16,5 +14,5 @@ class Site(conn.Site):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
-        current_year = date.today().strftime("%y")
-        self.url = f"http://www.jud.ct.gov/external/supapp/archiveAROap{current_year}.htm"
+        self.url = f"http://www.jud.ct.gov/external/supapp/archiveAROap{self.year}.htm"
+        self.docket_regex = r"AC\d+"

--- a/tests/examples/opinions/united_states/connappct_example_4.compare.json
+++ b/tests/examples/opinions/united_states/connappct_example_4.compare.json
@@ -1,0 +1,412 @@
+[
+  {
+    "case_dates": "2022-02-01",
+    "case_names": "Salamone v. Wesleyan University",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP128.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43819",
+    "case_name_shorts": "Salamone"
+  },
+  {
+    "case_dates": "2022-02-01",
+    "case_names": "Ostapowicz v. Wisniewski",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP117.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43944",
+    "case_name_shorts": "Ostapowicz"
+  },
+  {
+    "case_dates": "2022-02-01",
+    "case_names": "Nutmeg State Crematorium, LLC v. Dept. of Energy & Enviromental Protection",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP114.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43834",
+    "case_name_shorts": ""
+  },
+  {
+    "case_dates": "2022-02-01",
+    "case_names": "Ill v. Manzo-III",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP426.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC42735",
+    "case_name_shorts": "Ill"
+  },
+  {
+    "case_dates": "2022-02-01",
+    "case_names": "Freidburg v. Kurtz",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP120.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43695",
+    "case_name_shorts": "Freidburg"
+  },
+  {
+    "case_dates": "2022-02-01",
+    "case_names": "DiTullio v. LM General Ins. Co.",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP423.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44114",
+    "case_name_shorts": "DiTullio"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "Wooden v. Perez",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP110.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44301",
+    "case_name_shorts": "Wooden"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "Taylor v. Pollner",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP115.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44517",
+    "case_name_shorts": "Taylor"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "Taber v. Taber",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP113.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44272",
+    "case_name_shorts": "Taber"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "State v. Prudhomme",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP104.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43302",
+    "case_name_shorts": "Prudhomme"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "State v. Jones",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP107.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC42674",
+    "case_name_shorts": "Jones"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "State v. Cusson",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP87.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43352",
+    "case_name_shorts": "Cusson"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "Stanley v. Barone",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP106.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43889",
+    "case_name_shorts": "Stanley"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "Rider v. Rider",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP108.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44067",
+    "case_name_shorts": "Rider"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "R. S. v. E. S.",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP112.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43630",
+    "case_name_shorts": ""
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "Kiyak v. Dept. of Agriculture",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP111.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43314",
+    "case_name_shorts": "Kiyak"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "Karen v. Loftus",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP109.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43488",
+    "case_name_shorts": "Karen"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "Baltas v. Commissioner of Correction",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP103.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44259",
+    "case_name_shorts": "Baltas"
+  },
+  {
+    "case_dates": "2022-01-25",
+    "case_names": "Avon v. Freedom of Information Commission",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP105.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44255",
+    "case_name_shorts": "Avon"
+  },
+  {
+    "case_dates": "2022-01-18",
+    "case_names": "State v. McCarthy",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP97.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43785",
+    "case_name_shorts": "McCarthy"
+  },
+  {
+    "case_dates": "2022-01-18",
+    "case_names": "State v. LaMotte",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP98.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43973",
+    "case_name_shorts": "LaMotte"
+  },
+  {
+    "case_dates": "2022-01-18",
+    "case_names": "Salce v. Cardello",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP99.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43648",
+    "case_name_shorts": "Salce"
+  },
+  {
+    "case_dates": "2022-01-18",
+    "case_names": "Poce v. O & G Industries, Inc.",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP100Y.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43511",
+    "case_name_shorts": "Poce"
+  },
+  {
+    "case_dates": "2022-01-18",
+    "case_names": "Poce v. O & G Industries, Inc.",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP100X.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43511",
+    "case_name_shorts": "Poce"
+  },
+  {
+    "case_dates": "2022-01-18",
+    "case_names": "Poce v. O & G Industries, Inc.",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP100.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43511",
+    "case_name_shorts": "Poce"
+  },
+  {
+    "case_dates": "2022-01-18",
+    "case_names": "Marshall v. Commissioner of Motor Vehicles",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP102E.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44191",
+    "case_name_shorts": "Marshall"
+  },
+  {
+    "case_dates": "2022-01-18",
+    "case_names": "Marshall v. Commissioner of Motor Vehicles",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP210/210AP102.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44191",
+    "case_name_shorts": "Marshall"
+  },
+  {
+    "case_dates": "2022-01-11",
+    "case_names": "Zubrowski v. Commissioner of Correction",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP90.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43981",
+    "case_name_shorts": "Zubrowski"
+  },
+  {
+    "case_dates": "2022-01-11",
+    "case_names": "State v. Wilson",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP88.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC42914",
+    "case_name_shorts": "Wilson"
+  },
+  {
+    "case_dates": "2022-01-11",
+    "case_names": "State v. Reed",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP101.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC42509",
+    "case_name_shorts": "Reed"
+  },
+  {
+    "case_dates": "2022-01-11",
+    "case_names": "Purnell v. Inland Wetlands & Watercourses Commission",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP422.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44083",
+    "case_name_shorts": "Purnell"
+  },
+  {
+    "case_dates": "2022-01-11",
+    "case_names": "Parker v.Zoning Commision",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP412.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44130",
+    "case_name_shorts": "Parker v.Zoning Commision"
+  },
+  {
+    "case_dates": "2022-01-11",
+    "case_names": "LendingHome Marketplace, LLC v. Traditions Oil Group, LLC",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP96.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44450",
+    "case_name_shorts": ""
+  },
+  {
+    "case_dates": "2022-01-11",
+    "case_names": "Cokic v. Fiore Powersports, LLC",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP95.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44368",
+    "case_name_shorts": "Cokic"
+  },
+  {
+    "case_dates": "2022-01-11",
+    "case_names": "Baker v. Argueta",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP94.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43827",
+    "case_name_shorts": "Baker"
+  },
+  {
+    "case_dates": "2022-01-11",
+    "case_names": "Aldin Associates Ltd. Partnership v. State",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP421.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44102",
+    "case_name_shorts": ""
+  },
+  {
+    "case_dates": "2022-01-04",
+    "case_names": "Zakko v. Kasir",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP93.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44440",
+    "case_name_shorts": "Zakko"
+  },
+  {
+    "case_dates": "2022-01-04",
+    "case_names": "Walzer v. Walzer",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP86.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC44313",
+    "case_name_shorts": "Walzer"
+  },
+  {
+    "case_dates": "2022-01-04",
+    "case_names": "State v. Rosario",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP81.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC42827",
+    "case_name_shorts": "Rosario"
+  },
+  {
+    "case_dates": "2022-01-04",
+    "case_names": "Lasso v. Valley Tree & Landscaping, LLC",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP85.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43813",
+    "case_name_shorts": "Lasso"
+  },
+  {
+    "case_dates": "2022-01-04",
+    "case_names": "Housing Authority v. Stevens",
+    "download_urls": "tests/examples/opinions/united_states/Cases/AROap/AP209/209AP82.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "AC43471",
+    "case_name_shorts": "Stevens"
+  }
+]

--- a/tests/examples/opinions/united_states/connappct_example_4.html
+++ b/tests/examples/opinions/united_states/connappct_example_4.html
@@ -1,0 +1,410 @@
+<!doctype HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=windows-1252">
+<meta name="GENERATOR" content="Microsoft FrontPage 6.0">
+<meta name="ProgId" content="FrontPage.Editor.Document">
+<meta http-equiv="Content-Language" content="en-us">
+<meta NAME="keywords" CONTENT="Connecticut, Judicial, Civil, Opinion, Criminal, Law Libraries, Juror, Jury, Victim, Small Claims, Justice,  Supreme, Trial, Appellate, Court, Judical, Attorney, Judge, Court, docket, Housing, Landlord, Grievance, Bar Exam, Legal, Probate, Superior, Magistrate, Marshal">
+<title>Officially Released Appellate Court Opinions - 2018</title>
+<script type="text/javascript" language="JavaScript1.2" src="stmenu.js"></script>
+<style>A:hover {color: #CC0000; font-family: Arial}
+.aro_text {
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 13px;
+	text-align: left;
+	line-height: 19px;
+}
+.Head_Times {
+	font-family: "Times New Roman", Times, serif;
+	font-size: 24px;
+	font-weight: bold;
+	color: #1F3776;
+}
+.auto-style1 {
+	border-collapse: collapse;
+	border-style: solid;
+	border-width: 1px;
+}
+.auto-style2 {
+	font-weight: bold;
+	border-style: solid;
+	border-width: 0;
+}
+</style>
+<link href="jud.css" rel="stylesheet" type="text/css">
+</head>
+
+<body marginheight="0" marginwidth="10" topmargin="0" background="smalback10.gif" rightmargin="0">
+
+<table border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse" bordercolor="#111111" width="100%">
+    <tr>
+        <td bgcolor="#1F3776" height="3"><map name="FPMap1">
+        <area alt="History of the Connecticut Judicial Seal"
+        coords="512, 36, 32" shape="circle" href="../../sealhistory2.htm">
+        <area href="../../index.html" shape="default" alt="Home">
+        <area href="../../index.html" coords="0, 0, 10000, 10000" shape="rect" alt="Home">
+        </map>
+        <img border="0" src="longjudbanner770left-nobot.jpg"
+        align="left" alt="Banner" hspace="0" usemap="#FPMap1" width="555" height="72"><a href="../../index.html"><img
+        border="0" src="longjudbanner770right-nobot.jpg"
+        align="right" hspace="0" alt="Banner" width="195" height="72"></a></td>
+    </tr>
+    <tr>
+        <td bgcolor="#CFC0A7"></td>
+    </tr>
+    <tr>
+        <td height="2" bgcolor="#7a5a5b"></td>
+    </tr>
+  </table>
+
+<div align="left">
+    <table border="0" cellpadding="0"
+    style="border-collapse: collapse" bordercolor="#111111" width="99%" align="left">
+        <tr>
+            <td align="left" width="161" valign="top"><br>
+
+            <!--webbot bot="Include" U-Include="includenav.htm"
+            TAG="BODY" startspan -->
+
+<div align="left">
+    <table border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse" bordercolor="#111111" width="140">
+        <tr>
+            <td><map name="FPMap0_I1">
+            <area href="http://www.jud.ct.gov/jud2.htm" shape="rect" coords="0, 14, 121, 34" alt="Case Look-up">
+            <area href="http://www.jud.ct.gov/courts.htm" shape="rect" coords="0, 34, 122, 54" alt="Courts">
+            <area href="http://www.jud.ct.gov/directories.htm"
+            shape="rect" coords="0, 55, 119, 79" alt="Directories">
+            <area alt="Educational Resources" coords="0, 80, 120, 110" shape="rect" href="http://www.jud.ct.gov/EdResources.htm">
+            <area alt="E-Services" coords="0, 110, 118, 135" shape="rect"
+            href="http://www.jud.ct.gov/external/super/E-Services/efile/">
+            <area href="http://www.jud.ct.gov/jury/" shape="rect"
+            coords="0, 178, 131, 200" alt="Juror Information">
+            <area alt="Online Media Resource Center" coords="0, 201, 127, 237"
+            shape="rect" href="http://www.jud.ct.gov/external/media/">
+            <area href="http://www.jud.ct.gov/opinions.htm" shape="rect"
+            coords="0, 239, 127, 260" alt="Opinions">
+            <area href="http://www.jud.ct.gov/opportunities.htm"
+            shape="rect" coords="0, 260, 125, 281" alt="Opportunities">
+            <area href="http://www.jud.ct.gov/selfhelp.htm" shape="rect"
+            coords="0, 281, 122, 300" alt="Self-Help">
+            <area alt="Frequently Asked Questions" coords="2, 157, 120, 177"
+            shape="rect" href="http://www.jud.ct.gov/faq/Default.htm">
+            <area alt="Home" href="http://www.jud.ct.gov/" shape="rect"
+            coords="2, 300, 121, 301">
+            <area alt="Attorneys" coords="0, 0, 121, 14" shape="rect"
+            href="http://www.jud.ct.gov/attorneys.htm">
+            <area coords="3, 138, 121, 157" shape="rect" href="http://www.jud.ct.gov/espanol.htm">
+			<area href="../../index.html" shape="rect" coords="2, 302, 121, 318">
+            </map>
+            <img border="0" src="../imgs/LeftLinkMenu5a.gif" usemap="#FPMap0_I1"
+            align="left" alt="menu" width="122" height="319"></td>
+        </tr>
+        <tr>
+            <td>
+            <div align="left">
+                <table cellspacing="0" width="90" border="0" style="border-collapse: collapse" cellpadding="0" align="left" bordercolor="#1F3776" bgcolor="#1F3776">
+                    <tr>
+                        <td nowrap align="left" width="20%">&nbsp;&nbsp;</td>
+                        <td nowrap align="left" width="80%" bgcolor="#1F3776">
+                        <small><font color="#1f3776" face="Arial">
+                        <form name="seek" method="GET" action="/Search/JudSearch.aspx">
+                            <input type="hidden" name="col" value="allconn">
+                            <input type="hidden" name="qp1" value="url:www.jud.ct.gov">
+                            <input type="hidden" name="qs1" value>
+                            <input type="hidden" name="qc" value>
+                            <input type="hidden" name="ws" value="0">
+                            <input type="hidden" name="qm" value="0">
+                            <input type="hidden" name="st" value="1">
+                            <input type="hidden" name="nh" value="20">
+                            <input type="hidden" name="lk" value="1">
+                            <input type="hidden" name="rf" value="0">
+                            <input type="hidden" name="oq" value>
+                            <input type="hidden" name="rq" value="0">
+                            <input type="hidden" name="qp2" value="url:www.jud.ct.gov">
+                            <input type="hidden" name="qp3" value="url:www.jud.ct.gov">
+                            <input type="hidden" name="qs2" value>
+                            <input type="hidden" name="qp" value="url:www.jud.ct.gov">
+                            <input type="hidden" name="qs" value>
+                            <input type="hidden" name="SinglePane" value="Y">
+                            <table cellpadding="2" width="100%" border="0" style="border-collapse: collapse" bordercolor="#111111">
+                                <tr valign="top">
+                                    <td width="67%">
+                                    <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                                        <tr>
+                                            <td bgcolor="#1f3776">
+                                            <table width="100%" border="0" style="border-collapse: collapse" cellpadding="2">
+                                                <tr>
+                                                    <td nowrap bgcolor="#1F3776">
+                                                    <small>
+                                                    <font color="#1f3776" face="Arial">
+                                                    <b>
+                                                    <input type="text" name="qt" size="14" value maxlength="2047">
+                                                    <br>
+                                                    <input type="image" value="Search" src="../../imgs/SEARCH.gif" alt="Search" border="0" align="middle" name="Search" vspace="1" width="50" height="16">
+                                                    </b></font></small></td>
+                                                </tr>
+                                            </table>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                    </td>
+                                </tr>
+                            </table>
+                        </form>
+                        </font></small></td>
+                    </tr>
+                </table>
+            </div>
+            </td>
+        </tr>
+    </table>
+</div>
+
+<!--webbot bot="Include" i-checksum="38069" endspan --><p align="center">&nbsp;</p>
+            <p align="center">&nbsp;</p>
+            <p align="center">&nbsp;</p>
+            <p align="center">&nbsp;</p>
+            <p align="center">&nbsp;</p>
+            <p align="center">&nbsp;</td>
+            <td align="left" width="5" valign="top">&nbsp;</td>
+            <td align="left" valign="top">
+            &nbsp;<table border="0" cellpadding="0" cellspacing="0"
+            style="border-collapse: collapse" bordercolor="#111111"
+            width="100%" id="AutoNumber1">
+              <tr>
+                <td width="70%" align="left" valign="top">
+                <p class="Head_Times">Archive of Appellate Court Opinions</p>
+
+
+                <span class="Header_red" style="font-size:1.6em">2022 </span>
+				&nbsp;<span class="text"><a href="archiveAROap.htm">Previous Years</a></span><br>
+
+
+
+				&nbsp;<table border="0" cellpadding="3"
+                style="border-collapse: collapse" bordercolor="#111111"
+                width="95%" bgcolor="#EEEEEE">
+                  <tr>
+                    <td bgcolor="#DDDDDD" align="left" valign="top" class="auto-style2" style="width: 100%">
+        <font face="arial, helvetica" size="4" color="#1F3776">To Search:
+                    </font>
+        <font face="arial, helvetica" size="2" color="#1F3776">Hit Control, F,
+                    on your keyboard, and enter the name.</font></td>
+                  </tr>
+                  <tr>
+                    <td width="100%" bgcolor="#FFFFFF" align="left"
+                    valign="top">
+        			<br><span class="aro_text">
+					<strong>
+					<a href="http://www.jud.ct.gov/colp/publicat.htm">Information on how to purchase the Connecticut Appellate Reports</a></strong></span></td>
+                  </tr>
+                </table>
+                </td>
+                <td width="30%" align="center" valign="top">
+                <table
+                cellpadding="4" cellspacing="4" bordercolor="#1F3776"
+                width="90%" id="AutoNumber2" class="auto-style1">
+                  <tr>
+                    <td width="100%" bgcolor="#1F3776">
+                    <p align="center"><font face="Arial" color="#FFFFFF"><b>
+                    Quick Links</b></font></td>
+                  </tr>
+                  <tr>
+                    <td width="100%" bgcolor="#DDDDDD" align="left">
+                    <font size="2" face="Arial"><a href="aro.htm">Advance
+                    Release Opinions</a></font></td>
+                  </tr>
+                  <tr>
+                    <td width="100%" bgcolor="#DDDDDD" align="left">
+                    <font face="Arial" size="2"><a href="archiveAROap.htm">
+                    Appellate Court Archive</a></font></td>
+                  </tr>
+                  <tr>
+                    <td width="100%" bgcolor="#DDDDDD" align="left">
+                    <font face="Arial" size="2"><a href="archiveAROmd.htm">
+                    Memorandum Archive </a></font></td>
+                  </tr>
+                  <tr>
+                    <td width="100%" bgcolor="#DDDDDD" align="left">
+                    <font size="2" face="Arial"><a href="archiveAROsup.htm">
+                    Supreme Court Archive </a></font></td>
+                  </tr>
+                  </table>
+                </td>
+              </tr>
+              <tr>
+                <td width="100%" align="left" valign="top" colspan="2">
+        <b><font face="Arial" size="2">To Be Published in the Connecticut Law
+		Journal of 02/01/2022:</font></b><ul>
+			<li><font face="Arial"><a href="Cases/AROap/AP210/210AP423.pdf">
+			<font size="2">AC44114</font></a><font size="2"> - DiTullio v. LM General Ins. Co.</font></font></li>
+			<li><font face="Arial"><a href="Cases/AROap/AP210/210AP426.pdf">
+			<font size="2">AC42735</font></a><font size="2"> - Ill v. Manzo-III</font></font></li>
+			<li><font face="Arial"><a href="Cases/AROap/AP210/210AP114.pdf">
+			<font size="2">AC43834</font></a><font size="2"> - Nutmeg State Crematorium, LLC v. Dept. of
+					Energy &amp; Enviromental Protection</font></font></li>
+			<li><font face="Arial"><a href="Cases/AROap/AP210/210AP117.pdf">
+			<font size="2">AC43944</font></a><font size="2"> - Ostapowicz v. Wisniewski</font></font></li>
+			<li><font face="Arial"><a href="Cases/AROap/AP210/210AP120.pdf">
+			<font size="2">AC43695</font></a><font size="2"> - Freidburg v. Kurtz</font></font></li>
+			<li><font face="Arial"><a href="Cases/AROap/AP210/210AP128.pdf">
+			<font size="2">AC43819</font></a><font size="2"> - Salamone v. Wesleyan University</font></font></li>
+		</ul>
+		<p><b><font face="Arial" size="2">Published in the Connecticut Law
+		Journal of 01/25/2022:</font></b></p>
+		<ul>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP87.pdf">
+					<font size="2">AC43352</font></a><font size="2"> -
+					State v. Cusson</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP103.pdf">
+					<font size="2">AC44259</font></a><font size="2"> -
+					Baltas v. Commissioner of Correction</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP104.pdf">
+					<font size="2">AC43302</font></a><font size="2"> -
+					State v. Prudhomme</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP105.pdf">
+					<font size="2">AC44255</font></a><font size="2"> -
+					Avon v. Freedom of Information Commission</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP106.pdf">
+					<font size="2">AC43889</font></a><font size="2"> -
+					Stanley v. Barone</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP107.pdf">
+					<font size="2">AC42674</font></a><font size="2"> -
+					State v. Jones</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP108.pdf">
+					<font size="2">AC44067</font></a><font size="2"> -
+					Rider v. Rider</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP109.pdf">
+					<font size="2">AC43488</font></a><font size="2"> -
+					Karen v. Loftus</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP110.pdf">
+					<font size="2">AC44301</font></a><font size="2"> -
+					Wooden v. Perez</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP111.pdf">
+					<font size="2">AC43314</font></a><font size="2"> -
+					Kiyak v. Dept. of Agriculture</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP112.pdf">
+					<font size="2">AC43630</font></a><font size="2"> -
+					R. S. v. E. S.</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP113.pdf">
+					<font size="2">AC44272</font></a><font size="2"> -
+					Taber v. Taber</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP115.pdf">
+					<font size="2">AC44517</font></a><font size="2"> -
+					Taylor v. Pollner</font></font></li>
+				</ul>
+        <table border="0" cellpadding="0" width="100%" cellspacing="0"
+                style="border-collapse: collapse" bordercolor="#111111">
+            <tr>
+
+                            </tr>
+        </table>
+                </td>
+              </tr>
+              <tr>
+<!---------------------------------Start adding "Published in the Connecticut Law Journal of (date)"-------------------------------------------------->
+
+                <td width="100%" align="left" valign="top" colspan="2">
+
+                <b><font face="Arial" size="2">Published in the Connecticut Law Journal on 01/18/2022:</font></b><ul>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP97.pdf">
+					<font size="2">AC43785</font></a><font size="2"> - State v. McCarthy</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP98.pdf">
+					<font size="2">AC43973</font></a><font size="2"> - State v. LaMotte</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP99.pdf">
+					<font size="2">AC43648</font></a><font size="2"> - Salce v. Cardello</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP100.pdf">
+					<font size="2">AC43511</font></a><font size="2"> - Poce v. O &amp; G Industries, Inc.</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP100X.pdf">
+					<font size="2">AC43511&nbsp; Appendix</font></a><font size="2"> - Poce v. O &amp; G Industries, Inc.</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP100Y.pdf">
+					<font size="2">AC43511&nbsp; Appendix</font></a><font size="2"> - Poce v. O &amp; G Industries, Inc.</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP102.pdf">
+					<font size="2">AC44191</font></a><font size="2"> - Marshall v. Commissioner of Motor Vehicles</font></font></li>
+					<li><font face="Arial"><a href="Cases/AROap/AP210/210AP102E.pdf">
+					<font size="2">AC44191 Dissent</font></a><font size="2"> Marshall v. Commissioner of Motor
+					Vehicles</font></font></li>
+				</ul>
+				<p><b><font face="Arial" size="2">Published in the Connecticut Law Journal on 01/11/2022:</font></b>
+
+				</p>
+
+				<ul>
+					<li><font face="Arial"><a href="Cases/AROap/AP209/209AP412.pdf"><font size="2">AC44130</font></a><font size="2"> - Parker v.Zoning Commision</font></font></li>
+
+					<li><font face="Arial"><a href="Cases/AROap/AP209/209AP422.pdf"><font size="2">AC44083</font></a><font size="2"> - Purnell v. Inland Wetlands &amp; Watercourses Commission</font></font></li>
+
+					<li><font face="Arial"><a href="Cases/AROap/AP209/209AP421.pdf"><font size="2">AC44102</font></a><font size="2"> - Aldin Associates Ltd. Partnership v. State</font></font></li>
+
+					<li><font face="Arial"><a href="Cases/AROap/AP209/209AP88.pdf"><font size="2">AC42914</font></a><font size="2"> - State v. Wilson</font></font></li>
+
+					<li><font face="Arial"><a href="Cases/AROap/AP209/209AP90.pdf"><font size="2">AC43981</font></a><font size="2"> - Zubrowski v. Commissioner of Correction</font></font></li>
+
+					<li><font face="Arial"><a href="Cases/AROap/AP209/209AP94.pdf"><font size="2">AC43827</font></a><font size="2"> - Baker v. Argueta</font></font></li>
+
+					<li><font face="Arial"><a href="Cases/AROap/AP209/209AP95.pdf"><font size="2">AC44368</font></a><font size="2"> - Cokic v. Fiore Powersports, LLC</font></font></li>
+
+					<li><font face="Arial"><a href="Cases/AROap/AP209/209AP96.pdf"><font size="2">AC44450</font></a><font size="2"> - LendingHome Marketplace, LLC v. Traditions Oil Group, LLC</font></font></li>
+
+					<li><font face="Arial"><a href="Cases/AROap/AP209/209AP101.pdf"><font size="2">AC42509</font></a><font size="2"> - State v. Reed</font></font></li>
+				</ul>
+
+				<p><b><font face="Arial" size="2">Published in the Connecticut Law Journal on 01/04/2022:</font></b></p>
+
+				<ul style="color: rgb(0, 0, 0); font-family: &quot;Times New Roman&quot;; font-size: medium; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: -webkit-left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">
+					<li><font face="Arial" size="2"><a href="Cases/AROap/AP209/209AP81.pdf">AC42827</a>&nbsp;-&nbsp;State v. Rosario</font></li>
+					<li><font size="2" face="Arial"><a href="Cases/AROap/AP209/209AP82.pdf">AC43471</a>&nbsp;- Housing Authority v. Stevens</font></li>
+					<li><font size="2" face="Arial"><a href="Cases/AROap/AP209/209AP85.pdf">AC43813</a>&nbsp;- Lasso v. Valley Tree &amp; Landscaping, LLC</font></li>
+					<li><font size="2" face="Arial"><a href="Cases/AROap/AP209/209AP86.pdf">AC44313</a>&nbsp;- Walzer v. Walzer</font></li>
+					<li><font size="2" face="Arial"><a href="Cases/AROap/AP209/209AP93.pdf">AC44440</a>&nbsp;- Zakko v. Kasir</font></li>
+				</ul>
+
+
+								</td>
+
+
+<!---------------------------------End-------------------------------------------------->
+
+ </tr>
+              <tr>
+                <td width="100%" align="left" valign="top" colspan="2">
+</td>
+				</tr>
+				</table></font>
+<p align="center"><font face="Arial" size="2"><a href="#top">Return to Top</a><br>
+<p align="center"><font size="1" face="Arial">
+<a href="../../attorneys.htm">Attorneys</a> |
+<a href="../../jud2.htm">Case Look-up</a> |
+<a href="../../courts.htm">Courts</a> |
+<a href="../../Directories.htm">Directories</a> |
+<a href="../../EdResources.htm">Educational Resources</a> |
+<a href="http://www.jud.ct.gov/external/super/E-Services/efile/">E-Services</a> |
+			<a href="../../espanol.htm">Espa&ntilde;ol</a> |
+<a href="../../faq/Default.htm">FAQ's</a> |
+<a href="../../jury/">Juror Information</a> |
+<a href="../Media/">Media</a> |
+<a href="../../opinions.htm">Opinions</a> |
+<a href="../../opportunities.htm">Opportunities</a> |
+<a href="../../selfhelp.htm">Self-Help</a> |
+<a href="../../index.html">Home</a></font></p>
+<p align="center"><font size="1" face="Arial"><a href="../../legalterms.htm">Common Legal Words</a> |
+<a href="../../contactus.htm">Contact Us</a> |
+<a href="../../sitemap.htm">Site Map</a> | <a href="../../policies.htm">Website
+Polices and Disclaimers</a> </font></p>
+<p align="center"><font face="Arial" color="#000000" size="1">
+Copyright © 2016
+State of Connecticut Judicial Branch<br>
+</font></p>
+				  </td>
+              </tr>
+            </table>
+            </td>
+        </tr>
+        </table>
+</div>
+
+</body>
+
+</html>


### PR DESCRIPTION
Also changed super class to `OpinionSiteLinear`.


Fixes: #479 
Fixes: #[COURTLISTENER-220](https://sentry.io/organizations/freelawproject/issues/2929913663/?referrer=github_integration)