### PR TITLE
Add exception when PACER loging reply is not a valid JSON object

### DIFF
--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -279,8 +279,13 @@ class PacerSession(requests.Session):
             timeout=60,
             data=json.dumps(data),
         )
+        try:
+            response_json = login_post_r.json()
+        except json.JSONDecodeError:
+            message = "Unable to get a valid JSON object to parse the PACER login reply."
+            logger.warning(message)
+            raise PacerLoginException(message)
 
-        response_json = login_post_r.json()
         # 'loginResult': '0', user successfully logged; '1', user not logged
         if (
             response_json.get("loginResult") == None

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -279,13 +279,14 @@ class PacerSession(requests.Session):
             timeout=60,
             data=json.dumps(data),
         )
-        # Continue with login when response code is "200: OK"
-        if login_post_r.status_code == requests.codes.ok:
-            response_json = login_post_r.json()
-        else:
+
+        if login_post_r.status_code != requests.codes.ok:
             message = f"Unable connect to PACER site: '{login_post_r.status_code}: {login_post_r.reason}'"
             logger.warning(message)
             raise PacerLoginException(message)
+            
+        # Continue with login when response code is "200: OK"            
+        response_json = login_post_r.json()            
 
         # 'loginResult': '0', user successfully logged; '1', user not logged
         if (

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -279,10 +279,11 @@ class PacerSession(requests.Session):
             timeout=60,
             data=json.dumps(data),
         )
-        try:
+        # Continue with login when response code is "200: OK"
+        if login_post_r.status_code == requests.codes.ok:
             response_json = login_post_r.json()
-        except json.JSONDecodeError:
-            message = "Unable to get a valid JSON object to parse the PACER login reply."
+        else:
+            message = f"Unable connect to PACER site: '{login_post_r.status_code}: {login_post_r.reason}'"
             logger.warning(message)
             raise PacerLoginException(message)
 


### PR DESCRIPTION
Closes #482 
Closes [COURTLISTENER-22A](https://sentry.io/organizations/freelawproject/issues/2936179947/?referrer=github_integration)