### PR TITLE
CO: Fix missing dates from Supreme court opinions

### DIFF
--- a/juriscraper/opinions/united_states/state/colo.py
+++ b/juriscraper/opinions/united_states/state/colo.py
@@ -40,9 +40,11 @@ class Site(OpinionSiteLinear):
             ):
                 link_text = normalize_dashes(item.text_content().strip())
                 cite_match = re.findall(r"(\d{2,4}\s*CO\s*\d+\w?)", link_text)
+                citation = cite_match[0] if cite_match else ""
+                if self.test_mode_enabled() and citation == "":
+                    citation = "Citation to be scraped in 'extract_from_text'"
                 docket_match = re.findall(r"\d+[A-Z]+\d{2,}", link_text)
                 docket = docket_match[0] if docket_match else ""
-                citation = cite_match[0] if cite_match else ""
                 name = (
                     link_text.replace(docket, "")
                     .replace(citation, "")
@@ -63,7 +65,7 @@ class Site(OpinionSiteLinear):
         """Pass scraped text into function and return data as a dictionary
         Notes for 'Citation':
             - Reporter key for this court: 'CO'
-            - Type for a state: 2
+            - Type for citations from state-based reporters in CourtListener: 2
         :param scraped_text: Text of scraped content
         :return: metadata
         """

--- a/juriscraper/opinions/united_states/state/colo.py
+++ b/juriscraper/opinions/united_states/state/colo.py
@@ -37,14 +37,19 @@ class Site(OpinionSiteLinear):
                 ".//a[contains(@href, 'Supreme_Court/Opinions/')]"
             ):
                 link_text = normalize_dashes(item.text_content().strip())
-                try:
-                    citation, link_text = link_text.split("-", 1)
-                except ValueError:
+                cite_match = re.findall(r"\d{4} CO \d+", link_text)
+                docket_match = re.findall(r"\d{2,}\w{2}\d+", link_text)
+                if cite_match:
+                    citation = cite_match[0]
+                    link_text = link_text.replace(citation, "")
+                else:
                     citation = ""
-                    link_text = link_text
-                docket, name = link_text.split(" ", 1)
-                if not docket:
-                    docket, name = link_text.split(",", 1)
+                if docket_match:
+                    docket = docket_match[0]
+                    link_text = link_text.replace(docket, "")
+                else:
+                    docket = ""
+                name = link_text.lstrip(",- ")
                 self.cases.append(
                     {
                         "date": date_str,

--- a/juriscraper/opinions/united_states/state/colo.py
+++ b/juriscraper/opinions/united_states/state/colo.py
@@ -69,16 +69,19 @@ class Site(OpinionSiteLinear):
         :param scraped_text: Text of scraped content
         :return: metadata
         """
-        match = re.findall(r"\d{4}\s*CO\s*\d+", scraped_text)
+        cite_match = re.findall(r"\d{4}\s*CO\s*\d+", scraped_text)
+        docket_match = re.findall(r"\d{2}S[A|C]\d+", scraped_text)
         metadata = {}
-        if match:
-            volume, page = match[0].split("CO")
-            metadata = {
-                "Citation": {
-                    "volume": volume.strip(),
-                    "reporter": "CO",
-                    "page": page.strip(),
-                    "type": 2,
-                },
+        if cite_match:
+            volume, page = cite_match[0].split("CO")
+            metadata["Citation"] = {
+                "volume": volume.strip(),
+                "reporter": "CO",
+                "page": page.strip(),
+                "type": 2,
+            }
+        if docket_match:
+            metadata["OpinionCluster"] = {
+                "docket_number": docket_match[0],
             }
         return metadata

--- a/juriscraper/opinions/united_states/state/colo.py
+++ b/juriscraper/opinions/united_states/state/colo.py
@@ -67,15 +67,11 @@ class Site(OpinionSiteLinear):
         :param scraped_text: Text of scraped content
         :return: metadata
         """
-        cite_match = re.findall(r"\d{4}\s*CO\s*\d+", scraped_text)
-        docket_match = re.findall(r"\d+S[A-Z]\d+", scraped_text)
+        match = re.findall(r"\d{4}\s*CO\s*\d+", scraped_text)
         metadata = {}
-        if cite_match and docket_match:
-            volume, page = cite_match[0].split("CO")
+        if match:
+            volume, page = match[0].split("CO")
             metadata = {
-                "OpinionCluster": {
-                    "docket_number": docket_match[0],
-                },
                 "Citation": {
                     "volume": volume.strip(),
                     "reporter": "CO",

--- a/juriscraper/opinions/united_states/state/colo.py
+++ b/juriscraper/opinions/united_states/state/colo.py
@@ -24,8 +24,9 @@ class Site(OpinionSiteLinear):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
         self.url = "https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/"
+        self.status = "Published"
         self.cite_re = r"\d{4}\s+CO\s+\d+"
-        self.docket_re = r"\d{2}S[A|C]\d+"
+        self.docket_re = r"\d{2}S[AC]\d+"
 
     def _process_html(self) -> None:
         date = self.html.xpath(
@@ -41,10 +42,9 @@ class Site(OpinionSiteLinear):
                 ".//a[contains(@href, 'Supreme_Court/Opinions/')]"
             ):
                 link_text = normalize_dashes(item.text_content().strip())
-
                 cite_match = re.findall(r"(\d{2,4}\s*CO\s*\d+\w?)", link_text)
                 citation_raw = cite_match[0] if cite_match else ""
-                docket_match = re.findall(r"\d+S[A|C]\d{2,}", link_text)
+                docket_match = re.findall(r"\d+S[AC]\d{2,}", link_text)
                 docket_raw = docket_match[0] if docket_match else ""
                 name = (
                     link_text.replace(docket_raw, "")
@@ -69,7 +69,6 @@ class Site(OpinionSiteLinear):
                         "docket": docket,
                         "name": name,
                         "url": item.attrib["href"],
-                        "status": "Published",
                         "citation": citation,
                     }
                 )

--- a/juriscraper/opinions/united_states/state/colo.py
+++ b/juriscraper/opinions/united_states/state/colo.py
@@ -5,10 +5,11 @@ Author: Philip Ardery
 Reviewer: mlr
 Date created: 2016-06-03
 Contact: Email "Internet and Technology" staff listed at http://www.cobar.org/staff
-         they usually fix issues without resonding to the emails directly. You can
-         also try submitting the form here: http://www.cobar.org/contact
+    they usually fix issues without resonding to the emails directly. You can
+    also try submitting the form here: http://www.cobar.org/contact
 History:
     - 2022-01-31: Updated by William E. Palin
+    - 2022-02-09: Date validation and regexp. improovements, @satsuki-chan
 """
 
 import re
@@ -37,19 +38,15 @@ class Site(OpinionSiteLinear):
                 ".//a[contains(@href, 'Supreme_Court/Opinions/')]"
             ):
                 link_text = normalize_dashes(item.text_content().strip())
-                cite_match = re.findall(r"\d{4} CO \d+", link_text)
-                docket_match = re.findall(r"\d{2,}\w{2}\d+", link_text)
-                if cite_match:
-                    citation = cite_match[0]
-                    link_text = link_text.replace(citation, "")
-                else:
-                    citation = ""
-                if docket_match:
-                    docket = docket_match[0]
-                    link_text = link_text.replace(docket, "")
-                else:
-                    docket = ""
-                name = link_text.lstrip(",- ")
+                cite_match = re.findall(r"(\d{4} CO \d+\w?)", link_text)
+                docket_match = re.findall(r"\d+[A-Z]+\d+", link_text)
+                docket = docket_match[0] if docket_match else ""
+                citation = cite_match[0] if cite_match else ""
+                name = (
+                    link_text.replace(docket, "")
+                    .replace(citation, "")
+                    .lstrip(",- ")
+                )
                 self.cases.append(
                     {
                         "date": date_str,

--- a/juriscraper/opinions/united_states/state/colo.py
+++ b/juriscraper/opinions/united_states/state/colo.py
@@ -67,15 +67,14 @@ class Site(OpinionSiteLinear):
         :param scraped_text: Text of scraped content
         :return: metadata
         """
-        match_re = r"The Supreme Court of the State of Colorado.*?(?P<citation>\d{4}\s*CO\s*\d+).*?Supreme Court Case No\. (?P<docket>\d+S[A-Z]\d+)"
-        match = re.findall(match_re, scraped_text, re.M | re.S)
-        if not match:
-            metadata = {}
-        else:
-            volume, page = match[0][0].split("CO")
+        cite_match = re.findall(r"\d{4}\s*CO\s*\d+", scraped_text)
+        docket_match = re.findall(r"\d+S[A-Z]\d+", scraped_text)
+        metadata = {}
+        if cite_match and docket_match:
+            volume, page = cite_match[0].split("CO")
             metadata = {
                 "OpinionCluster": {
-                    "docket_number": match[0][1],
+                    "docket_number": docket_match[0],
                 },
                 "Citation": {
                     "volume": volume.strip(),

--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -4,6 +4,7 @@ Court Short Name: Colo. Ct. App.
 
 History:
     - 2022-01-31: Updated by William E. Palin
+    - 2022-02-09: Status verification and cases names cleaning, @satsuki-chan
 """
 
 from juriscraper.lib.string_utils import clean_string, convert_date_string

--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -19,6 +19,7 @@ class Site(colo.Site):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
         self.url = "https://www.courts.state.co.us/Courts/Court_of_Appeals/Case_Announcements/"
+        self.status = "Published"
 
     def _process_html(self) -> None:
         """Process the HTML
@@ -56,7 +57,6 @@ class Site(colo.Site):
                     "docket": docket,
                     "name": name,
                     "url": f"https://www.courts.state.co.us/Courts/Court_of_Appeals/Opinion/{date_year.year}/{docket}-PD.pdf",
-                    "status": "Published",
                     "citation": citation,
                 }
             )
@@ -69,7 +69,7 @@ class Site(colo.Site):
         :param scraped_text: Text of scraped content
         :return: metadata
         """
-        match_re = r"The.*SUMMARY.*?(?P<citation>\d{4}COA\d+).*?No\. (?P<docket>\d+CA\d+), (?P<headnotes>.*?)\n{2,}(?P<summary>.*?)COLORADO COURT OF APPEALS"
+        match_re = r"(?P<citation>\d{4}COA\d+).*?(?P<docket>\d+CA\d+),.*? (?P<headnotes>—.*?)\n{2,}\s{4,}(?P<summary>.*?)COLORADO"
         match = re.findall(match_re, scraped_text, re.M | re.S)
         metadata = {}
         if match:
@@ -77,7 +77,7 @@ class Site(colo.Site):
             metadata = {
                 "OpinionCluster": {
                     "docket_number": match[0][1],
-                    "headnotes": clean_string(match[0][2]),
+                    "headnotes": clean_string(match[0][2]).lstrip("— "),
                     "summary": clean_string(match[0][3]),
                 },
                 "Citation": {

--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -6,7 +6,7 @@ History:
     - 2022-01-31: Updated by William E. Palin
 """
 
-from juriscraper.lib.string_utils import convert_date_string
+from juriscraper.lib.string_utils import clean_string, convert_date_string
 from juriscraper.opinions.united_states.state import colo
 
 
@@ -34,12 +34,14 @@ class Site(colo.Site):
         date = rows[0].text_content()
         date_year = convert_date_string(date)
 
-        if "P U B L I S H E D  O P I N I O N S" != rows[1].text_content():
+        if "P U B L I S H E D O P I N I O N S" != clean_string(
+            rows[1].text_content()
+        ):
             return {}
         for row in rows[2:]:
-            if row.text_content() == "U N P U B L I S H E D  O P I N I O N S":
+            row_text = clean_string(row.text_content().strip())
+            if row_text == "U N P U B L I S H E D O P I N I O N S":
                 break
-            row_text = row.text_content().strip()
             docket, name = row_text.split(" ", 1)
             self.cases.append(
                 {

--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -47,6 +47,9 @@ class Site(colo.Site):
             if row_text == "U N P U B L I S H E D O P I N I O N S":
                 break
             docket, name = row_text.split(" ", 1)
+            citation = ""
+            if self.test_mode_enabled():
+                citation = "Citation to be scraped in 'extract_from_text'"
             self.cases.append(
                 {
                     "date": date,
@@ -54,6 +57,7 @@ class Site(colo.Site):
                     "name": name,
                     "url": f"https://www.courts.state.co.us/Courts/Court_of_Appeals/Opinion/{date_year.year}/{docket}-PD.pdf",
                     "status": "Published",
+                    "citation": citation,
                 }
             )
 

--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -43,7 +43,7 @@ class Site(colo.Site):
         ):
             return {}
         for row in rows[2:]:
-            row_text = clean_string(row.text_content().strip())
+            row_text = clean_string(row.text_content())
             if row_text == "U N P U B L I S H E D O P I N I O N S":
                 break
             docket, name = row_text.split(" ", 1)
@@ -67,9 +67,8 @@ class Site(colo.Site):
         """
         match_re = r"The.*SUMMARY.*?(?P<citation>\d{4}COA\d+).*?No\. (?P<docket>\d+CA\d+), (?P<headnotes>.*?)\n{2,}(?P<summary>.*?)COLORADO COURT OF APPEALS"
         match = re.findall(match_re, scraped_text, re.M | re.S)
-        if not match:
-            metadata = {}
-        else:
+        metadata = {}
+        if match:
             volume, page = match[0][0].split("COA")
             metadata = {
                 "OpinionCluster": {

--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -61,7 +61,7 @@ class Site(colo.Site):
         """Pass scraped text into function and return data as a dictionary
         Notes for 'Citation':
             - Reporter key for this court: 'COA'
-            - Type for a state: 2
+            - Type for citations from state-based reporters in CourtListener: 2
         :param scraped_text: Text of scraped content
         :return: metadata
         """

--- a/tests/examples/opinions/united_states/colo_example.compare.json
+++ b/tests/examples/opinions/united_states/colo_example.compare.json
@@ -7,6 +7,7 @@
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "21SA286",
+    "citations": "",
     "case_name_shorts": ""
   }
 ]

--- a/tests/examples/opinions/united_states/colo_example.compare.json
+++ b/tests/examples/opinions/united_states/colo_example.compare.json
@@ -7,7 +7,7 @@
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "21SA286",
-    "citations": "",
+    "citations": "Citation to be scraped in 'extract_from_text'",
     "case_name_shorts": ""
   }
 ]

--- a/tests/examples/opinions/united_states/colo_example_2.compare.json
+++ b/tests/examples/opinions/united_states/colo_example_2.compare.json
@@ -1,0 +1,13 @@
+[
+  {
+    "case_dates": "2022-02-07",
+    "case_names": "Garcia v. People",
+    "download_urls": "/userfiles/file/Court_Probation/Supreme_Court/Opinions/2020/20SC758.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "20SC758",
+    "citations": "2022 CO 6",
+    "case_name_shorts": "Garcia"
+  }
+]

--- a/tests/examples/opinions/united_states/colo_example_2.html
+++ b/tests/examples/opinions/united_states/colo_example_2.html
@@ -1,0 +1,539 @@
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+    <head><script type="text/javascript" src="/CFIDE/scriptsdir/cfform.js"></script>
+<script type="text/javascript" src="/CFIDE/scriptsdir/masks.js"></script>
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+
+
+
+        <title>Colorado Judicial Branch - Courts - Supreme Court - Case Announcements and Published Opinions</title>
+
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/main-small.css" media="only screen and (max-width:640px)" />
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/header-small.css" media="only screen and (max-width:640px)"  />
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/navigation-small.css" media="only screen and (max-width:640px)"  />
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/main-medium.css" media="only screen and (min-width:641px) and (max-width:1019px)" />
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/header-medium.css" media="only screen and (min-width:641px) and (max-width:1019px)"  />
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/navigation-medium.css" media="only screen and (min-width:641px) and (max-width:1019px)"  />
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/main-large.css" media="only screen and (min-width:1020px)"  />
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/header-large.css" media="only screen and (min-width:1020px)"  />
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/navigation-large.css" media="only screen and (min-width:1020px)"  />
+        <!--[if lte IE 8]>
+        <script type="text/javascript" src="/assets/scripts/respond.min.js"></script>
+        <![endif]-->
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/global.css" />
+
+        <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,700' rel='stylesheet' type='text/css' />
+        <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/css/Print.css" media="print" />
+        <link rel="shortcut icon" href="https://www.courts.state.co.us/images/icons/favicon_public.ico" />
+        <link rel="apple-touch-icon-precomposed" href="https://www.courts.state.co.us/images/apple-touch-icon-precomposed.png"/>
+
+        <script type="text/javascript" src="https://www.courts.state.co.us/assets/scripts/jquery-1.11.0.min.js"></script>
+        <script type="text/javascript" src="https://www.courts.state.co.us/assets/scripts/global-scripts.js"></script>
+
+		<!-- PNotify -->
+  		<script type="text/javascript" src="https://www.courts.state.co.us/assets/scripts/PNotify.js"></script>
+  		<link href="https://www.courts.state.co.us/assets/css/PNotifyBrightTheme.css" rel="stylesheet" type="text/css" />
+		<script type="text/javascript" src="https://www.courts.state.co.us/assets/scripts/PNotifyButtons.js"></script>
+
+
+
+        <script type="text/javascript">
+
+          var _gaq = _gaq || [];
+          _gaq.push(['_setAccount', 'UA-23986541-1']);
+          _gaq.push(['_trackPageview']);
+
+          (function() {
+            var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+            ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+          })();
+
+        </script>
+
+
+
+<script type="text/javascript">
+<!--
+    _CF_checkCFForm_1 = function(_CF_this)
+    {
+        //reset on submit
+        _CF_error_exists = false;
+        _CF_error_messages = new Array();
+        _CF_error_fields = new Object();
+        _CF_FirstErrorField = null;
+
+
+        //display error messages and return success
+        if( _CF_error_exists )
+        {
+            if( _CF_error_messages.length > 0 )
+            {
+                // show alert() message
+                _CF_onErrorAlert(_CF_error_messages);
+                // set focus to first form error, if the field supports js focus().
+                if( _CF_this[_CF_FirstErrorField].type == "text" )
+                { _CF_this[_CF_FirstErrorField].focus(); }
+
+            }
+            return false;
+        }else {
+            return true;
+        }
+    }
+//-->
+</script>
+<script type="text/javascript">
+<!--
+    _CF_checkfrm_Search = function(_CF_this)
+    {
+        //reset on submit
+        _CF_error_exists = false;
+        _CF_error_messages = new Array();
+        _CF_error_fields = new Object();
+        _CF_FirstErrorField = null;
+
+
+        //display error messages and return success
+        if( _CF_error_exists )
+        {
+            if( _CF_error_messages.length > 0 )
+            {
+                // show alert() message
+                _CF_onErrorAlert(_CF_error_messages);
+                // set focus to first form error, if the field supports js focus().
+                if( _CF_this[_CF_FirstErrorField].type == "text" )
+                { _CF_this[_CF_FirstErrorField].focus(); }
+
+            }
+            return false;
+        }else {
+            return true;
+        }
+    }
+//-->
+</script>
+</head>
+
+	<body>
+    	<a href="#main-content" class="skip-content">Skip to main content</a>
+
+
+
+	<div class="header-top">
+    	<div class="header-mobile-left"></div>
+        <a href="https://www.courts.state.co.us" class="header-mobile-right"></a>
+        <div class="inner-header">
+        	<a href="https://www.courts.state.co.us" class="home-link"></a>
+            <div class="searchbar">
+                <form name="frm_Search" id="frm_Search" action="https://www.courts.state.co.us/search/index.cfm" style="margin:0;" method="get" class="MainSearch">
+                	<input type="submit" name="name" value="" style="float:right" />
+                    <input name="q" type="text" id="q" value="Search" onclick="if(this.value == 'Search'){this.value = '';}" onblur="if(this.value == ''){this.value = 'Search';}" style="float:right" />
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div id="headerDisplay">
+
+        <div id="headercontainer">
+            <div id="header">
+                <ul>
+                    <li class="noscreen"><a href="https://www.courts.state.co.us">Home</a></li>
+                    <li class="noscreen"><a href="https://www.courts.state.co.us/search.cfm">Search</a></li>
+                    <li class="current"><a href="https://www.courts.state.co.us/Courts/Index.cfm" class="tab">Courts</a>
+                    <ul>
+                    	<li><a href="https://www.courts.state.co.us/Courts/County/Choose.cfm">Trial Courts by County</a></li>
+                        <li><a href="https://www.courts.state.co.us/Courts/District/Choose.cfm">Trial Courts by District</a></li>
+                        <li><a href="https://www.courts.state.co.us/Courts/Supreme_Court/Index.cfm">Supreme Court</a></li>
+                        <li><a href="https://www.courts.state.co.us/Courts/Court_Of_Appeals/Index.cfm">Court of Appeals</a></li>
+                        <li><a href="https://www.courts.state.co.us/Courts/Water/Index.cfm">Water Courts</a></li>
+                        <li><a href="https://www.courts.state.co.us/Courts/Denver_Juvenile/Index.cfm">Denver Juvenile Court</a></li>
+                        <li><a href="https://www.courts.state.co.us/Courts/Denver_Probate/Index.cfm">Denver Probate Court</a></li>
+                        <li><a href="https://www.courts.state.co.us/Courts/Education/Index.cfm">Educational Resources</a></li>
+                    </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Probation/Index.cfm" class="tab">Probation</a>
+                    <ul>
+                        <li><a href="https://www.courts.state.co.us/Probation/County/Choose.cfm">By County</a></li>
+                        <li><a href="https://www.courts.state.co.us/Probation/Denver_Juvenile/Index.cfm">Denver Juvenile Probation</a></li>
+                         <li><a href="https://www.courts.state.co.us/Probation/Resources.cfm">Resources</a></li>
+                    </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Jury/Index.cfm" class="tab">Jury</a>
+                    <ul>
+                        <li><a href="https://www.courts.state.co.us/Jury/County/Choose.cfm">By County</a></li>
+                        <li><a href="https://www.courts.state.co.us/Jury/District/Choose.cfm">By District</a></li>
+                        <li><a href="https://www.courts.state.co.us/Jury/Jury_Commissioners.cfm">List of Jury Commissioners</a></li>
+                        <li><a href="https://www.courts.state.co.us/Jury/Employer.cfm">Information for Employers</a></li>
+                        <li><a href="https://www.courts.state.co.us/Jury/FAQs.cfm">Jury FAQs</a></li>
+                        <li><a href="https://www.courts.state.co.us/userfiles/file/jury/video/ColoradoJuror.mp4">Colorado Jury Service Video</a></li>
+                    </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Self_Help/Index.cfm" class="tab">Self&nbsp;Help&nbsp;&frasl;&nbsp;Forms</a>
+                    <ul>
+                    	<li><a href="https://www.courts.state.co.us/Forms/Index.cfm">All Court Forms and Instructions</a></li>
+                        <li><a href="https://www.courts.state.co.us/Forms/Espanol/Index.cfm">Formularios e instrucciones judiciales en espa&ntilde;ol</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/adoption/">Adoption</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/appeals/">Appeals</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/bonds/">Bonds</a></li>
+                    	<li><a href="https://www.courts.state.co.us/Self_Help/conservatorship/">Conservatorship</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/criminalcases/">Criminal Cases</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/estate/">Estate Cases</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/extremeriskprotectionorders/">Extreme Risk Protection Orders</a></li>
+                    	<li><a href="https://www.courts.state.co.us/Self_Help/family/">Family Cases</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/garnishments/">Garnishments</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/guardianship/">Guardianship</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/housing/">Housing Cases</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/judgments/">Judgments</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/money/">Money Cases</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/namechange/">Name Changes</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/protectionorders/">Protection Orders</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/sealingrecords/">Sealing Records</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/smallclaims/">Small Claims Cases</a></li>
+                        <li><a href="https://www.courts.state.co.us/Self_Help/watercases/">Water Cases</a></li>
+                        <li><a href="https://www.courts.state.co.us/Administration/Section.cfm?Section=jp3dnad">Dependency &amp; Neglect Advisement</a></li>
+                    </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Careers/Index.cfm" class="tab">Careers</a>
+                    <ul>
+                        <li><a href="https://www.courts.state.co.us/Careers/Opportunities.cfm">Career Opportunities</a></li>
+                        <li><a href="https://www.courts.state.co.us/Careers/Internship.cfm">Internship Opportunities</a></li>
+                        <li><a href="https://www.courts.state.co.us/Careers/Judge.cfm">Judge Opportunities</a></li>
+                        <li><a href="https://www.courts.state.co.us/Administration/Unit.cfm?Unit=interp">Interpreter Opportunities</a></li>
+                        <li><a href="https://www.courts.state.co.us/Careers/Volunteer.cfm">Volunteer Opportunities</a></li>
+                        <li><a href="https://www.courts.state.co.us/Careers/Benefits.cfm">Benefits</a></li>
+                        <li><a href="https://www.courts.state.co.us/Careers/Descriptions.cfm">Job Descriptions</a></li>
+                        <li><a href="https://www.courts.state.co.us/Careers/FAQs.cfm">Career FAQs</a></li>
+                    </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Media/Index.cfm" class="tab">Media</a>
+                    <ul>
+                        <li><a href="https://www.courts.state.co.us/Media/Press_Releases.cfm">Press Releases</a></li>
+                        <li><a href="https://www.courts.state.co.us/Media/Opinions.cfm">Recent Orders &amp; Opinions of Interest</a></li>
+                        <li><a href="https://www.courts.state.co.us/Media/Alerts.cfm">Media Alerts</a></li>
+                        <li><a href="https://www.courts.state.co.us/Media/Appointments.cfm">Judge Appointments</a></li>
+                        <li><a href="https://www.courts.state.co.us/Media/Law_School.cfm">Law School for Journalists</a></li>
+                        <li><a href="https://www.courts.state.co.us/Administration/Section.cfm?Section=pubacag">Access Guide to Public Records</a></li>
+                        <li><a href="https://www.courts.state.co.us/Media/Link_Request.cfm">Web Link Request</a></li>
+                    </ul>
+                    </li>
+                    <li ><a href="https://www.courts.state.co.us/Administration/Index.cfm" class="tab">Administration</a>
+                    <ul>
+                        <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=pa">Court Services</a></li>
+                        <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=exec">Executive Division</a></li>
+                        <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=finan">Financial Services</a></li>
+                        <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=hr">Human Resources</a></li>
+                        <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=jbits">Information Technology Services</a></li>
+                        <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=prob">Probation Services</a></li>
+                    </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+            <div id="main-wrapper">
+                <div id="main-content">
+
+    <span class="BreadcrumbsMobile">
+
+            <a href="https://www.courts.state.co.us" class="Breadcrumbs" style="padding-left:0px;">Home</a>
+
+
+		<a href="https://www.courts.state.co.us/Courts/Index.cfm" title="Courts" class="Breadcrumbs">Courts</a>
+		<a href="https://www.courts.state.co.us/Courts/Supreme_Court/Index.cfm" class="Breadcrumbs">Supreme Court</a>
+		<span class="Breadcrumbs_Selected">Case Announcements</span>
+
+
+    </span>
+    <div style="clear:both"></div>
+
+                    <div class="wrapper-full">
+                        <div class="center-content-left">
+
+    <span class="BreadcrumbsLarge">
+
+
+            	<a href="https://www.courts.state.co.us" class="Breadcrumbs" style="padding-left:0px;">Home</a>
+
+
+
+		<a href="https://www.courts.state.co.us/Courts/Index.cfm" title="Courts" class="Breadcrumbs">Courts</a>
+		<a href="https://www.courts.state.co.us/Courts/Supreme_Court/Index.cfm" class="Breadcrumbs">Supreme Court</a>
+		<span class="Breadcrumbs_Selected">Case Announcements</span>
+
+
+    </span>
+    <div style="clear:both"></div>
+
+
+		<link rel="alternate" type="application/rss+xml" title="Supreme Court Case Announcements RSS Feed" href="/RSS/scAnnouncementFeed.xml">
+
+        <span class="Title">Supreme Court Case Announcements <a href="/RSS/scAnnouncementFeed.xml" title="Supreme Court Announcements RSS Feed"><img src="/images/rssbuttonsmall.png" hspace="10"  border="0" /></a></span><br />
+
+        <span class="SubTitle">Future Case Announcements</span>
+        <br />
+
+        <p>Colorado Supreme Court case announcements for Monday, February 7, 2022, are now available.</p>
+
+<p>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>
+
+<p><a href="/userfiles/file/Court_Probation/Supreme_Court/Opinions/2020/20SC758.pdf">2022 CO 6 &ndash; 20SC758, Garcia v. People</a></p>
+
+<p>&nbsp;</p>
+
+<p>&nbsp;</p>
+
+<p>&nbsp;</p>
+
+        <br /><br />
+
+       <span class="SubTitle">Past Case Announcements for the Supreme Court</span><br /><br />
+
+       <form name="CFForm_1" id="CFForm_1" action="&#x2f;Courts&#x2f;Supreme_Court&#x2f;Case_Announcements&#x2f;Index.cfm" method="get" class="WebForm" onsubmit="return _CF_checkCFForm_1(this)">
+
+           <span style="display:block; float:left; margin-right:50px">
+               <label>Year</label><br />
+               <select name="year" style="width:200px;"  id="year" >
+
+
+                       <option value="2022" selected="selected">2022</option>
+
+                       <option value="2021" >2021</option>
+
+                       <option value="2020" >2020</option>
+
+                       <option value="2019" >2019</option>
+
+                       <option value="2018" >2018</option>
+
+                       <option value="2017" >2017</option>
+
+                       <option value="2016" >2016</option>
+
+                       <option value="2015" >2015</option>
+
+                       <option value="2014" >2014</option>
+
+                       <option value="2013" >2013</option>
+
+                       <option value="2012" >2012</option>
+
+                       <option value="2011" >2011</option>
+
+                       <option value="2010" >2010</option>
+
+                       <option value="2009" >2009</option>
+
+                       <option value="2008" >2008</option>
+
+                       <option value="2007" >2007</option>
+
+                       <option value="2006" >2006</option>
+
+                       <option value="2005" >2005</option>
+
+                       <option value="2004" >2004</option>
+
+                       <option value="2003" >2003</option>
+
+                       <option value="2002" >2002</option>
+
+                       <option value="2001" >2001</option>
+
+                       <option value="2000" >2000</option>
+
+                       <option value="1999" >1999</option>
+
+                       <option value="1998" >1998</option>
+
+               </select>
+               <br /><br />
+           </span>
+
+           <span style="display:block; float:left;">
+               <label>Month</label><br />
+               <select name="month" style="width:200px;"  id="month" >
+
+                   <option value="">All</option>
+                   <option value="1" >January</option>
+                   <option value="2" >February</option>
+                   <option value="3" >March</option>
+                   <option value="4" >April</option>
+                   <option value="5" >May</option>
+                   <option value="6" >June</option>
+                   <option value="7" >July</option>
+                   <option value="8" >August</option>
+                   <option value="9" >September</option>
+                   <option value="10" >October</option>
+                   <option value="11" >November</option>
+                   <option value="12" >December</option>
+               </select>
+
+               <br /><br />
+           </span>
+           <div style="clear:both"></div>
+
+           <input name="Submit" type="submit" value="Go" id="Submit"  />
+           <br /><br />
+
+       </form>
+
+
+
+
+
+
+               <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/881AB902.07.22.pdf" title="February 07, 2022" target="_blank" class="touchable-link">February 07, 2022</a>
+
+
+
+               <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/A4FC0601.31.22.pdf" title="January 31, 2022" target="_blank" class="touchable-link">January 31, 2022</a>
+
+
+
+               <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/D5879701-24-22.pdf" title="January 24, 2022" target="_blank" class="touchable-link">January 24, 2022</a>
+
+
+
+               <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/AAE98301-18-22.pdf" title="January 18, 2022" target="_blank" class="touchable-link">January 18, 2022</a>
+
+
+
+               <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/FF88FF01.10.22.pdf" title="January 10, 2022" target="_blank" class="touchable-link">January 10, 2022</a>
+
+
+
+
+
+
+                        </div>
+                        <div class="right-content">
+
+
+        <span class="RightTitle">Can't Find It?</span>
+        <br />
+
+        Search Case Announcements
+        and Published Opinions<br /><br />
+
+        <form name="frm_Search" id="frm_Search" action="https://www.courts.state.co.us/search/index.cfm" method="get" onload="This.blur();" class="WebForm" onsubmit="return _CF_checkfrm_Search(this)">
+            <input name="q" type="text" style="width:90%"  id="q"  />
+            <input name="f" id="f"  type="hidden" value="0" />
+            <input name="s" id="s"  type="hidden" value="Supreme_Court_Opinions" />
+            <br /><br />
+            <input name="btn_Submit" type="submit" value="Search" id="btn_Submit"  /><br />
+        </form>
+
+
+        <span class="RightTitle">Court Proceedings</span>
+        <br />
+
+        <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Index.cfm">Supreme Court Homepage</a><br />
+        <a href="https://www.courts.state.co.us/Courts/live">Live and Archived Oral Argument Videos</a><br />
+        <a title="Oral Arguments" href="https://www.courts.state.co.us/Courts/Supreme_Court/Oral_Arguments/Index.cfm">Oral Arguments</a><br />
+        <a title="Original Proceedings" href="https://www.courts.state.co.us/Courts/Supreme_Court/Proceedings/Index.cfm">Original Proceedings</a><br />
+        <a title="Ballot Initiative" href="https://www.courts.state.co.us/Courts/Supreme_Court/Ballot_Initiative.cfm">Ballot Initiative</a>
+
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+
+	<div style="clear:both"></div>
+    <div class="footer-spacer"></div>
+
+        <span class="fixed-footer-announce nomobile">
+        	<a href="https://www.courts.state.co.us/announcements/index.cfm">important announcement</a>
+        </span>
+
+
+    <span class="fixed-footer">
+        <a href="https://data.colorado.gov/Government/State-Government-Revenue-and-Expenditures-in-Color/rifs-n6ib" target="_blank">Transparency Online</a>
+        &nbsp; &bull; &nbsp;
+        <a href="https://www.courts.state.co.us/Contact/Index.cfm">Contact Us</a>
+        &nbsp; &bull; &nbsp;
+        <a href="https://www.courts.state.co.us/Administration/Unit.cfm?Unit=interp">Interpreters</a>
+        &nbsp; &bull; &nbsp;
+        <a href="https://www.courts.state.co.us/FAQs/Index.cfm">FAQ</a>
+        &nbsp; &bull; &nbsp;
+        <a href="https://www.courts.state.co.us/gallery/">Photos</a>
+        &nbsp; &bull; &nbsp;
+        <a href="https://www.courts.state.co.us/holiday.cfm">Holidays</a>
+    </span>
+
+    <span class="mobile-footer">
+    	<span class="mobile-footer-title">Menu</span>
+
+        	<a href="https://www.courts.state.co.us/announcements/index.cfm" style="color:#FFF; background-color:#C30">Important Announcement</a>
+
+        <a href="https://www.courts.state.co.us/Index.cfm">Home</a>
+        <a href="https://www.courts.state.co.us/search.cfm">Search</a>
+        <a href="https://www.courts.state.co.us/Courts/Index.cfm">Courts</a>
+        <a href="https://www.courts.state.co.us/Probation/Index.cfm">Probation</a>
+        <a href="https://www.courts.state.co.us/Jury/Index.cfm">Jury</a>
+        <a href="https://www.courts.state.co.us/Self_Help/Index.cfm">Self&nbsp;Help &frasl; Forms</a>
+        <a href="https://www.courts.state.co.us/Careers/Index.cfm">Careers</a>
+        <a href="https://www.courts.state.co.us/Media/Index.cfm">Media</a>
+        <a href="https://www.courts.state.co.us/Administration/Index.cfm">Administration</a>
+        <a href="https://www.courts.state.co.us/Contact/Index.cfm">Contact us</a>
+        <a href="https://www.courts.state.co.us/Administration/Unit.cfm?Unit=interp">Interpreters</a>
+        <a href="https://www.courts.state.co.us/FAQs/Index.cfm">FAQ</a>
+        <a href="https://www.courts.state.co.us/gallery/">Photo Gallery</a>
+        <a href="https://www.courts.state.co.us/holiday.cfm">Holiday Schedule</a>
+    </span>
+    <div style="display:none">1a</div>
+
+
+
+
+	</body>
+</html>

--- a/tests/examples/opinions/united_states/colo_example_3.compare.json
+++ b/tests/examples/opinions/united_states/colo_example_3.compare.json
@@ -1,0 +1,13 @@
+[
+  {
+    "case_dates": "2022-02-14",
+    "case_names": "People v. Ray Ojeda",
+    "download_urls": "/userfiles/file/Court_Probation/Supreme_Court/Opinions/2019/19SC763.pdf",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "19SC763",
+    "citations": "22CO7",
+    "case_name_shorts": ""
+  }
+]

--- a/tests/examples/opinions/united_states/colo_example_3.compare.json
+++ b/tests/examples/opinions/united_states/colo_example_3.compare.json
@@ -7,7 +7,7 @@
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "19SC763",
-    "citations": "22CO7",
+    "citations": "Citation to be scraped in 'extract_from_text'",
     "case_name_shorts": ""
   }
 ]

--- a/tests/examples/opinions/united_states/colo_example_3.html
+++ b/tests/examples/opinions/united_states/colo_example_3.html
@@ -1,0 +1,578 @@
+<!DOCTYPE html
+    PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+
+<head>
+    <script type="text/javascript" src="/CFIDE/scriptsdir/cfform.js"></script>
+    <script type="text/javascript" src="/CFIDE/scriptsdir/masks.js"></script>
+
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+
+
+
+
+    <title>Colorado Judicial Branch - Courts - Supreme Court - Case Announcements and Published Opinions</title>
+
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/main-small.css"
+        media="only screen and (max-width:640px)" />
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/header-small.css"
+        media="only screen and (max-width:640px)" />
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/navigation-small.css"
+        media="only screen and (max-width:640px)" />
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/main-medium.css"
+        media="only screen and (min-width:641px) and (max-width:1019px)" />
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/header-medium.css"
+        media="only screen and (min-width:641px) and (max-width:1019px)" />
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/navigation-medium.css"
+        media="only screen and (min-width:641px) and (max-width:1019px)" />
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/main-large.css"
+        media="only screen and (min-width:1020px)" />
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/header-large.css"
+        media="only screen and (min-width:1020px)" />
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/navigation-large.css"
+        media="only screen and (min-width:1020px)" />
+    <!--[if lte IE 8]>
+        <script type="text/javascript" src="/assets/scripts/respond.min.js"></script>
+        <![endif]-->
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/assets/css/global.css" />
+
+    <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,700' rel='stylesheet' type='text/css' />
+    <link rel="stylesheet" type="text/css" href="https://www.courts.state.co.us/css/Print.css" media="print" />
+    <link rel="shortcut icon" href="https://www.courts.state.co.us/images/icons/favicon_public.ico" />
+    <link rel="apple-touch-icon-precomposed"
+        href="https://www.courts.state.co.us/images/apple-touch-icon-precomposed.png" />
+
+    <script type="text/javascript" src="https://www.courts.state.co.us/assets/scripts/jquery-1.11.0.min.js"></script>
+    <script type="text/javascript" src="https://www.courts.state.co.us/assets/scripts/global-scripts.js"></script>
+
+    <!-- PNotify -->
+    <script type="text/javascript" src="https://www.courts.state.co.us/assets/scripts/PNotify.js"></script>
+    <link href="https://www.courts.state.co.us/assets/css/PNotifyBrightTheme.css" rel="stylesheet" type="text/css" />
+    <script type="text/javascript" src="https://www.courts.state.co.us/assets/scripts/PNotifyButtons.js"></script>
+
+
+
+    <script type="text/javascript">
+
+        var _gaq = _gaq || [];
+        _gaq.push(['_setAccount', 'UA-23986541-1']);
+        _gaq.push(['_trackPageview']);
+
+        (function () {
+            var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
+            ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
+            var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(ga, s);
+        })();
+
+    </script>
+
+
+
+    <script type="text/javascript">
+< !--
+            _CF_checkCFForm_1 = function(_CF_this) {
+            //reset on submit
+            _CF_error_exists = false;
+            _CF_error_messages = new Array();
+            _CF_error_fields = new Object();
+            _CF_FirstErrorField = null;
+
+
+            //display error messages and return success
+            if (_CF_error_exists) {
+                if (_CF_error_messages.length > 0) {
+                    // show alert() message
+                    _CF_onErrorAlert(_CF_error_messages);
+                    // set focus to first form error, if the field supports js focus().
+                    if (_CF_this[_CF_FirstErrorField].type == "text") { _CF_this[_CF_FirstErrorField].focus(); }
+
+                }
+                return false;
+            } else {
+                return true;
+            }
+        }
+//-->
+    </script>
+    <script type="text/javascript">
+< !--
+            _CF_checkfrm_Search = function(_CF_this) {
+            //reset on submit
+            _CF_error_exists = false;
+            _CF_error_messages = new Array();
+            _CF_error_fields = new Object();
+            _CF_FirstErrorField = null;
+
+
+            //display error messages and return success
+            if (_CF_error_exists) {
+                if (_CF_error_messages.length > 0) {
+                    // show alert() message
+                    _CF_onErrorAlert(_CF_error_messages);
+                    // set focus to first form error, if the field supports js focus().
+                    if (_CF_this[_CF_FirstErrorField].type == "text") { _CF_this[_CF_FirstErrorField].focus(); }
+
+                }
+                return false;
+            } else {
+                return true;
+            }
+        }
+//-->
+    </script>
+</head>
+
+<body>
+    <a href="#main-content" class="skip-content">Skip to main content</a>
+
+
+
+    <div class="header-top">
+        <div class="header-mobile-left"></div>
+        <a href="https://www.courts.state.co.us" class="header-mobile-right"></a>
+        <div class="inner-header">
+            <a href="https://www.courts.state.co.us" class="home-link"></a>
+            <div class="searchbar">
+                <form name="frm_Search" id="frm_Search" action="https://www.courts.state.co.us/search/index.cfm"
+                    style="margin:0;" method="get" class="MainSearch">
+                    <input type="submit" name="name" value="" style="float:right" />
+                    <input name="q" type="text" id="q" value="Search"
+                        onclick="if(this.value == 'Search'){this.value = '';}"
+                        onblur="if(this.value == ''){this.value = 'Search';}" style="float:right" />
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <div id="headerDisplay">
+
+        <div id="headercontainer">
+            <div id="header">
+                <ul>
+                    <li class="noscreen"><a href="https://www.courts.state.co.us">Home</a></li>
+                    <li class="noscreen"><a href="https://www.courts.state.co.us/search.cfm">Search</a></li>
+                    <li class="current"><a href="https://www.courts.state.co.us/Courts/Index.cfm" class="tab">Courts</a>
+                        <ul>
+                            <li><a href="https://www.courts.state.co.us/Courts/County/Choose.cfm">Trial Courts by
+                                    County</a></li>
+                            <li><a href="https://www.courts.state.co.us/Courts/District/Choose.cfm">Trial Courts by
+                                    District</a></li>
+                            <li><a href="https://www.courts.state.co.us/Courts/Supreme_Court/Index.cfm">Supreme
+                                    Court</a></li>
+                            <li><a href="https://www.courts.state.co.us/Courts/Court_Of_Appeals/Index.cfm">Court of
+                                    Appeals</a></li>
+                            <li><a href="https://www.courts.state.co.us/Courts/Water/Index.cfm">Water Courts</a></li>
+                            <li><a href="https://www.courts.state.co.us/Courts/Denver_Juvenile/Index.cfm">Denver
+                                    Juvenile Court</a></li>
+                            <li><a href="https://www.courts.state.co.us/Courts/Denver_Probate/Index.cfm">Denver Probate
+                                    Court</a></li>
+                            <li><a href="https://www.courts.state.co.us/Courts/Education/Index.cfm">Educational
+                                    Resources</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Probation/Index.cfm" class="tab">Probation</a>
+                        <ul>
+                            <li><a href="https://www.courts.state.co.us/Probation/County/Choose.cfm">By County</a></li>
+                            <li><a href="https://www.courts.state.co.us/Probation/Denver_Juvenile/Index.cfm">Denver
+                                    Juvenile Probation</a></li>
+                            <li><a href="https://www.courts.state.co.us/Probation/Resources.cfm">Resources</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Jury/Index.cfm" class="tab">Jury</a>
+                        <ul>
+                            <li><a href="https://www.courts.state.co.us/Jury/County/Choose.cfm">By County</a></li>
+                            <li><a href="https://www.courts.state.co.us/Jury/District/Choose.cfm">By District</a></li>
+                            <li><a href="https://www.courts.state.co.us/Jury/Jury_Commissioners.cfm">List of Jury
+                                    Commissioners</a></li>
+                            <li><a href="https://www.courts.state.co.us/Jury/Employer.cfm">Information for Employers</a>
+                            </li>
+                            <li><a href="https://www.courts.state.co.us/Jury/FAQs.cfm">Jury FAQs</a></li>
+                            <li><a href="https://www.courts.state.co.us/userfiles/file/jury/video/ColoradoJuror.mp4">Colorado
+                                    Jury Service Video</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Self_Help/Index.cfm"
+                            class="tab">Self&nbsp;Help&nbsp;&frasl;&nbsp;Forms</a>
+                        <ul>
+                            <li><a href="https://www.courts.state.co.us/Forms/Index.cfm">All Court Forms and
+                                    Instructions</a></li>
+                            <li><a href="https://www.courts.state.co.us/Forms/Espanol/Index.cfm">Formularios e
+                                    instrucciones judiciales en espa&ntilde;ol</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/adoption/">Adoption</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/appeals/">Appeals</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/bonds/">Bonds</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/conservatorship/">Conservatorship</a>
+                            </li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/criminalcases/">Criminal Cases</a>
+                            </li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/estate/">Estate Cases</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/extremeriskprotectionorders/">Extreme
+                                    Risk Protection Orders</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/family/">Family Cases</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/garnishments/">Garnishments</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/guardianship/">Guardianship</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/housing/">Housing Cases</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/judgments/">Judgments</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/money/">Money Cases</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/namechange/">Name Changes</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/protectionorders/">Protection
+                                    Orders</a></li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/sealingrecords/">Sealing Records</a>
+                            </li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/smallclaims/">Small Claims Cases</a>
+                            </li>
+                            <li><a href="https://www.courts.state.co.us/Self_Help/watercases/">Water Cases</a></li>
+                            <li><a href="https://www.courts.state.co.us/Administration/Section.cfm?Section=jp3dnad">Dependency
+                                    &amp; Neglect Advisement</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Careers/Index.cfm" class="tab">Careers</a>
+                        <ul>
+                            <li><a href="https://www.courts.state.co.us/Careers/Opportunities.cfm">Career
+                                    Opportunities</a></li>
+                            <li><a href="https://www.courts.state.co.us/Careers/Internship.cfm">Internship
+                                    Opportunities</a></li>
+                            <li><a href="https://www.courts.state.co.us/Careers/Judge.cfm">Judge Opportunities</a></li>
+                            <li><a href="https://www.courts.state.co.us/Administration/Unit.cfm?Unit=interp">Interpreter
+                                    Opportunities</a></li>
+                            <li><a href="https://www.courts.state.co.us/Careers/Volunteer.cfm">Volunteer
+                                    Opportunities</a></li>
+                            <li><a href="https://www.courts.state.co.us/Careers/Benefits.cfm">Benefits</a></li>
+                            <li><a href="https://www.courts.state.co.us/Careers/Descriptions.cfm">Job Descriptions</a>
+                            </li>
+                            <li><a href="https://www.courts.state.co.us/Careers/FAQs.cfm">Career FAQs</a></li>
+                        </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Media/Index.cfm" class="tab">Media</a>
+                        <ul>
+                            <li><a href="https://www.courts.state.co.us/Media/Press_Releases.cfm">Press Releases</a>
+                            </li>
+                            <li><a href="https://www.courts.state.co.us/Media/Opinions.cfm">Recent Orders &amp; Opinions
+                                    of Interest</a></li>
+                            <li><a href="https://www.courts.state.co.us/Media/Alerts.cfm">Media Alerts</a></li>
+                            <li><a href="https://www.courts.state.co.us/Media/Appointments.cfm">Judge Appointments</a>
+                            </li>
+                            <li><a href="https://www.courts.state.co.us/Media/Law_School.cfm">Law School for
+                                    Journalists</a></li>
+                            <li><a href="https://www.courts.state.co.us/Administration/Section.cfm?Section=pubacag">Access
+                                    Guide to Public Records</a></li>
+                            <li><a href="https://www.courts.state.co.us/Media/Link_Request.cfm">Web Link Request</a>
+                            </li>
+                        </ul>
+                    </li>
+                    <li><a href="https://www.courts.state.co.us/Administration/Index.cfm" class="tab">Administration</a>
+                        <ul>
+                            <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=pa">Court
+                                    Services</a></li>
+                            <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=exec">Executive
+                                    Division</a></li>
+                            <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=finan">Financial
+                                    Services</a></li>
+                            <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=hr">Human
+                                    Resources</a></li>
+                            <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=jbits">Information
+                                    Technology Services</a></li>
+                            <li><a href="https://www.courts.state.co.us/Administration/Division.cfm?Division=prob">Probation
+                                    Services</a></li>
+                        </ul>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+    </div>
+
+
+
+
+
+
+    <div id="main-wrapper">
+        <div id="main-content">
+
+            <span class="BreadcrumbsMobile">
+
+                <a href="https://www.courts.state.co.us" class="Breadcrumbs" style="padding-left:0px;">Home</a>
+
+
+                <a href="https://www.courts.state.co.us/Courts/Index.cfm" title="Courts" class="Breadcrumbs">Courts</a>
+                <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Index.cfm" class="Breadcrumbs">Supreme
+                    Court</a>
+                <span class="Breadcrumbs_Selected">Case Announcements</span>
+
+
+            </span>
+            <div style="clear:both"></div>
+
+            <div class="wrapper-full">
+                <div class="center-content-left">
+
+                    <span class="BreadcrumbsLarge">
+
+
+                        <a href="https://www.courts.state.co.us" class="Breadcrumbs" style="padding-left:0px;">Home</a>
+
+
+
+                        <a href="https://www.courts.state.co.us/Courts/Index.cfm" title="Courts"
+                            class="Breadcrumbs">Courts</a>
+                        <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Index.cfm"
+                            class="Breadcrumbs">Supreme Court</a>
+                        <span class="Breadcrumbs_Selected">Case Announcements</span>
+
+
+                    </span>
+                    <div style="clear:both"></div>
+
+
+                    <link rel="alternate" type="application/rss+xml" title="Supreme Court Case Announcements RSS Feed"
+                        href="/RSS/scAnnouncementFeed.xml">
+
+                    <span class="Title">Supreme Court Case Announcements <a href="/RSS/scAnnouncementFeed.xml"
+                            title="Supreme Court Announcements RSS Feed"><img src="/images/rssbuttonsmall.png"
+                                hspace="10" border="0" /></a></span><br />
+
+                    <span class="SubTitle">Future Case Announcements</span>
+                    <br />
+
+                    <p>&nbsp;</p>
+
+                    <p>Colorado Supreme Court case announcements for Monday, February 14, 2022 are now available.</p>
+
+                    <p><a href="/userfiles/file/Court_Probation/Supreme_Court/Opinions/2019/19SC763.pdf">22CO7, 19SC763-
+                            People v. Ray Ojeda</a></p>
+
+                    <p>&nbsp;</p>
+
+                    <p>&nbsp;</p>
+
+                    <br /><br />
+
+                    <span class="SubTitle">Past Case Announcements for the Supreme Court</span><br /><br />
+
+                    <form name="CFForm_1" id="CFForm_1"
+                        action="&#x2f;Courts&#x2f;Supreme_Court&#x2f;Case_Announcements&#x2f;Index.cfm" method="get"
+                        class="WebForm" onsubmit="return _CF_checkCFForm_1(this)">
+
+                        <span style="display:block; float:left; margin-right:50px">
+                            <label>Year</label><br />
+                            <select name="year" style="width:200px;" id="year">
+
+
+                                <option value="2022" selected="selected">2022</option>
+
+                                <option value="2021">2021</option>
+
+                                <option value="2020">2020</option>
+
+                                <option value="2019">2019</option>
+
+                                <option value="2018">2018</option>
+
+                                <option value="2017">2017</option>
+
+                                <option value="2016">2016</option>
+
+                                <option value="2015">2015</option>
+
+                                <option value="2014">2014</option>
+
+                                <option value="2013">2013</option>
+
+                                <option value="2012">2012</option>
+
+                                <option value="2011">2011</option>
+
+                                <option value="2010">2010</option>
+
+                                <option value="2009">2009</option>
+
+                                <option value="2008">2008</option>
+
+                                <option value="2007">2007</option>
+
+                                <option value="2006">2006</option>
+
+                                <option value="2005">2005</option>
+
+                                <option value="2004">2004</option>
+
+                                <option value="2003">2003</option>
+
+                                <option value="2002">2002</option>
+
+                                <option value="2001">2001</option>
+
+                                <option value="2000">2000</option>
+
+                                <option value="1999">1999</option>
+
+                                <option value="1998">1998</option>
+
+                            </select>
+                            <br /><br />
+                        </span>
+
+                        <span style="display:block; float:left;">
+                            <label>Month</label><br />
+                            <select name="month" style="width:200px;" id="month">
+
+                                <option value="">All</option>
+                                <option value="1">January</option>
+                                <option value="2">February</option>
+                                <option value="3">March</option>
+                                <option value="4">April</option>
+                                <option value="5">May</option>
+                                <option value="6">June</option>
+                                <option value="7">July</option>
+                                <option value="8">August</option>
+                                <option value="9">September</option>
+                                <option value="10">October</option>
+                                <option value="11">November</option>
+                                <option value="12">December</option>
+                            </select>
+
+                            <br /><br />
+                        </span>
+                        <div style="clear:both"></div>
+
+                        <input name="Submit" type="submit" value="Go" id="Submit" />
+                        <br /><br />
+
+                    </form>
+
+
+
+
+
+
+                    <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/42F7C502.14.22.pdf"
+                        title="February 14, 2022" target="_blank" class="touchable-link">February 14, 2022</a>
+
+
+
+                    <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/881AB902.07.22.pdf"
+                        title="February 07, 2022" target="_blank" class="touchable-link">February 07, 2022</a>
+
+
+
+                    <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/A4FC0601.31.22.pdf"
+                        title="January 31, 2022" target="_blank" class="touchable-link">January 31, 2022</a>
+
+
+
+                    <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/D5879701-24-22.pdf"
+                        title="January 24, 2022" target="_blank" class="touchable-link">January 24, 2022</a>
+
+
+
+                    <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/AAE98301-18-22.pdf"
+                        title="January 18, 2022" target="_blank" class="touchable-link">January 18, 2022</a>
+
+
+
+                    <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Case_Announcements/Files/2022/FF88FF01.10.22.pdf"
+                        title="January 10, 2022" target="_blank" class="touchable-link">January 10, 2022</a>
+
+
+
+
+
+
+                </div>
+                <div class="right-content">
+
+
+                    <span class="RightTitle">Can't Find It?</span>
+                    <br />
+
+                    Search Case Announcements
+                    and Published Opinions<br /><br />
+
+                    <form name="frm_Search" id="frm_Search" action="https://www.courts.state.co.us/search/index.cfm"
+                        method="get" onload="This.blur();" class="WebForm" onsubmit="return _CF_checkfrm_Search(this)">
+                        <input name="q" type="text" style="width:90%" id="q" />
+                        <input name="f" id="f" type="hidden" value="0" />
+                        <input name="s" id="s" type="hidden" value="Supreme_Court_Opinions" />
+                        <br /><br />
+                        <input name="btn_Submit" type="submit" value="Search" id="btn_Submit" /><br />
+                    </form>
+
+
+                    <span class="RightTitle">Court Proceedings</span>
+                    <br />
+
+                    <a href="https://www.courts.state.co.us/Courts/Supreme_Court/Index.cfm">Supreme Court
+                        Homepage</a><br />
+                    <a href="https://www.courts.state.co.us/Courts/live">Live and Archived Oral Argument
+                        Videos</a><br />
+                    <a title="Oral Arguments"
+                        href="https://www.courts.state.co.us/Courts/Supreme_Court/Oral_Arguments/Index.cfm">Oral
+                        Arguments</a><br />
+                    <a title="Original Proceedings"
+                        href="https://www.courts.state.co.us/Courts/Supreme_Court/Proceedings/Index.cfm">Original
+                        Proceedings</a><br />
+                    <a title="Ballot Initiative"
+                        href="https://www.courts.state.co.us/Courts/Supreme_Court/Ballot_Initiative.cfm">Ballot
+                        Initiative</a>
+
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+    <div style="clear:both"></div>
+    <div class="footer-spacer"></div>
+
+    <span class="fixed-footer-announce nomobile">
+        <a href="https://www.courts.state.co.us/announcements/index.cfm">important announcement</a>
+    </span>
+
+
+    <span class="fixed-footer">
+        <a href="https://data.colorado.gov/Government/State-Government-Revenue-and-Expenditures-in-Color/rifs-n6ib"
+            target="_blank">Transparency Online</a>
+        &nbsp; &bull; &nbsp;
+        <a href="https://www.courts.state.co.us/Contact/Index.cfm">Contact Us</a>
+        &nbsp; &bull; &nbsp;
+        <a href="https://www.courts.state.co.us/Administration/Unit.cfm?Unit=interp">Interpreters</a>
+        &nbsp; &bull; &nbsp;
+        <a href="https://www.courts.state.co.us/FAQs/Index.cfm">FAQ</a>
+        &nbsp; &bull; &nbsp;
+        <a href="https://www.courts.state.co.us/gallery/">Photos</a>
+        &nbsp; &bull; &nbsp;
+        <a href="https://www.courts.state.co.us/holiday.cfm">Holidays</a>
+    </span>
+
+    <span class="mobile-footer">
+        <span class="mobile-footer-title">Menu</span>
+
+        <a href="https://www.courts.state.co.us/announcements/index.cfm"
+            style="color:#FFF; background-color:#C30">Important Announcement</a>
+
+        <a href="https://www.courts.state.co.us/Index.cfm">Home</a>
+        <a href="https://www.courts.state.co.us/search.cfm">Search</a>
+        <a href="https://www.courts.state.co.us/Courts/Index.cfm">Courts</a>
+        <a href="https://www.courts.state.co.us/Probation/Index.cfm">Probation</a>
+        <a href="https://www.courts.state.co.us/Jury/Index.cfm">Jury</a>
+        <a href="https://www.courts.state.co.us/Self_Help/Index.cfm">Self&nbsp;Help &frasl; Forms</a>
+        <a href="https://www.courts.state.co.us/Careers/Index.cfm">Careers</a>
+        <a href="https://www.courts.state.co.us/Media/Index.cfm">Media</a>
+        <a href="https://www.courts.state.co.us/Administration/Index.cfm">Administration</a>
+        <a href="https://www.courts.state.co.us/Contact/Index.cfm">Contact us</a>
+        <a href="https://www.courts.state.co.us/Administration/Unit.cfm?Unit=interp">Interpreters</a>
+        <a href="https://www.courts.state.co.us/FAQs/Index.cfm">FAQ</a>
+        <a href="https://www.courts.state.co.us/gallery/">Photo Gallery</a>
+        <a href="https://www.courts.state.co.us/holiday.cfm">Holiday Schedule</a>
+    </span>
+    <div style="display:none">1a</div>
+
+
+
+
+</body>
+
+</html>

--- a/tests/examples/opinions/united_states/coloctapp_example.compare.json
+++ b/tests/examples/opinions/united_states/coloctapp_example.compare.json
@@ -7,6 +7,7 @@
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "19CA0438",
+    "citations": "Citation to be scraped in 'extract_from_text'",
     "case_name_shorts": ""
   },
   {
@@ -17,6 +18,7 @@
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "19CA2084",
+    "citations": "Citation to be scraped in 'extract_from_text'",
     "case_name_shorts": "Marriage of Crouch"
   }
 ]

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -67,6 +67,7 @@ class ScraperExtractFromText(unittest.TestCase):
             (
                 """                 The Supreme Court of the State of Colorado\n                 2 East 14th Avenue • Denver, Colorado 80203\n\n                                   2020 CO 6\n\n                      Supreme Court Case No. 20SC758\n                    Certiorari to the Colorado Court of Appeals\n                      Court of Appeals Case No. 18CA38\n""",
                 {
+                    "OpinionCluster": {"docket_number": "20SC758"},
                     "Citation": {
                         "volume": "2020",
                         "reporter": "CO",

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -9,6 +9,8 @@ class ScraperExtractFromText(unittest.TestCase):
     without a full integration test.
     """
 
+    # To avoid AssertionError when comparing example results for Colorado Appellate
+    maxDiff = None
     test_data = {
         "juriscraper.opinions.united_states.administrative_agency.bia": [
             (
@@ -61,6 +63,38 @@ class ScraperExtractFromText(unittest.TestCase):
             (
                 """Cite as 2022 Ark. App. 43\nARKANSAS COURT OF APPEALS\nDIVISION IV No. E-21-215\n  FRED JACKSON""",
                 {"OpinionCluster": {"docket_number": "E-21-215"}},
+            ),
+        ],
+        "juriscraper.opinions.united_states.state.colo": [
+            (
+                """                 The Supreme Court of the State of Colorado\n                 2 East 14th Avenue • Denver, Colorado 80203\n\n                                   2020 CO 6\n\n                      Supreme Court Case No. 20SC758\n                    Certiorari to the Colorado Court of Appeals\n                      Court of Appeals Case No. 18CA38\n""",
+                {
+                    "OpinionCluster": {"docket_number": "20SC758"},
+                    "Citation": {
+                        "volume": "2020",
+                        "reporter": "CO",
+                        "page": "6",
+                        "type": 2,
+                    },
+                },
+            ),
+        ],
+        "juriscraper.opinions.united_states.state.coloctapp": [
+            (
+                """     The summaries of the Colorado Court of Appeals published opinions\n  constitute no part of the opinion of the division but have been prepared by\n  the division for the convenience of the reader. The summaries may not be\n    cited or relied upon as they are not the official language of the division.\n  Any discrepancy between the language in the summary and in the opinion\n           should be resolved in favor of the language in the opinion.\n\n\n                                                                 SUMMARY\n                                                          September 9, 2021\n\n                               2021COA122\n\nNo. 20CA0621, Cummings v. Arapahoe Cnty. Sheriff’s Office —\nGovernment — County Officers — Sheriff — Deputies\n\n     A division of the court of appeals applies the holding from\n\nCummings v. Arapahoe County Sheriff’s Department, 2018 COA 136,\n\nto a sheriff’s personnel policy granting notice of an investigation and\n\nprovides guidance as to the scope of Cummings and section 30-10-\n\n506, C.R.S. 2020. Because the subject policy did not effectuate the\n\nspecific right section 30-10-506 grants a deputy — the right to\n\nnotice “of the reason for the proposed revocation” of his employment\n\n— the division concludes the policy was not contractually binding.\n\nAccordingly, the district court erred by instructing the jury to\n\nconsider the sheriff’s compliance with the policy in determining\n\nwhether he breached an implied employment contract.\nCOLORADO COURT OF APPEALS                                        2021COA122\n\n\nCourt of Appeals No. 20CA0621\nArapahoe County District Court No. 16CV32444\nHonorable Kenneth M. Plotz, Judge\n""",
+                {
+                    "OpinionCluster": {
+                        "docket_number": "20CA0621",
+                        "headnotes": "Cummings v. Arapahoe Cnty. Sheriff's Office — Government — County Officers — Sheriff — Deputies",
+                        "summary": """A division of the court of appeals applies the holding from Cummings v. Arapahoe County Sheriff's Department, 2018 COA 136, to a sheriff's personnel policy granting notice of an investigation and provides guidance as to the scope of Cummings and section 30-10- 506, C.R.S. 2020. Because the subject policy did not effectuate the specific right section 30-10-506 grants a deputy — the right to notice "of the reason for the proposed revocation" of his employment — the division concludes the policy was not contractually binding. Accordingly, the district court erred by instructing the jury to consider the sheriff's compliance with the policy in determining whether he breached an implied employment contract.""",
+                    },
+                    "Citation": {
+                        "volume": "2021",
+                        "reporter": "COA",
+                        "page": "122",
+                        "type": 2,
+                    },
+                },
             ),
         ],
     }

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -9,8 +9,6 @@ class ScraperExtractFromText(unittest.TestCase):
     without a full integration test.
     """
 
-    # To avoid AssertionError when comparing example results for Colorado Appellate
-    maxDiff = None
     test_data = {
         "juriscraper.opinions.united_states.administrative_agency.bia": [
             (

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -67,7 +67,6 @@ class ScraperExtractFromText(unittest.TestCase):
             (
                 """                 The Supreme Court of the State of Colorado\n                 2 East 14th Avenue • Denver, Colorado 80203\n\n                                   2020 CO 6\n\n                      Supreme Court Case No. 20SC758\n                    Certiorari to the Colorado Court of Appeals\n                      Court of Appeals Case No. 18CA38\n""",
                 {
-                    "OpinionCluster": {"docket_number": "20SC758"},
                     "Citation": {
                         "volume": "2020",
                         "reporter": "CO",

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -9,6 +9,8 @@ class ScraperExtractFromText(unittest.TestCase):
     without a full integration test.
     """
 
+    maxDiff = None
+
     test_data = {
         "juriscraper.opinions.united_states.administrative_agency.bia": [
             (
@@ -83,7 +85,7 @@ class ScraperExtractFromText(unittest.TestCase):
                 {
                     "OpinionCluster": {
                         "docket_number": "20CA0621",
-                        "headnotes": "Cummings v. Arapahoe Cnty. Sheriff's Office — Government — County Officers — Sheriff — Deputies",
+                        "headnotes": "Government — County Officers — Sheriff — Deputies",
                         "summary": """A division of the court of appeals applies the holding from Cummings v. Arapahoe County Sheriff's Department, 2018 COA 136, to a sheriff's personnel policy granting notice of an investigation and provides guidance as to the scope of Cummings and section 30-10- 506, C.R.S. 2020. Because the subject policy did not effectuate the specific right section 30-10-506 grants a deputy — the right to notice "of the reason for the proposed revocation" of his employment — the division concludes the policy was not contractually binding. Accordingly, the district court erred by instructing the jury to consider the sheriff's compliance with the policy in determining whether he breached an implied employment contract.""",
                     },
                     "Citation": {


### PR DESCRIPTION
Adds validation to prevent an error in the date's search when the Colorado court's staff changes the announcement text in the week's opinion releases page.
Also, adds the optional citation for the Supreme court's opinions.

Closes #495 
Closes [COURTLISTENER-23R](https://sentry.io/organizations/freelawproject/issues/2989083379/?referrer=github_integration)