### PR TITLE
Fix pre-commit black error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,6 +32,7 @@ repos:
     rev: 22.3.0
     hooks:
      - id: black
+       additional_dependencies: ['click==8.0.4']
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.10.1


### PR DESCRIPTION
- Locked black dependency to click=8.0.4 to avoid python 3.10 incompatibility error.