### PR TITLE
fix(wva): W.Va. just throws up bad and broken links.

### DIFF
--- a/juriscraper/opinions/united_states/state/wva.py
+++ b/juriscraper/opinions/united_states/state/wva.py
@@ -96,7 +96,8 @@ class Site(OpinionSite):
         dont work. Instead we should just do head requests on the newest 50
         opinions and drop them.
         """
-
+        if self.test_mode_enabled():
+            return
         to_be_removed = [
             index
             for index, url in enumerate(self.download_urls[:50])


### PR DESCRIPTION
Fixes W.Va. 

WVa. throws out bad PDFs.  The scraper also grabs way more than is necessary.  So instead 
We just do a head request for all the PDFs and remove any broken ones.  

Currently this removes two PDFs from the list.  