### PR TITLE
Fixes PACER download PDF error messages

### DIFF
--- a/juriscraper/lib/html_utils.py
+++ b/juriscraper/lib/html_utils.py
@@ -8,6 +8,7 @@ from lxml import etree, html
 from lxml.etree import XMLSyntaxError
 from lxml.html import HtmlElement, fromstring, html5parser, tostring
 from lxml.html.clean import Cleaner
+from requests import Response
 
 try:
     # Use cchardet for performance to detect the character encoding.
@@ -275,3 +276,11 @@ def fix_links_in_lxml_tree(link, keep_anchors=False):
         return url
     else:
         return url.split("#")[0]
+
+
+def is_html(response: Response) -> bool:
+    """Determines whether the item downloaded is an HTML document or something
+    else."""
+    if "text/html" in response.headers.get("content-type", ""):
+        return True
+    return False

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -189,14 +189,6 @@ def is_text(response):
     return False
 
 
-def is_html(response):
-    """Determines whether the item downloaded is an HTML document or something
-    else."""
-    if "text/html" in response.headers.get("content-type", ""):
-        return True
-    return False
-
-
 def get_nonce_from_form(r):
     """Get a nonce value from a HTML response. Returns the first nonce that is
     found.

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -189,6 +189,14 @@ def is_text(response):
     return False
 
 
+def is_html(response):
+    """Determines whether the item downloaded is an HTML document or something
+    else."""
+    if "text/html" in response.headers.get("content-type", ""):
+        return True
+    return False
+
+
 def get_nonce_from_form(r):
     """Get a nonce value from a HTML response. Returns the first nonce that is
     found.

--- a/tests/network/test_PacerFreeOpinionsTest.py
+++ b/tests/network/test_PacerFreeOpinionsTest.py
@@ -132,7 +132,7 @@ class PacerFreeOpinionsTest(unittest.TestCase):
         report = self.reports["ksd"]
         r, msg = report.download_pdf("81531", "07902639735")
         self.assertIsNone(r)
-        self.assertIn("Failed to get docket entry", msg)
+        self.assertIn("Document not available in case", msg)
 
     @SKIP_IF_NO_PACER_LOGIN
     def test_query_can_get_multiple_results(self):
@@ -221,10 +221,9 @@ class PacerMagicLinkTest(unittest.TestCase):
         r, msg = report.download_pdf(
             pacer_case_id, pacer_doc_id, pacer_magic_num
         )
-        mock_logger.error.assert_called_with(
-            "Unable to download PDF. PDF not served as "
-            "binary data and unable to find iframe src "
-            f"attribute. URL: {url}, caseid: {pacer_case_id}, "
+        mock_logger.warning.assert_called_with(
+            "Magic link document not available in case: "
+            f"URL: {url}, caseid: {pacer_case_id}, "
             f"magic_num: {pacer_magic_num}"
         )
         # No PDF should be returned

--- a/tests/network/test_PacerFreeOpinionsTest.py
+++ b/tests/network/test_PacerFreeOpinionsTest.py
@@ -222,9 +222,9 @@ class PacerMagicLinkTest(unittest.TestCase):
             pacer_case_id, pacer_doc_id, pacer_magic_num
         )
         mock_logger.warning.assert_called_with(
-            "Magic link document not available in case: "
-            f"URL: {url}, caseid: {pacer_case_id}, "
-            f"magic_num: {pacer_magic_num}"
+            "Document not available via magic link in case: "
+            f"caseid: {pacer_case_id}, magic_num: {pacer_magic_num}, "
+            f"URL: {url}"
         )
         # No PDF should be returned
         self.assertEqual(r, None)


### PR DESCRIPTION
After testing sentry errors that were throwing these error messages: `Unable to download PDF. PDF not served as binary data and unable to find iframe src attribute.`

I found three reasons:

1.- `The document is not available.`
![Screen Shot 2022-06-27 at 18 48 19](https://user-images.githubusercontent.com/486004/176056948-669613cf-3b36-48b9-b1c5-83afbf9adec3.png)

The text to compare and detect this error it's currently `This document is not available` so I changed the text to compare to `document is not available` in order to cover the two versions with `This` and `The`

2.- `This document is currently Under Seal and not available to the general public.`
![Screen Shot 2022-06-27 at 18 50 37](https://user-images.githubusercontent.com/486004/176057570-b37b1833-352d-4c47-ae08-e3afbc79ff51.png)

Currently, to detect a sealed document error we look for the text `Sealed Document` so to cover this sealed error version I added the text `Under Seal`

3.- Magic link document:
 Since we don't log in to PACER when downloading a magic link document if the document is unavailable (because the magic link is not valid, document not available, sealed, etc), we get an HTML document to log into pacer, after reviewing some recap.emails I found to versions one HTML that redirects to `pacer.login.uscourts.gov` and other for txwd that uses its own login page: `ecf.txwd.uscourts.gov/cgi-bin/login.pl?logout`, I was wondering if some other courts could use their own login page?
 So I better decided to check after the first GET request to obtain the magic link document if the response is an HTML document and if it doesn't contain an IFRAME, it means that the document has a problem and we can't download it directly because it's necessary to log in whether to check the error or to download if the magic link is no longer valid,  however, I think it's not recommendable to log in to check the actual error because if the problem is that the magic link is not valid but the document is available that could generate charges, so I think this might be the best option.

Finally, I changed the text to verify this test: `test_download_unavailable_pdf ` from `Failed to get docket entry` to `Document not available in case` because it was not passing the test seems that the error message might be changed recently.

