### PR TITLE
fix(michigan): Michigan supreme court tweak

### DIFF
--- a/juriscraper/opinions/united_states/state/mich.py
+++ b/juriscraper/opinions/united_states/state/mich.py
@@ -84,9 +84,9 @@ class Site(OpinionSiteLinear):
                 # Else, query the API and return the name of the case
                 self.url = f"https://www.courts.michigan.gov/api/CaseSearch/SearchCaseSearchContent/?searchQuery={case['title']}"
                 self.html = self._download()
-                case["name"] = self.html["caseDetailResults"]["searchItems"][
-                    0
-                ]["title"].title()
+                case["name"] = self.html["opinionResults"]["searchItems"][0][
+                    "title"
+                ].title()
             return case["name"]
 
         return DeferringList(seed=self.cases, fetcher=fetcher)


### PR DESCRIPTION
We found a handy api but it appears
the wrong key was being used to get
to the supreme court opinions in the
elastic results.