### PR TITLE
Fix Tax Scraper Again

### DIFF
--- a/juriscraper/opinions/united_states/federal_special/tax.py
+++ b/juriscraper/opinions/united_states/federal_special/tax.py
@@ -4,6 +4,8 @@
 # Neutral Citation Format (Tax Court opinions): 138 T.C. No. 1 (2012)
 # Neutral Citation Format (Memorandum opinions): T.C. Memo 2012-1
 # Neutral Citation Format (Summary opinions: T.C. Summary Opinion 2012-1
+import json
+from datetime import date, timedelta
 
 from juriscraper.lib.string_utils import titlecase
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
@@ -12,8 +14,33 @@ from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 class Site(OpinionSiteLinear):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.url = "https://public-api-green.dawson.ustaxcourt.gov/public-api/todays-opinions"
+        self.url = "https://public-api-blue.dawson.ustaxcourt.gov/public-api/opinion-search"
         self.court_id = self.__module__
+        self.td = date.today()
+        today = self.td.strftime("%m/%d/%Y")
+        self.method = "GET"
+
+        last_month = (self.td - timedelta(days=31)).strftime("%m/%d/%Y")
+        self.params = {
+            "dateRange": "customDates",
+            "startDate": last_month,
+            "endDate": today,
+            "opinionTypes": "MOP,SOP,TCOP",
+        }
+
+    def _download(self, request_dict={}):
+        print(self.url)
+        if self.test_mode_enabled():
+            self.json = json.load(open(self.url))
+        else:
+            self.json = (
+                self.request["session"]
+                .get(
+                    self.url,
+                    params=self.params,
+                )
+                .json()
+            )
 
     def _process_html(self) -> None:
         """Process the html
@@ -21,8 +48,7 @@ class Site(OpinionSiteLinear):
         Iterate over each item on the page collecting our data.
         return: None
         """
-        opinion_json = self.request["response"].json()
-        for case in opinion_json:
+        for case in self.json:
             url = self._get_url(case["docketNumber"], case["docketEntryId"])
             status = (
                 "Published"
@@ -47,7 +73,7 @@ class Site(OpinionSiteLinear):
         param docketEntryId: The docket entry id
         return: The URL to the PDF
         """
-        self.url = f"https://public-api-green.dawson.ustaxcourt.gov/public-api/{docket_number}/{docketEntryId}/public-document-download-url"
+        self.url = f"https://public-api-blue.dawson.ustaxcourt.gov/public-api/{docket_number}/{docketEntryId}/public-document-download-url"
         if self.test_mode_enabled():
             # Don't fetch urls when running tests.  Because it requires
             # a second api request.

--- a/tests/examples/opinions/united_states/tax_example.compare.json
+++ b/tests/examples/opinions/united_states/tax_example.compare.json
@@ -2,7 +2,7 @@
   {
     "case_dates": "2021-12-08",
     "case_names": "Alice J. Coggin",
-    "download_urls": "https://public-api-green.dawson.ustaxcourt.gov/public-api/21580-19/919cb4ce-fb26-4cb3-a0f3-a1a2f0e6927b/public-document-download-url",
+    "download_urls": "https://public-api-blue.dawson.ustaxcourt.gov/public-api/21580-19/919cb4ce-fb26-4cb3-a0f3-a1a2f0e6927b/public-document-download-url",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,


### PR DESCRIPTION
Fix tax scraper for changes to website.

Updated endpoints and changes to the website broke the scraper again

