### PR TITLE
533 Adds NDAs support for recap email

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Features:
 Changes:
 
  - Added support to parse NDAs and download their free documents.
+ - Added support to get attached documents from NEFs.
 
 ## Past
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,18 @@ Releases are also tagged in git, if that's helpful.
 
 ## Current
 
+**2.5.12 - 2022-08-12**
+
+Features:
+
+ - N/A
+
+Changes:
+
+ - Added support to parse NDAs and download their free documents.
+
+## Past
+
 **2.5.11 - 2022-07-29**
 
 Features:
@@ -25,8 +37,6 @@ Features:
 Changes:
 
  - Fix Tax Scraper
-
-## Past
 
 **2.5.10 - 2022-07-28**
 

--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -20,6 +20,7 @@ class NotificationEmail(BaseDocketReport, BaseReport):
     def __init__(self, court_id):
         self.court_id = court_id
         self.content_type = None
+        self.email_notice_type = None
         super().__init__(court_id)
 
     @property
@@ -49,6 +50,19 @@ class NotificationEmail(BaseDocketReport, BaseReport):
                 }
 
         return {**base, **parsed}
+
+    def _email_notice_type(self) -> str:
+        """Gets the email notice type from the email text.
+
+        :returns: The email notice type NEF or NDA.
+        """
+        if self.email_notice_type is None:
+            if "Notice of Docket Activity" in self.tree.text_content():
+                self.email_notice_type = "NDA"
+                return self.email_notice_type
+            self.email_notice_type = "NEF"
+            return self.email_notice_type
+        return self.email_notice_type
 
     def _sibling_path(self, label):
         """Gets the path string for the sibling of a label cell (td)
@@ -93,6 +107,12 @@ class NotificationEmail(BaseDocketReport, BaseReport):
 
         :returns: Docket number, parsed
         """
+
+        if self._email_notice_type() == "NDA":
+            path = self._sibling_path("Case Number")
+            case_number = self._xpath_text_0(self.tree, f"{path}/a")
+            return case_number
+
         path = self._sibling_path("Case Number")
         docket_number = self._parse_docket_number_strs(
             self.tree.xpath(f"{path}/a/text()")
@@ -156,7 +176,10 @@ class NotificationEmail(BaseDocketReport, BaseReport):
         :returns: Anchor tag, if it's found
         """
         try:
-            path = f"{self._sibling_path('Document Number')}//a"
+            if self._email_notice_type() == "NDA":
+                path = f"{self._sibling_path('Document(s)')}//a"
+            else:
+                path = f"{self._sibling_path('Document Number')}//a"
             return self.tree.xpath(path)[0]
         except IndexError:
             return None
@@ -167,7 +190,10 @@ class NotificationEmail(BaseDocketReport, BaseReport):
         :returns: Cleaned docket text
         """
         path = '//strong[contains(., "Docket Text:")]/following-sibling::'
-        node = self.tree.xpath(f"{path}font[1]/b//text()")
+        if self._email_notice_type() == "NDA":
+            node = self.tree.xpath(f"{path}br[1]/following::text()[1]")
+        else:
+            node = self.tree.xpath(f"{path}font[1]/b//text()")
         description = ""
         if len(node):
             for des_part in node:
@@ -262,7 +288,15 @@ class NotificationEmail(BaseDocketReport, BaseReport):
                 document_url = (
                     anchor.xpath("./@href")[0] if anchor is not None else None
                 )
-                document_number = self._get_document_number()
+                if self._email_notice_type() == "NDA":
+                    if document_url is not None:
+                        document_number = get_pacer_doc_id_from_doc1_url(
+                            document_url
+                        )
+                    else:
+                        document_number = None
+                else:
+                    document_number = self._get_document_number()
 
         if description is not None:
             entries = [
@@ -281,15 +315,18 @@ class NotificationEmail(BaseDocketReport, BaseReport):
                 entries[0]["pacer_doc_id"] = get_pacer_doc_id_from_doc1_url(
                     document_url
                 )
-                entries[0]["pacer_case_id"] = get_pacer_case_id_from_doc1_url(
-                    document_url
-                )
-                entries[0]["pacer_seq_no"] = get_pacer_seq_no_from_doc1_url(
-                    document_url
-                )
-                entries[0][
-                    "pacer_magic_num"
-                ] = get_pacer_magic_num_from_doc1_url(document_url)
+                if self._email_notice_type() != "NDA":
+                    entries[0][
+                        "pacer_case_id"
+                    ] = get_pacer_case_id_from_doc1_url(document_url)
+                    entries[0][
+                        "pacer_seq_no"
+                    ] = get_pacer_seq_no_from_doc1_url(document_url)
+                    entries[0][
+                        "pacer_magic_num"
+                    ] = get_pacer_magic_num_from_doc1_url(document_url)
+            if self._email_notice_type() == "NDA":
+                entries[0]["pacer_case_id"] = self._get_docket_number()
             return entries
         return []
 
@@ -324,6 +361,7 @@ class NotificationEmail(BaseDocketReport, BaseReport):
         :returns: List of email recipients with names and email addresses
         """
         # Matching names in this format is a bit less reliable. May be worth coming back to.
+
         end_point = self._get_docket_number()
 
         replacements = [
@@ -381,15 +419,19 @@ class NotificationEmail(BaseDocketReport, BaseReport):
 
         :returns: List of email recipients with names and email addresses
         """
-        path = '//b[contains(., "Notice has been electronically mailed to")]/following-sibling::'
-        recipient_lines = self.tree.xpath(f"{path}text()")
-        link_lines = self.tree.xpath(f"{path}a")
-        if len(link_lines):
-            return self._get_email_recipients_with_links(
-                self.tree.xpath(
-                    'string(//b[contains(., "Notice has been electronically mailed to")]/parent::node())'
+        if self._email_notice_type() == "NDA":
+            path = '//strong[contains(., "Notice will be electronically mailed to")]/following-sibling::'
+            recipient_lines = self.tree.xpath(f"{path}text()")
+        else:
+            path = '//b[contains(., "Notice has been electronically mailed to")]/following-sibling::'
+            recipient_lines = self.tree.xpath(f"{path}text()")
+            link_lines = self.tree.xpath(f"{path}a")
+            if len(link_lines):
+                return self._get_email_recipients_with_links(
+                    self.tree.xpath(
+                        'string(//b[contains(., "Notice has been electronically mailed to")]/parent::node())'
+                    )
                 )
-            )
         return self._get_email_recipients_with_links(" ".join(recipient_lines))
 
     def _get_email_recipients_plain(

--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -36,6 +36,7 @@ class NotificationEmail(BaseDocketReport, BaseReport):
                     "contains_attachments": self._contains_attachments_plain(),
                     "docket_number": self._get_docket_number_plain(),
                     "date_filed": self._get_date_filed(),
+                    "email_notice_type": self._email_notice_type(),
                     "docket_entries": self._get_docket_entries(),
                     "email_recipients": self._get_email_recipients_plain(),
                 }
@@ -45,6 +46,7 @@ class NotificationEmail(BaseDocketReport, BaseReport):
                     "contains_attachments": self._contains_attachments(),
                     "docket_number": self._get_docket_number(),
                     "date_filed": self._get_date_filed(),
+                    "email_notice_type": self._email_notice_type(),
                     "docket_entries": self._get_docket_entries(),
                     "email_recipients": self._get_email_recipients(),
                 }
@@ -315,6 +317,11 @@ class NotificationEmail(BaseDocketReport, BaseReport):
                 entries[0]["pacer_doc_id"] = get_pacer_doc_id_from_doc1_url(
                     document_url
                 )
+                entries[0][
+                    "pacer_magic_num"
+                ] = get_pacer_magic_num_from_doc1_url(
+                    document_url, self.email_notice_type
+                )
                 if self._email_notice_type() != "NDA":
                     entries[0][
                         "pacer_case_id"
@@ -322,9 +329,6 @@ class NotificationEmail(BaseDocketReport, BaseReport):
                     entries[0][
                         "pacer_seq_no"
                     ] = get_pacer_seq_no_from_doc1_url(document_url)
-                    entries[0][
-                        "pacer_magic_num"
-                    ] = get_pacer_magic_num_from_doc1_url(document_url)
             if self._email_notice_type() == "NDA":
                 entries[0]["pacer_case_id"] = self._get_docket_number()
             return entries

--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -16,7 +16,7 @@ from ..lib.html_utils import (
     strip_bad_html_tags_insecure,
 )
 from ..lib.log_tools import make_default_logger
-from .utils import is_pdf, make_doc1_url
+from .utils import is_pdf, make_doc1_url, make_docs1_url
 
 logger = make_default_logger()
 
@@ -176,6 +176,7 @@ class BaseReport:
         pacer_case_id: str,
         pacer_doc_id: int,
         pacer_magic_num: Optional[str] = None,
+        email_notice_type: Optional[str] = None,
     ) -> Tuple[Optional[Response], str]:
         """Download a PDF from PACER.
 
@@ -198,6 +199,11 @@ class BaseReport:
                 "caseid": pacer_case_id,
                 "magic_num": pacer_magic_num,
             }
+            if email_notice_type == "NDA":
+                url = make_docs1_url(self.court_id, pacer_doc_id)
+                params = {
+                    "uid": pacer_magic_num,
+                }
             # Add parameters to the PACER base url and make a GET request
             req_timeout = (60, 300)
             r = requests.get(url, params=params, timeout=req_timeout)

--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -176,7 +176,7 @@ class BaseReport:
         pacer_case_id: str,
         pacer_doc_id: int,
         pacer_magic_num: Optional[str] = None,
-        email_notice_type: Optional[str] = None,
+        appellate: bool = False,
     ) -> Tuple[Optional[Response], str]:
         """Download a PDF from PACER.
 
@@ -199,7 +199,7 @@ class BaseReport:
                 "caseid": pacer_case_id,
                 "magic_num": pacer_magic_num,
             }
-            if email_notice_type == "NDA":
+            if appellate:
                 url = make_docs1_url(self.court_id, pacer_doc_id)
                 params = {
                     "uid": pacer_magic_num,

--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -191,19 +191,21 @@ class BaseReport:
             # document anonymously by its magic link
 
             # Create PACER base url from court_id and pacer_doc_id
-            url = make_doc1_url(self.court_id, pacer_doc_id, True)
-
             # Magic link parameters
             # We don't need the de_seq_num parameter to fetch the free document
-            params = {
-                "caseid": pacer_case_id,
-                "magic_num": pacer_magic_num,
-            }
             if appellate:
                 url = make_docs1_url(self.court_id, pacer_doc_id)
+                # For appellate documents the magic_number is the uid param
                 params = {
                     "uid": pacer_magic_num,
                 }
+            else:
+                url = make_doc1_url(self.court_id, pacer_doc_id, True)
+                params = {
+                    "caseid": pacer_case_id,
+                    "magic_num": pacer_magic_num,
+                }
+
             # Add parameters to the PACER base url and make a GET request
             req_timeout = (60, 300)
             r = requests.get(url, params=params, timeout=req_timeout)

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -61,10 +61,10 @@ def get_pacer_case_id_from_doc1_url(url):
 
 
 def get_pacer_magic_num_from_doc1_url(
-    url: str, email_notice_type: Optional[str] = None
+    url: str, appellate: bool = False,
 ) -> Optional[str]:
     """Extract the magic number from the doc1 URL."""
-    if email_notice_type == "NDA":
+    if appellate:
         # NDA free look link format is:
         # https://ecf.ca2.uscourts.gov/docs1/00208721516?uid=b775e9908ad79ce2
         match = re.search(r"uid=(\w+)", url)

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -61,7 +61,8 @@ def get_pacer_case_id_from_doc1_url(url):
 
 
 def get_pacer_magic_num_from_doc1_url(
-    url: str, appellate: bool = False,
+    url: str,
+    appellate: bool = False,
 ) -> Optional[str]:
     """Extract the magic number from the doc1 URL."""
     if appellate:

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -1,4 +1,5 @@
 import re
+from typing import Optional
 
 import requests
 import tldextract
@@ -59,9 +60,18 @@ def get_pacer_case_id_from_doc1_url(url):
         return None
 
 
-def get_pacer_magic_num_from_doc1_url(url):
-    """Extract the caseid from the doc1 URL."""
-    match = re.search(r"magic_num=(\d+)", url)
+def get_pacer_magic_num_from_doc1_url(
+    url: str, email_notice_type: Optional[str] = None
+) -> Optional[str]:
+    """Extract the magic number from the doc1 URL."""
+    if email_notice_type == "NDA":
+        # NDA free look link format is:
+        # https://ecf.ca2.uscourts.gov/docs1/00208721516?uid=b775e9908ad79ce2
+        match = re.search(r"uid=(\w+)", url)
+    else:
+        # NEF free look link format is:
+        # https://ecf.almd.uscourts.gov/doc1/01713718205?caseid=75736&de_seq_num=30&magic_num=77910494
+        match = re.search(r"magic_num=(\d+)", url)
     if match:
         return match.group(1)
     else:
@@ -173,6 +183,15 @@ def make_doc1_url(court_id, pacer_doc_id, skip_attachment_page):
         # If the fourth digit is a 0, replace it with a 1
         pacer_doc_id = f"{pacer_doc_id[:3]}1{pacer_doc_id[4:]}"
     return f"https://ecf.{court_id}.uscourts.gov/doc1/{pacer_doc_id}"
+
+
+def make_docs1_url(court_id: str, pacer_doc_id: str) -> str:
+    """Make a docs1 URL for NDAs free look downloads.
+
+    :param court_id: The court ID.
+    :param pacer_doc_id: The PACER document ID.
+    """
+    return f"https://ecf.{court_id}.uscourts.gov/docs1/{pacer_doc_id}"
 
 
 def is_pdf(response):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import unittest
 from setuptools import find_packages, setup
 from setuptools.command.install import install
 
-VERSION = "2.5.11"
+VERSION = "2.5.12"
 AUTHOR = "Free Law Project"
 EMAIL = "info@free.law"
 HERE = os.path.abspath(os.path.dirname(__file__))

--- a/tests/examples/pacer/nda/ca11_1.json
+++ b/tests/examples/pacer/nda/ca11_1.json
@@ -1,5 +1,6 @@
 {
   "case_name": "Marjorie Taylor Greene v. Secretary of State for the State of Georgia",
+  "contains_attachments": false,
   "court_id": "ca11",
   "date_filed": "2022-08-10",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca11_1.json
+++ b/tests/examples/pacer/nda/ca11_1.json
@@ -1,0 +1,20 @@
+{
+  "case_name": "Marjorie Taylor Greene v. Secretary of State for the State of Georgia",
+  "court_id": "ca11",
+  "date_filed": "2022-08-10",
+  "docket_entries": [
+    {
+      "date_filed": "2022-08-10",
+      "description": "MOTION to take judicial notice filed by Marjorie Taylor Greene. Opposition to Motion is Unknown. [9735298-1] [22-11299] (ECF: James Bopp)",
+      "document_number": null,
+      "document_url": "https://ecf.ca11.uscourts.gov/docs1/011012414726?uid=5d3e5e8bb0269ddd",
+      "pacer_case_id": "78099",
+      "pacer_doc_id": "011012414726",
+      "pacer_magic_num": "5d3e5e8bb0269ddd",
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "22-11299",
+  "appellate": true,
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nda/ca11_1.txt
+++ b/tests/examples/pacer/nda/ca11_1.txt
@@ -1,0 +1,77 @@
+Return-Path: <ecf_help@ca11.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 21j6f7k8qd262mhfcnh3ufpa1jml6l8n1kf8rco1
+ for archive@recap.email;
+ Wed, 10 Aug 2022 20:53:55 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca11.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecf_help@ca11.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca11.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecf_help@ca11.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ca11.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFGSXlRT0I0ZDBCdFpvSlNFcW5WZWRLdGNvYnVpL01wdVhyd3dTQlpqaDFYS0lMNkZmb21rWlYxcUYzWWQyc3ZuQzA1MFNLcy9TZm9VbjFVWjd5RWxkbFdrb1h4MTNOSmtYbDFEVkp2eGVjMG5NMTQxUWtyUVBOOE80NzNBclVBSW1Vdi91UjVBcVNhVDhHM3FXekVWU2RrUkpwaGsveXZOQ09zbzVqNkJqc3MxaTZnclp4VlBwdW41RktFRTZHL2F4dlAva3RnbEdzSHY2eFFWT0FUUUlpcnB2NzZSZGoxOHhJZGxzSkhWdEJ3M3NXR0NIZ3J2U3VQQzVQQUxjME5Benc4bG1zTWtNd2dsckozeVZGSmV0S0VDUEgvanVNVVhBcVV2RHN6bHdkY2c9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=GQySDUAKESya3eX+GiU0eY8HS6C8Sm7bBwKg2KYuAsPRQK9XfEKpJ+tCI5Skzc/R/sXoLbAU944acE3IirhzofL+8vBelZKV/qsr67CsiJCMHe+lzpqSqMqj78FDxW6LRKGzHRpliFZ6GRIodJP5FuAvWGsj5CWw3DxB8Glo8i0=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1660164836; v=1; bh=fhyrPA2DP1Glzt/drjxq99qzJpoDLcwu9IF69dXLfVs=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.227
+Received: from ca11db.ca11.gtwy.dcn ([156.119.190.227])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 10 Aug 2022 16:53:55 -0400
+Received: from ca11db.ca11.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca11db.ca11.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 27AKrIuZ042298
+	for <archive@recap.email>; Wed, 10 Aug 2022 16:53:18 -0400
+Date: Wed, 10 Aug 2022 16:53:18 -0400 (EDT)
+From: ecf_help@ca11.uscourts.gov
+To: archive@recap.email
+Message-ID: <1485724778.3702.1660164798150@ca11db.ca11.gtwy.dcn>
+Subject: 22-11299-W Marjorie Taylor Greene v. Secretary of State for the
+ State of Georgia, et al "Motion filed Take Judicial Notice"
+ (1:22-cv-01294-AT)
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-11299-W Marjorie Taylor Greene v. Secretary of State for the State of Georgia, et al "Motion filed Take Judicial Notice" (1:22-cv-01294-AT)</TITLE>
+</HEAD>
+<BODY BGCOLOR="#FFFFCC" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Eleventh Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 08/10/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Marjorie Taylor Greene v. Secretary of State for the State of Georgia, et al<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=78099">22-11299</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca11.uscourts.gov/docs1/011012414726?uid=5d3e5e8bb0269ddd">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+<i>MOTION to take judicial notice filed by Marjorie Taylor Greene. Opposition to Motion is Unknown. [9735298-1]</i> [22-11299] (ECF: James Bopp)<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Recipient User Test 1<BR>
+Recipient User Test 2<BR>
+Recipient U. Test 3<BR>
+Recipient U. Test 4<BR>
+Recipient U. Test 5<BR>
+Recipient U. Test<BR>
+<BR><BR><STRONG>Notice sent via US Mail to:</STRONG><BR><BR>
+<P>Recipient User Test 1<BR>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit
+<BR>
+<P>Recipient User Test 2.<BR>
+Lorem ipsum dolor sit amet, consectetur adipiscing elit
+<BR>
+<BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Appellant's Motion to Take Judicial Notice<BR>
+<STRONG>Original Filename: </STRONG>Greene Federal Resp to Mot to Take Notice Dismissal.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1160056652 [Date=08/10/2022] [FileNumber=9735298-0] [3ad851861401211b73a399f5b0aba979de78cf42f8b98abbe0f957176c90282e677d22b065afad4e03ff61a50b5fcf74c8994157e558cfe89b372be6024ea2e4]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca11_1.txt
+++ b/tests/examples/pacer/nda/ca11_1.txt
@@ -34,7 +34,7 @@ Content-Transfer-Encoding: 7bit
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-11299-W Marjorie Taylor Greene v. Secretary of State for the State of Georgia, et al "Motion filed Take Judicial Notice" (1:22-cv-01294-AT)</TITLE>
 </HEAD>
-<BODY BGCOLOR="#FFFFCC" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<BODY BGCOLOR="#FFFFCC" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
 <P><STRONG>
 ***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
 <P><CENTER><STRONG>United States Court of Appeals for the Eleventh Circuit</STRONG></CENTER>

--- a/tests/examples/pacer/nda/ca11_2.json
+++ b/tests/examples/pacer/nda/ca11_2.json
@@ -1,6 +1,7 @@
 {
   "court_id":"ca11",
   "case_name":"Marjorie Taylor Greene v. Secretary of State for the State of Georgia",
+  "contains_attachments": false,
   "docket_number":"22-11299",
   "date_filed":"2022-08-22",
   "appellate":true,

--- a/tests/examples/pacer/nda/ca11_2.json
+++ b/tests/examples/pacer/nda/ca11_2.json
@@ -17,6 +17,6 @@
      }
   ],
   "email_recipients":[
-     
+
   ]
 }

--- a/tests/examples/pacer/nda/ca11_2.json
+++ b/tests/examples/pacer/nda/ca11_2.json
@@ -1,0 +1,22 @@
+{
+  "court_id":"ca11",
+  "case_name":"Marjorie Taylor Greene v. Secretary of State for the State of Georgia",
+  "docket_number":"22-11299",
+  "date_filed":"2022-08-22",
+  "appellate":true,
+  "docket_entries":[
+     {
+        "date_filed":"2022-08-22",
+        "description":"ORDER: Benjamin Horton's motion to withdraw as counsel for Intervenor Defendants-Appellees is GRANTED. ENTERED FOR THE COURT-BY DIRECTION. [9740726-2]",
+        "document_url":"https://ecf.ca11.uscourts.gov/docs1/011012430127?uid=689705320460ce5c",
+        "document_number": null,
+        "pacer_doc_id":"011012430127",
+        "pacer_case_id":"78099",
+        "pacer_seq_no":null,
+        "pacer_magic_num":"689705320460ce5c"
+     }
+  ],
+  "email_recipients":[
+     
+  ]
+}

--- a/tests/examples/pacer/nda/ca11_2.txt
+++ b/tests/examples/pacer/nda/ca11_2.txt
@@ -1,0 +1,88 @@
+Return-Path: <ecf_help@ca11.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 7n68id1q0b33fouf2i492gqib2sgejn52n45mp81
+ for archive@recap.email;
+ Mon, 22 Aug 2022 16:26:53 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca11.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecf_help@ca11.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca11.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecf_help@ca11.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ca11.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHZ2NKOEU5bDFpbWh3MVBZUlowSVlhRnZmV3FEaWNSazMvWDZlcDZNZUJrWk45VUlibzNpdkhUdkYxR3BrS0lJU0FZRjJnU0R1amdoYU9MODJPVFk4UmFXNzJIeWVLcXVxTGlsRUtEcFREdkdOQUFqMkpEakh3OThjZlRxZTc0Q0NjTnV3NExNeUkyOHR6KzBtSjJvMkZHRW15a0JESHFHYmF1WFNNamJXaFBHK0tqTVU4SEU5VDB5cncrVm1mRFpTNnErbXVONjBSM1NDWHZhODREd2RwZEQrZlNxRnhQNVc0eFBKN3M1YndvR1NGR25Eay9OMXZWS1RHMGxTRWQ3WDJMa1lkaWNlS3l2VFBlRzdqZjdpTTd2THNJNysxNXFBbUpuVmt3bzlvdUE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=erCRkcCbJkdeiadZypqkhH1zRTdNunc6sRQ/4g5cLB3mDXpsygwAbjAiPNQIRDesvc3iJ2HoMZy3IQr3xtHrjNIhwGnm2DpYHsnZ4k/wIse2n8EcRTG8BXe4YQUTPzAXXSXMsHm2edzX4aN61DoKHxF5+RxK87iajyKyrSA7KQA=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1661185614; v=1; bh=DSEzMCWm91T5Tvuy2OWhhp4KgBryoSCZCgTPRxwjJGY=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.227
+Received: from ca11db.ca11.gtwy.dcn ([156.119.190.227])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 22 Aug 2022 12:26:53 -0400
+Received: from ca11db.ca11.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca11db.ca11.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 27MGQqWJ075812
+	for <archive@recap.email>; Mon, 22 Aug 2022 12:26:52 -0400
+Date: Mon, 22 Aug 2022 12:26:52 -0400 (EDT)
+From: ecf_help@ca11.uscourts.gov
+To: archive@recap.email
+Message-ID: <912456404.1449.1661185612646@ca11db.ca11.gtwy.dcn>
+Subject: 22-11299-JJ Marjorie Taylor Greene v. Secretary of State for the
+ State of Georgia, et al "Court Order Filed Granted by Court Withdraw as
+ Counsel" (1:22-cv-01294-AT)
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.=
+w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV=3D"Content-Type" CONTENT=3D"text/html; charset=3Dutf-8"><T=
+ITLE>22-11299-JJ Marjorie Taylor Greene v. Secretary of State for the State=
+ of Georgia, et al "Court Order Filed Granted by Court Withdraw as Counsel"=
+ (1:22-cv-01294-AT)</TITLE>
+</HEAD>
+<BODY BGCOLOR=3D"#FFFFCC" TEXT=3D"#000000" LINK=3D"#0000ff" VLINK=3D"#551a8=
+b" ALINK=3D"#ff0000">=20
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States =
+policy permits attorneys of record and parties in a case (including pro se =
+litigants) to receive one free electronic copy of all documents filed elect=
+ronically, if receipt is required by law or directed by the filer.  PACER a=
+ccess fees apply to all other users.  To avoid later charges, download a co=
+py of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Eleventh Circuit<=
+/STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 08/22/2022
+<TABLE BORDER=3D0 CELLSPACING=3D3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan=3D'2'>Marjorie Taylor Greene v. Secretary of State for the Stat=
+e of Georgia, et al<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF=3D"https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?s=
+ervlet=3DDocketReportFilter.jsp&caseId=3D78099">22-11299</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF=3D"https://ecf.ca11.uscourts.gov/docs1/011012430127?uid=3D68970=
+5320460ce5c">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+<font color =3D Green>ORDER: Benjamin Horton=E2=80=99s motion to withdraw a=
+s counsel for Intervenor Defendants-Appellees
+is GRANTED. ENTERED FOR THE COURT-BY DIRECTION. [9740726-2] </font><BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Recipient User Test 1<BR>
+Recipient User Test 2<BR>
+Recipient U. Test 3<BR>
+Recipient U. Test 4<BR>
+Recipient U. Test 5<BR>
+Recipient U. Test<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Court Order Filed<BR>
+<STRONG>Original Filename: </STRONG>22-11299+order.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=3D1160056652 [Date=3D08/22/2022] [FileNumber=3D9742970=
+-0] [0ea474df38d952168ee2be273f5bf7ee9e40ae627cf771c7a2ed9fe26ef7f1f8aea978=
+00e6c850cecfd9c085b8f9c416e8c358dac6853107e4aa1f8ea40135b6]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca2_1.json
+++ b/tests/examples/pacer/nda/ca2_1.json
@@ -1,0 +1,80 @@
+{
+  "case_name": "New York State Telecommunicati v. James",
+  "court_id": "ca2",
+  "date_filed": "2022-07-27",
+  "docket_entries": [
+    {
+      "date_filed": "2022-07-27",
+      "description": "LETTER, on behalf of Appellant Letitia A. James, <EDIT by Clerk's Office> RECEIVED. Service date 07/27/2022 by CM/ECF.[3355063] [21-1975]",
+      "document_number": "00208942267",
+      "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208942267?uid=37cacbbc313ab362",
+      "pacer_case_id": "21-1975",
+      "pacer_doc_id": "00208942267",
+      "pacer_magic_num": null,
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "21-1975",
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "andyschwartzman@gmail.com"
+      ],
+      "name": "Mr. Andrew Jay Schwartzman, -:"
+    },
+    {
+      "email_addresses": [
+        "mberry@akingump.com"
+      ],
+      "name": "Matthew B. Berry, -:"
+    },
+    {
+      "email_addresses": [
+        "krussell@goldsteinrussell.com",
+        "eoevans@goldsteinrussell.com"
+      ],
+      "name": "Kevin K. Russell, -:"
+    },
+    {
+      "email_addresses": [
+        "agoldsmith@kellogghansen.com",
+        "mswank@kellogghansen.com",
+        "jhois@kellogghansen.com"
+      ],
+      "name": "Mr. Andrew Edward Goldsmith, -:"
+    },
+    {
+      "email_addresses": [
+        "jlamken@mololamken.com"
+      ],
+      "name": "Mr. Jeffrey A. Lamken, -:"
+    },
+    {
+      "email_addresses": [
+        "estallman@clinical.law.berkeley.edu",
+        "estallman@recap.email"
+      ],
+      "name": "Erik Robert Stallman, Assistant Director:"
+    },
+    {
+      "email_addresses": [
+        "eric.delpozo@ag.ny.gov",
+        "nyoag.nycpdf@ag.ny.gov"
+      ],
+      "name": "Eric Del Pozo, -:"
+    },
+    {
+      "email_addresses": [
+        "dmills@cooley.com",
+        "efiling-notice@ecf.pacerpro.com"
+      ],
+      "name": "David E. Mills, -:"
+    },
+    {
+      "email_addresses": [
+        "Wilson_Dudley@ca2.uscourts.gov"
+      ],
+      "name": "Wilson Dudley, Deputy Clerk:"
+    }
+  ]
+}

--- a/tests/examples/pacer/nda/ca2_1.json
+++ b/tests/examples/pacer/nda/ca2_1.json
@@ -10,11 +10,12 @@
       "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208942267?uid=37cacbbc313ab362",
       "pacer_case_id": "21-1975",
       "pacer_doc_id": "00208942267",
-      "pacer_magic_num": null,
+      "pacer_magic_num": "37cacbbc313ab362",
       "pacer_seq_no": null
     }
   ],
   "docket_number": "21-1975",
+  "email_notice_type": "NDA",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca2_1.json
+++ b/tests/examples/pacer/nda/ca2_1.json
@@ -1,5 +1,6 @@
 {
   "case_name": "New York State Telecommunicati v. James",
+  "contains_attachments": false,
   "court_id": "ca2",
   "date_filed": "2022-07-27",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca2_1.json
+++ b/tests/examples/pacer/nda/ca2_1.json
@@ -15,7 +15,7 @@
     }
   ],
   "docket_number": "21-1975",
-  "email_notice_type": "NDA",
+  "appellate": true,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca2_1.txt
+++ b/tests/examples/pacer/nda/ca2_1.txt
@@ -52,15 +52,11 @@ The following transaction was filed on 07/27/2022
 LETTER, on behalf of Appellant Letitia A. James, &lt;EDIT by Clerk's Office&gt; RECEIVED. Service date 07/27/2022 by CM/ECF.[3355063] [21-1975]<BR>
 <BR>
 <STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
-Mr. Andrew Jay Schwartzman, -: andyschwartzman@gmail.com<BR>
-Matthew B. Berry, -: mberry@akingump.com<BR>
-Kevin K. Russell, -: krussell@goldsteinrussell.com, eoevans@goldsteinrussell.com<BR>
-Mr. Andrew Edward Goldsmith, -: agoldsmith@kellogghansen.com, mswank@kellogghansen.com, jhois@kellogghansen.com<BR>
-Mr. Jeffrey A. Lamken, -: jlamken@mololamken.com<BR>
-Erik Robert Stallman, Assistant Director: estallman@clinical.law.berkeley.edu, estallman@recap.email<BR>
-Eric Del Pozo, -: eric.delpozo@ag.ny.gov, nyoag.nycpdf@ag.ny.gov<BR>
-David E. Mills, -: dmills@cooley.com, efiling-notice@ecf.pacerpro.com<BR>
-Wilson Dudley, Deputy Clerk: Wilson_Dudley@ca2.uscourts.gov<BR>
+Recipient User Test 1, -: testing1@gexample.com<BR>
+Recipient User Test 2, -: testing2@gexample.com<BR>
+Recipient User Test 3, -: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4, -: testing4@gexample.com, testing4_1@gexample.com, testing4_2@gexample.com<BR>
+Recipient User Test 5, Deputy Clerk: Testing5@gexample.com<BR>
 <BR><BR><BR><STRONG>Notice will be stored in the notice cart for:</STRONG><BR><BR>
 Wilson Dudley, Deputy Clerk<BR>
 Quality Control 1<BR>

--- a/tests/examples/pacer/nda/ca2_1.txt
+++ b/tests/examples/pacer/nda/ca2_1.txt
@@ -1,0 +1,74 @@
+Return-Path: <cmecf@ca2.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 193ea8q09fvfv5anoukc227eaapgrggbsbk7mh81
+ for estallman@recap.email;
+ Wed, 27 Jul 2022 14:15:12 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca2.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=cmecf@ca2.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca2.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=cmecf@ca2.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ca2.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFGLzJnS3VISlh4c1lXVU10dVk5akl0WHRRMDBrWEkzVHhlSkxWY1pOc1V5VWQxKzlSNVdhVlUzY3RDemRZajdrQXFDVTB0YmphaG1ENnFYT0FYT3hXajlQNHlNZS80YmtGcHoxdXAxSHJlVVlIaWZDZnp4STIvc1plMjh5RTlrMVFWTDVUNW9zZFhvdTl0azRQTksvV3BxSlpUSjRIRWJ1NnJqVFI3eC94VzFYaFBzR2Q4VGd6Z2tURkVpWTZib1F2NzJDSjN2Z3BaejlBVFFKOTJMTXNSeDR5aXZZa21ZdTJTWHNBUDRjS1RBK2hqZG9XZ1ZsMVhGWGpBT1pJTkJWTHNQUnV0YVIrQWllNDlPNzFWd3JYbkhNUE5NclNWQmZNN2lGaG5rdW1ibkE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=DgnY60iv/RFGTDbUPsuCAO0EX61rL8vQW8ik8JjIXkR9UfiZs8jnxsEzpXQSs+WVeIHFBcUE97QxIz4c7dXM+u3BvTAP1NRMU7sZMTtzj9wNvkEIK/PK8PMB11VAenzuua8WKrdkZoWTTEODBg4MHU/CM34aikehn5sl5vsV9Ek=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1658931313; v=1; bh=60vxeUZ4TNqAJ+hIVhFiz2ARNsEEBhOMgMJ0sHV/iXQ=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.45
+Received: from ca2db.ca2.gtwy.dcn ([156.119.190.45])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 27 Jul 2022 10:15:12 -0400
+Received: from ca2db.ca2.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca2db.ca2.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 26REEQeZ096711
+	for <estallman@recap.email>; Wed, 27 Jul 2022 10:14:27 -0400
+Date: Wed, 27 Jul 2022 10:14:26 -0400 (EDT)
+From: cmecf@ca2.uscourts.gov
+To: estallman@recap.email
+Message-ID: <581527383.726.1658931267053@ca2db.ca2.gtwy.dcn>
+Subject: 21-1975 New York State Telecommunicati v. James "Letter RECEIVED"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-1975 New York State Telecommunicati v. James "Letter RECEIVED"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>Court of Appeals, 2nd Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 07/27/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>New York State Telecommunicati v. James<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=55129">21-1975</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca2.uscourts.gov/docs1/00208942267?uid=37cacbbc313ab362">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+LETTER, on behalf of Appellant Letitia A. James, &lt;EDIT by Clerk's Office&gt; RECEIVED. Service date 07/27/2022 by CM/ECF.[3355063] [21-1975]<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Mr. Andrew Jay Schwartzman, -: andyschwartzman@gmail.com<BR>
+Matthew B. Berry, -: mberry@akingump.com<BR>
+Kevin K. Russell, -: krussell@goldsteinrussell.com, eoevans@goldsteinrussell.com<BR>
+Mr. Andrew Edward Goldsmith, -: agoldsmith@kellogghansen.com, mswank@kellogghansen.com, jhois@kellogghansen.com<BR>
+Mr. Jeffrey A. Lamken, -: jlamken@mololamken.com<BR>
+Erik Robert Stallman, Assistant Director: estallman@clinical.law.berkeley.edu, estallman@recap.email<BR>
+Eric Del Pozo, -: eric.delpozo@ag.ny.gov, nyoag.nycpdf@ag.ny.gov<BR>
+David E. Mills, -: dmills@cooley.com, efiling-notice@ecf.pacerpro.com<BR>
+Wilson Dudley, Deputy Clerk: Wilson_Dudley@ca2.uscourts.gov<BR>
+<BR><BR><BR><STRONG>Notice will be stored in the notice cart for:</STRONG><BR><BR>
+Wilson Dudley, Deputy Clerk<BR>
+Quality Control 1<BR>
+<BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Letter RECEIVED<BR>
+<STRONG>Original Filename: </STRONG>argument unavailability letter.pdfa.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1161632333 [Date=07/27/2022] [FileNumber=3355063-0] [6e34d879a246dc15ce259ff404d9b62e1316b271bb78eda98ae3e703ddec742de8c0147e4c28e20f6258b491b8fbe66cc2524d180a4381cc7f8c4b9f8389cd87]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca2_2.json
+++ b/tests/examples/pacer/nda/ca2_2.json
@@ -1,5 +1,6 @@
 {
   "case_name": "New York State Telecommunicati v. James",
+  "contains_attachments": false,
   "court_id": "ca2",
   "date_filed": "2022-06-14",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca2_2.json
+++ b/tests/examples/pacer/nda/ca2_2.json
@@ -10,11 +10,12 @@
       "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208883934?uid=4a800555f691be89",
       "pacer_case_id": "21-1975",
       "pacer_doc_id": "00208883934",
-      "pacer_magic_num": null,
+      "pacer_magic_num": "4a800555f691be89",
       "pacer_seq_no": null
     }
   ],
   "docket_number": "21-1975",
+  "email_notice_type": "NDA",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca2_2.json
+++ b/tests/examples/pacer/nda/ca2_2.json
@@ -1,0 +1,94 @@
+{
+  "case_name": "New York State Telecommunicati v. James",
+  "court_id": "ca2",
+  "date_filed": "2022-06-14",
+  "docket_entries": [
+    {
+      "date_filed": "2022-06-14",
+      "description": "LETTER, on behalf of Appellee CTIA - The Wireless Association, New York State Telecommunications Association, Inc., NTCA - The Rural Broadband Association and USTelecom - The Broadband Association, <EDIT by Clerk's Office> RECEIVED. Service date 06/14/2022 by CM/ECF.[3332664] [21-1975]",
+      "document_number": "00208883934",
+      "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208883934?uid=4a800555f691be89",
+      "pacer_case_id": "21-1975",
+      "pacer_doc_id": "00208883934",
+      "pacer_magic_num": null,
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "21-1975",
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "andyschwartzman@gmail.com"
+      ],
+      "name": "Mr. Andrew Jay Schwartzman, -:"
+    },
+    {
+      "email_addresses": [
+        "mberry@akingump.com"
+      ],
+      "name": "Matthew B. Berry, -:"
+    },
+    {
+      "email_addresses": [
+        "wus@dany.nyc.gov"
+      ],
+      "name": "Mr. Steven Wu, -:"
+    },
+    {
+      "email_addresses": [
+        "krussell@goldsteinrussell.com",
+        "eoevans@goldsteinrussell.com"
+      ],
+      "name": "Kevin K. Russell, -:"
+    },
+    {
+      "email_addresses": [
+        "agoldsmith@kellogghansen.com",
+        "mswank@kellogghansen.com",
+        "jhois@kellogghansen.com"
+      ],
+      "name": "Mr. Andrew Edward Goldsmith, -:"
+    },
+    {
+      "email_addresses": [
+        "jlamken@mololamken.com"
+      ],
+      "name": "Mr. Jeffrey A. Lamken, -:"
+    },
+    {
+      "email_addresses": [
+        "sangstreich@kellogghansen.com",
+        "aoak@kellogghansen.com",
+        "scott-angstreich-1818@ecf.pacerpro.com"
+      ],
+      "name": "Mr. Scott Harris Angstreich, -:"
+    },
+    {
+      "email_addresses": [
+        "estallman@clinical.law.berkeley.edu",
+        "estallman@recap.email"
+      ],
+      "name": "Erik Robert Stallman, Assistant Director:"
+    },
+    {
+      "email_addresses": [
+        "eric.delpozo@ag.ny.gov",
+        "nyoag.nycpdf@ag.ny.gov"
+      ],
+      "name": "Eric Del Pozo, -:"
+    },
+    {
+      "email_addresses": [
+        "dmills@cooley.com",
+        "efiling-notice@ecf.pacerpro.com"
+      ],
+      "name": "David E. Mills, -:"
+    },
+    {
+      "email_addresses": [
+        "Wilson_Dudley@ca2.uscourts.gov"
+      ],
+      "name": "Wilson Dudley, Deputy Clerk:"
+    }
+  ]
+}

--- a/tests/examples/pacer/nda/ca2_2.json
+++ b/tests/examples/pacer/nda/ca2_2.json
@@ -15,7 +15,7 @@
     }
   ],
   "docket_number": "21-1975",
-  "email_notice_type": "NDA",
+  "appellate": true,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca2_2.json
+++ b/tests/examples/pacer/nda/ca2_2.json
@@ -6,9 +6,9 @@
     {
       "date_filed": "2022-06-14",
       "description": "LETTER, on behalf of Appellee CTIA - The Wireless Association, New York State Telecommunications Association, Inc., NTCA - The Rural Broadband Association and USTelecom - The Broadband Association, <EDIT by Clerk's Office> RECEIVED. Service date 06/14/2022 by CM/ECF.[3332664] [21-1975]",
-      "document_number": "00208883934",
+      "document_number": null,
       "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208883934?uid=4a800555f691be89",
-      "pacer_case_id": "21-1975",
+      "pacer_case_id": "55129",
       "pacer_doc_id": "00208883934",
       "pacer_magic_num": "4a800555f691be89",
       "pacer_seq_no": null
@@ -18,78 +18,37 @@
   "appellate": true,
   "email_recipients": [
     {
-      "email_addresses": [
-        "andyschwartzman@gmail.com"
-      ],
-      "name": "Mr. Andrew Jay Schwartzman, -:"
+       "name":"Recipient User Test 1, -:",
+       "email_addresses":[
+          "testing1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "mberry@akingump.com"
-      ],
-      "name": "Matthew B. Berry, -:"
+       "name":"Recipient User Test 2, -:",
+       "email_addresses":[
+          "testing2@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "wus@dany.nyc.gov"
-      ],
-      "name": "Mr. Steven Wu, -:"
+       "name":"Recipient User Test 3, -:",
+       "email_addresses":[
+          "testing3@gexample.com",
+          "testing3_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "krussell@goldsteinrussell.com",
-        "eoevans@goldsteinrussell.com"
-      ],
-      "name": "Kevin K. Russell, -:"
+       "name":"Recipient User Test 4, -:",
+       "email_addresses":[
+          "testing4@gexample.com",
+          "testing4_1@gexample.com",
+          "testing4_2@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "agoldsmith@kellogghansen.com",
-        "mswank@kellogghansen.com",
-        "jhois@kellogghansen.com"
-      ],
-      "name": "Mr. Andrew Edward Goldsmith, -:"
-    },
-    {
-      "email_addresses": [
-        "jlamken@mololamken.com"
-      ],
-      "name": "Mr. Jeffrey A. Lamken, -:"
-    },
-    {
-      "email_addresses": [
-        "sangstreich@kellogghansen.com",
-        "aoak@kellogghansen.com",
-        "scott-angstreich-1818@ecf.pacerpro.com"
-      ],
-      "name": "Mr. Scott Harris Angstreich, -:"
-    },
-    {
-      "email_addresses": [
-        "estallman@clinical.law.berkeley.edu",
-        "estallman@recap.email"
-      ],
-      "name": "Erik Robert Stallman, Assistant Director:"
-    },
-    {
-      "email_addresses": [
-        "eric.delpozo@ag.ny.gov",
-        "nyoag.nycpdf@ag.ny.gov"
-      ],
-      "name": "Eric Del Pozo, -:"
-    },
-    {
-      "email_addresses": [
-        "dmills@cooley.com",
-        "efiling-notice@ecf.pacerpro.com"
-      ],
-      "name": "David E. Mills, -:"
-    },
-    {
-      "email_addresses": [
-        "Wilson_Dudley@ca2.uscourts.gov"
-      ],
-      "name": "Wilson Dudley, Deputy Clerk:"
+       "name":"Recipient User Test 5, Deputy Clerk:",
+       "email_addresses":[
+          "Testing5@gexample.com"
+       ]
     }
-  ]
+ ]
 }

--- a/tests/examples/pacer/nda/ca2_2.txt
+++ b/tests/examples/pacer/nda/ca2_2.txt
@@ -1,0 +1,76 @@
+Return-Path: <cmecf@ca2.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id c7jk6m9ggfjeu8g9arh5acjcmlaei19ekf4lkp01
+ for estallman@recap.email;
+ Tue, 14 Jun 2022 20:21:13 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca2.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=cmecf@ca2.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca2.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=cmecf@ca2.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ca2.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHVjR1TmE3VlBESDhpOCtGN3RIY0w0Sld6VlF5MDNxUENpN05NL3Nka2w3WkpyekpzRWgxV2hCMGkvT1RlT29tVEdnQWlubDl6UHVUNlZOdEo0V0I0eWdjRXBKVStjM1JaMXdqQ01XMlRtd3RDR1BTQVg5Q0NnMHhkZ214cFpyaUdwclVqSnh3cXJRNlc1dU1mcXNXUy83M0dqVm81S2pnTXJCK25OYmZpVVBUZENTZ0ROQlkwVWkxaXN5NFVVL24wSk5yRHpFSUl3YmdiN3Z3ek1rTnc5cHNkVW9PZHdYTk1FM1p2d1dTd2ZyTlZzVGtlOUdyM1RuQ1VKZitZSjdoVkpHanJpNXViUGF5eGJoUDdXL2x1MktDMGNtbEY1SWRwSGx4bVBJTFZOM2c9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=WWKIsDKqcONc6z0+NV9/nOLBF8lfeSFJEjUxuxtbEtdIxXfcf5PX351P6WSLkdBF56Z4LiqgXxeD8dyBquSDXDz52tMXXVK4PeseqmrGP3cD2hCEqxK0WSKEEjWnhVhE0by6ZI77nvX61F4IycXmQWYRHTLB+UsK04uPWBsQ2Zc=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1655238074; v=1; bh=Tqw8ETb7pdiuLBgN1w8gW0Z+mqdjHqtcZ2hdmisQsaU=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.45
+Received: from ca2db.ca2.gtwy.dcn ([156.119.190.45])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 14 Jun 2022 16:21:12 -0400
+Received: from ca2db.ca2.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca2db.ca2.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 25EKKIwX024465
+	for <estallman@recap.email>; Tue, 14 Jun 2022 16:20:18 -0400
+Date: Tue, 14 Jun 2022 16:20:18 -0400 (EDT)
+From: cmecf@ca2.uscourts.gov
+To: estallman@recap.email
+Message-ID: <367869517.2783.1655238018172@ca2db.ca2.gtwy.dcn>
+Subject: 21-1975 New York State Telecommunicati v. James "Letter RECEIVED"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-1975 New York State Telecommunicati v. James "Letter RECEIVED"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>Court of Appeals, 2nd Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 06/14/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>New York State Telecommunicati v. James<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=55129">21-1975</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca2.uscourts.gov/docs1/00208883934?uid=4a800555f691be89">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+LETTER, on behalf of Appellee CTIA - The Wireless Association, New York State Telecommunications Association, Inc., NTCA - The Rural Broadband Association and USTelecom - The Broadband Association, &lt;EDIT by Clerk's Office&gt; RECEIVED. Service date 06/14/2022 by CM/ECF.[3332664] [21-1975]<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Mr. Andrew Jay Schwartzman, -: andyschwartzman@gmail.com<BR>
+Matthew B. Berry, -: mberry@akingump.com<BR>
+Mr. Steven Wu, -: wus@dany.nyc.gov<BR>
+Kevin K. Russell, -: krussell@goldsteinrussell.com, eoevans@goldsteinrussell.com<BR>
+Mr. Andrew Edward Goldsmith, -: agoldsmith@kellogghansen.com, mswank@kellogghansen.com, jhois@kellogghansen.com<BR>
+Mr. Jeffrey A. Lamken, -: jlamken@mololamken.com<BR>
+Mr. Scott Harris Angstreich, -: sangstreich@kellogghansen.com, aoak@kellogghansen.com, scott-angstreich-1818@ecf.pacerpro.com<BR>
+Erik Robert Stallman, Assistant Director: estallman@clinical.law.berkeley.edu, estallman@recap.email<BR>
+Eric Del Pozo, -: eric.delpozo@ag.ny.gov, nyoag.nycpdf@ag.ny.gov<BR>
+David E. Mills, -: dmills@cooley.com, efiling-notice@ecf.pacerpro.com<BR>
+Wilson Dudley, Deputy Clerk: Wilson_Dudley@ca2.uscourts.gov<BR>
+<BR><BR><BR><STRONG>Notice will be stored in the notice cart for:</STRONG><BR><BR>
+Wilson Dudley, Deputy Clerk<BR>
+Quality Control 1<BR>
+<BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Letter RECEIVED<BR>
+<STRONG>Original Filename: </STRONG>2022 06 14 SHA Ltr to Clerk re Unavailability.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1161632333 [Date=06/14/2022] [FileNumber=3332664-0] [10c9234264bda4f0612894b687eded14b4bc763336bc2e171e8434dbc2dea17ef7daa9ebf6072759e0b460dfb3f2dfc8ce650262855047d553f63161baf80096]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca2_2.txt
+++ b/tests/examples/pacer/nda/ca2_2.txt
@@ -52,17 +52,11 @@ The following transaction was filed on 06/14/2022
 LETTER, on behalf of Appellee CTIA - The Wireless Association, New York State Telecommunications Association, Inc., NTCA - The Rural Broadband Association and USTelecom - The Broadband Association, &lt;EDIT by Clerk's Office&gt; RECEIVED. Service date 06/14/2022 by CM/ECF.[3332664] [21-1975]<BR>
 <BR>
 <STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
-Mr. Andrew Jay Schwartzman, -: andyschwartzman@gmail.com<BR>
-Matthew B. Berry, -: mberry@akingump.com<BR>
-Mr. Steven Wu, -: wus@dany.nyc.gov<BR>
-Kevin K. Russell, -: krussell@goldsteinrussell.com, eoevans@goldsteinrussell.com<BR>
-Mr. Andrew Edward Goldsmith, -: agoldsmith@kellogghansen.com, mswank@kellogghansen.com, jhois@kellogghansen.com<BR>
-Mr. Jeffrey A. Lamken, -: jlamken@mololamken.com<BR>
-Mr. Scott Harris Angstreich, -: sangstreich@kellogghansen.com, aoak@kellogghansen.com, scott-angstreich-1818@ecf.pacerpro.com<BR>
-Erik Robert Stallman, Assistant Director: estallman@clinical.law.berkeley.edu, estallman@recap.email<BR>
-Eric Del Pozo, -: eric.delpozo@ag.ny.gov, nyoag.nycpdf@ag.ny.gov<BR>
-David E. Mills, -: dmills@cooley.com, efiling-notice@ecf.pacerpro.com<BR>
-Wilson Dudley, Deputy Clerk: Wilson_Dudley@ca2.uscourts.gov<BR>
+Recipient User Test 1, -: testing1@gexample.com<BR>
+Recipient User Test 2, -: testing2@gexample.com<BR>
+Recipient User Test 3, -: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4, -: testing4@gexample.com, testing4_1@gexample.com, testing4_2@gexample.com<BR>
+Recipient User Test 5, Deputy Clerk: Testing5@gexample.com<BR>
 <BR><BR><BR><STRONG>Notice will be stored in the notice cart for:</STRONG><BR><BR>
 Wilson Dudley, Deputy Clerk<BR>
 Quality Control 1<BR>

--- a/tests/examples/pacer/nda/ca2_3.json
+++ b/tests/examples/pacer/nda/ca2_3.json
@@ -1,5 +1,6 @@
 {
   "case_name": "New York State Telecommunicati v. James",
+  "contains_attachments": false,
   "court_id": "ca2",
   "date_filed": "2022-03-23",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca2_3.json
+++ b/tests/examples/pacer/nda/ca2_3.json
@@ -10,11 +10,12 @@
       "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208754210?uid=59a7f7615f78153b",
       "pacer_case_id": "21-1975",
       "pacer_doc_id": "00208754210",
-      "pacer_magic_num": null,
+      "pacer_magic_num": "59a7f7615f78153b",
       "pacer_seq_no": null
     }
   ],
   "docket_number": "21-1975",
+  "email_notice_type": "NDA",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca2_3.json
+++ b/tests/examples/pacer/nda/ca2_3.json
@@ -6,9 +6,9 @@
     {
       "date_filed": "2022-03-23",
       "description": "REPLY BRIEF, on behalf of Appellant Letitia A. James, FILED. Service date 03/23/2022 by CM/ECF. [3283515] [21-1975]",
-      "document_number": "00208754210",
+      "document_number": null,
       "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208754210?uid=59a7f7615f78153b",
-      "pacer_case_id": "21-1975",
+      "pacer_case_id": "55129",
       "pacer_doc_id": "00208754210",
       "pacer_magic_num": "59a7f7615f78153b",
       "pacer_seq_no": null
@@ -18,78 +18,37 @@
   "appellate": true,
   "email_recipients": [
     {
-      "email_addresses": [
-        "andyschwartzman@gmail.com"
-      ],
-      "name": "Mr. Andrew Jay Schwartzman, -:"
+       "name":"Recipient User Test A, -:",
+       "email_addresses":[
+          "testinga@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "mberry@akingump.com"
-      ],
-      "name": "Matthew B. Berry, -:"
+       "name":"Recipient User Test B, -:",
+       "email_addresses":[
+          "testingb@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "wus@dany.nyc.gov"
-      ],
-      "name": "Mr. Steven Wu, -:"
+       "name":"Recipient User Test C, -:",
+       "email_addresses":[
+          "testingc@gexample.com",
+          "testingcc@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "krussell@goldsteinrussell.com",
-        "eoevans@goldsteinrussell.com"
-      ],
-      "name": "Kevin K. Russell, -:"
+       "name":"Recipient User Test D, -:",
+       "email_addresses":[
+          "testingd@gexample.com",
+          "testingdd@gexample.com",
+          "testingddd@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "agoldsmith@kellogghansen.com",
-        "mswank@kellogghansen.com",
-        "jhois@kellogghansen.com"
-      ],
-      "name": "Mr. Andrew Edward Goldsmith, -:"
-    },
-    {
-      "email_addresses": [
-        "jlamken@mololamken.com"
-      ],
-      "name": "Mr. Jeffrey A. Lamken, -:"
-    },
-    {
-      "email_addresses": [
-        "sangstreich@kellogghansen.com",
-        "aoak@kellogghansen.com",
-        "scott-angstreich-1818@ecf.pacerpro.com"
-      ],
-      "name": "Mr. Scott Harris Angstreich, -:"
-    },
-    {
-      "email_addresses": [
-        "estallman@clinical.law.berkeley.edu",
-        "estallman@recap.email"
-      ],
-      "name": "Erik Robert Stallman, Assistant Director:"
-    },
-    {
-      "email_addresses": [
-        "eric.delpozo@ag.ny.gov",
-        "nyoag.nycpdf@ag.ny.gov"
-      ],
-      "name": "Eric Del Pozo, -:"
-    },
-    {
-      "email_addresses": [
-        "dmills@cooley.com",
-        "efiling-notice@ecf.pacerpro.com"
-      ],
-      "name": "David Mills, -:"
-    },
-    {
-      "email_addresses": [
-        "Wilson_Dudley@ca2.uscourts.gov"
-      ],
-      "name": "Wilson Dudley, Deputy Clerk:"
+       "name":"Recipient User Test F, Deputy Clerk:",
+       "email_addresses":[
+          "Testingf@gexample.com"
+       ]
     }
-  ]
+ ]
 }

--- a/tests/examples/pacer/nda/ca2_3.json
+++ b/tests/examples/pacer/nda/ca2_3.json
@@ -1,0 +1,94 @@
+{
+  "case_name": "New York State Telecommunicati v. James",
+  "court_id": "ca2",
+  "date_filed": "2022-03-23",
+  "docket_entries": [
+    {
+      "date_filed": "2022-03-23",
+      "description": "REPLY BRIEF, on behalf of Appellant Letitia A. James, FILED. Service date 03/23/2022 by CM/ECF. [3283515] [21-1975]",
+      "document_number": "00208754210",
+      "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208754210?uid=59a7f7615f78153b",
+      "pacer_case_id": "21-1975",
+      "pacer_doc_id": "00208754210",
+      "pacer_magic_num": null,
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "21-1975",
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "andyschwartzman@gmail.com"
+      ],
+      "name": "Mr. Andrew Jay Schwartzman, -:"
+    },
+    {
+      "email_addresses": [
+        "mberry@akingump.com"
+      ],
+      "name": "Matthew B. Berry, -:"
+    },
+    {
+      "email_addresses": [
+        "wus@dany.nyc.gov"
+      ],
+      "name": "Mr. Steven Wu, -:"
+    },
+    {
+      "email_addresses": [
+        "krussell@goldsteinrussell.com",
+        "eoevans@goldsteinrussell.com"
+      ],
+      "name": "Kevin K. Russell, -:"
+    },
+    {
+      "email_addresses": [
+        "agoldsmith@kellogghansen.com",
+        "mswank@kellogghansen.com",
+        "jhois@kellogghansen.com"
+      ],
+      "name": "Mr. Andrew Edward Goldsmith, -:"
+    },
+    {
+      "email_addresses": [
+        "jlamken@mololamken.com"
+      ],
+      "name": "Mr. Jeffrey A. Lamken, -:"
+    },
+    {
+      "email_addresses": [
+        "sangstreich@kellogghansen.com",
+        "aoak@kellogghansen.com",
+        "scott-angstreich-1818@ecf.pacerpro.com"
+      ],
+      "name": "Mr. Scott Harris Angstreich, -:"
+    },
+    {
+      "email_addresses": [
+        "estallman@clinical.law.berkeley.edu",
+        "estallman@recap.email"
+      ],
+      "name": "Erik Robert Stallman, Assistant Director:"
+    },
+    {
+      "email_addresses": [
+        "eric.delpozo@ag.ny.gov",
+        "nyoag.nycpdf@ag.ny.gov"
+      ],
+      "name": "Eric Del Pozo, -:"
+    },
+    {
+      "email_addresses": [
+        "dmills@cooley.com",
+        "efiling-notice@ecf.pacerpro.com"
+      ],
+      "name": "David Mills, -:"
+    },
+    {
+      "email_addresses": [
+        "Wilson_Dudley@ca2.uscourts.gov"
+      ],
+      "name": "Wilson Dudley, Deputy Clerk:"
+    }
+  ]
+}

--- a/tests/examples/pacer/nda/ca2_3.json
+++ b/tests/examples/pacer/nda/ca2_3.json
@@ -15,7 +15,7 @@
     }
   ],
   "docket_number": "21-1975",
-  "email_notice_type": "NDA",
+  "appellate": true,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca2_3.txt
+++ b/tests/examples/pacer/nda/ca2_3.txt
@@ -1,0 +1,77 @@
+Return-Path: <cmecf@ca2.uscourts.gov>
+Received: from icmecf201.gtwy.uscourts.gov (icmecf201.gtwy.uscourts.gov [63.241.40.204])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id il9pann4hu1g13rgbeuo0oc3dm6cvu3h8hgv5j01
+ for estallman@recap.email;
+ Wed, 23 Mar 2022 19:30:17 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca2.uscourts.gov designates 63.241.40.204 as permitted sender) client-ip=63.241.40.204; envelope-from=cmecf@ca2.uscourts.gov; helo=icmecf201.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca2.uscourts.gov designates 63.241.40.204 as permitted sender) client-ip=63.241.40.204; envelope-from=cmecf@ca2.uscourts.gov; helo=icmecf201.gtwy.uscourts.gov;
+ dmarc=none header.from=ca2.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFIanhUYXFYNSt4QllYUUhBNEpDS04wQ3FvRmZnTzBzcDlLRTYrOThOdmF5RVNlKzdNbkc5VE9VZlB2SzY4VUgyWjFPbGFOZmp0cXNQMm52WTRxRmlaUDJNdWJSbmNMZkZEWDhuTHU5cElkbWwrSld5NnBTNUZpLzd5SVRSMVVpS09hZFk2WmJwUmxoanB4QitKZmNxbzZoeW9yL2QzYWhNWEtzcldKZGk1ekJIMVJtNE1Nb1pFbUN0aDJkNk9HMENub3ZNRzNud0hRMEtkSXlpdi9IMHZCdDlwUXp3YU8wUE41K0pLa1FtSFYzWXRmMmNOZFlmL2FiTDY0Y2FwM1hlcWJXZXNlU01jYkhzUHFUSGNienhZV3h1aHlyQkUrYUEvOVFRK3lZWDFSblE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=G5ez+FlAnXM5Nl3BCggLlIu2pRd79IYfBA8sLTOC8AUlCQEUeW2G6VkcSAN1eP6cdB7BzL7knRHPvi0psR5JLenEYuOxgwfxLugp8m4u5q3SqVSlXlpHyKuMTieTAsZdDOdh2WSD9VKvOusqKgOnMi9E1gCqdeV1UvsyEz9xA1M=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1648063817; v=1; bh=9OoOp1rIWNQo4hRQsB4RKdMSY9xXaFGvoNrqSxXZp0Y=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.45
+Received: from ca2db.ca2.gtwy.dcn ([156.119.190.45])
+  by icmecf201.gtwy.uscourts.gov with ESMTP; 23 Mar 2022 15:30:16 -0400
+Received: from ca2db.ca2.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca2db.ca2.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 22NJTLXK061043
+	for <estallman@recap.email>; Wed, 23 Mar 2022 15:29:21 -0400
+Date: Wed, 23 Mar 2022 15:29:21 -0400
+From: cmecf@ca2.uscourts.gov
+To: estallman@recap.email
+Message-ID: <1777006619.4225.1648063761372.JavaMail.ecf_web@ca2db.ca2.gtwy.dcn>
+Subject: 21-1975 New York State Telecommunicati v. James
+ "Appellant/Petitioner Reply Brief FILED"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-1975 New York State Telecommunicati v. James "Appellant/Petitioner Reply Brief FILED"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>Court of Appeals, 2nd Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 03/23/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>New York State Telecommunicati v. James<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=55129">21-1975</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca2.uscourts.gov/docs1/00208754210?uid=59a7f7615f78153b">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+REPLY BRIEF, on behalf of Appellant Letitia A. James, FILED. Service date 03/23/2022 by CM/ECF. [3283515] [21-1975]<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Mr. Andrew Jay Schwartzman, -: andyschwartzman@gmail.com<BR>
+Matthew B. Berry, -: mberry@akingump.com<BR>
+Mr. Steven Wu, -: wus@dany.nyc.gov<BR>
+Kevin K. Russell, -: krussell@goldsteinrussell.com, eoevans@goldsteinrussell.com<BR>
+Mr. Andrew Edward Goldsmith, -: agoldsmith@kellogghansen.com, mswank@kellogghansen.com, jhois@kellogghansen.com<BR>
+Mr. Jeffrey A. Lamken, -: jlamken@mololamken.com<BR>
+Mr. Scott Harris Angstreich, -: sangstreich@kellogghansen.com, aoak@kellogghansen.com, scott-angstreich-1818@ecf.pacerpro.com<BR>
+Erik Robert Stallman, Assistant Director: estallman@clinical.law.berkeley.edu, estallman@recap.email<BR>
+Eric Del Pozo, -: eric.delpozo@ag.ny.gov, nyoag.nycpdf@ag.ny.gov<BR>
+David Mills, -: dmills@cooley.com, efiling-notice@ecf.pacerpro.com<BR>
+Wilson Dudley, Deputy Clerk: Wilson_Dudley@ca2.uscourts.gov<BR>
+<BR><BR><BR><STRONG>Notice will be stored in the notice cart for:</STRONG><BR><BR>
+Wilson Dudley, Deputy Clerk<BR>
+Quality Control 1<BR>
+<BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Appellant/Petitioner Reply Brief FILED<BR>
+<STRONG>Original Filename: </STRONG>21-1975_NYS Telecomms. Ass'n v. James_Reply Br. for Appellant.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1161632333 [Date=03/23/2022] [FileNumber=3283515-0] [2ae719217bd3c10af0d9bf4fe58b5483ce7ba2805d096e03c023d784301b9c8c6ef41d715570f014f33776b75e9fe815bd9b207dabca4855c15fb81af7afd906]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca2_3.txt
+++ b/tests/examples/pacer/nda/ca2_3.txt
@@ -53,17 +53,11 @@ The following transaction was filed on 03/23/2022
 REPLY BRIEF, on behalf of Appellant Letitia A. James, FILED. Service date 03/23/2022 by CM/ECF. [3283515] [21-1975]<BR>
 <BR>
 <STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
-Mr. Andrew Jay Schwartzman, -: andyschwartzman@gmail.com<BR>
-Matthew B. Berry, -: mberry@akingump.com<BR>
-Mr. Steven Wu, -: wus@dany.nyc.gov<BR>
-Kevin K. Russell, -: krussell@goldsteinrussell.com, eoevans@goldsteinrussell.com<BR>
-Mr. Andrew Edward Goldsmith, -: agoldsmith@kellogghansen.com, mswank@kellogghansen.com, jhois@kellogghansen.com<BR>
-Mr. Jeffrey A. Lamken, -: jlamken@mololamken.com<BR>
-Mr. Scott Harris Angstreich, -: sangstreich@kellogghansen.com, aoak@kellogghansen.com, scott-angstreich-1818@ecf.pacerpro.com<BR>
-Erik Robert Stallman, Assistant Director: estallman@clinical.law.berkeley.edu, estallman@recap.email<BR>
-Eric Del Pozo, -: eric.delpozo@ag.ny.gov, nyoag.nycpdf@ag.ny.gov<BR>
-David Mills, -: dmills@cooley.com, efiling-notice@ecf.pacerpro.com<BR>
-Wilson Dudley, Deputy Clerk: Wilson_Dudley@ca2.uscourts.gov<BR>
+Recipient User Test A, -: testinga@gexample.com<BR>
+Recipient User Test B, -: testingb@gexample.com<BR>
+Recipient User Test C, -: testingc@gexample.com, testingcc@gexample.com<BR>
+Recipient User Test D, -: testingd@gexample.com, testingdd@gexample.com, testingddd@gexample.com<BR>
+Recipient User Test F, Deputy Clerk: Testingf@gexample.com<BR>
 <BR><BR><BR><STRONG>Notice will be stored in the notice cart for:</STRONG><BR><BR>
 Wilson Dudley, Deputy Clerk<BR>
 Quality Control 1<BR>

--- a/tests/examples/pacer/nda/ca2_4.json
+++ b/tests/examples/pacer/nda/ca2_4.json
@@ -10,11 +10,12 @@
       "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208721516?uid=b775e9908ad79ce2",
       "pacer_case_id": "21-1975",
       "pacer_doc_id": "00208721516",
-      "pacer_magic_num": null,
+      "pacer_magic_num": "b775e9908ad79ce2",
       "pacer_seq_no": null
     }
   ],
   "docket_number": "21-1975",
+  "email_notice_type": "NDA",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca2_4.json
+++ b/tests/examples/pacer/nda/ca2_4.json
@@ -6,9 +6,9 @@
     {
       "date_filed": "2022-03-03",
       "description": "DEFECTIVE DOCUMENT,Amicus Brief, [166], on behalf of Amicus Curiae Muticultural Media, Telecom, and Internet Council, and Allvanza, FILED.[3270986] [21-1975]",
-      "document_number": "00208721516",
+      "document_number": null,
       "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208721516?uid=b775e9908ad79ce2",
-      "pacer_case_id": "21-1975",
+      "pacer_case_id": "55129",
       "pacer_doc_id": "00208721516",
       "pacer_magic_num": "b775e9908ad79ce2",
       "pacer_seq_no": null
@@ -18,86 +18,30 @@
   "appellate": true,
   "email_recipients": [
     {
-      "email_addresses": [
-        "sangstreich@kellogghansen.com",
-        "aoak@kellogghansen.com",
-        "scott-angstreich-1818@ecf.pacerpro.com"
-      ],
-      "name": ":"
+       "name":":",
+       "email_addresses":[
+          "testing3@gexample.com",
+          "testing3_1@gexample.com",
+          "testing3_2@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "tbadgley@uschamber.com"
-      ],
-      "name": ":"
+       "name":":",
+       "email_addresses":[
+          "testing1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "c.k.barthold@gmail.com"
-      ],
-      "name": ":"
+       "name":":",
+       "email_addresses":[
+          "testing2@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "mberry@akingump.com"
-      ],
-      "name": ":"
-    },
-    {
-      "email_addresses": [
-        "eric.delpozo@ag.ny.gov",
-        "nyoag.nycpdf@ag.ny.gov"
-      ],
-      "name": ":"
-    },
-    {
-      "email_addresses": [
-        "agoldsmith@kellogghansen.com",
-        "mswank@kellogghansen.com",
-        "jhois@kellogghansen.com"
-      ],
-      "name": ":"
-    },
-    {
-      "email_addresses": [
-        "jlamken@mololamken.com"
-      ],
-      "name": ":"
-    },
-    {
-      "email_addresses": [
-        "dmills@cooley.com",
-        "efiling-notice@ecf.pacerpro.com"
-      ],
-      "name": ":"
-    },
-    {
-      "email_addresses": [
-        "krussell@goldsteinrussell.com",
-        "eoevans@goldsteinrussell.com"
-
-      ],
-      "name": ":"
-    },
-    {
-      "email_addresses": [
-        "andyschwartzman@gmail.com"
-      ],
-      "name": ":"
-    },
-    {
-      "email_addresses": [
-        "estallman@clinical.law.berkeley.edu",
-        "estallman@recap.email"
-      ],
-      "name": ":"
-    },
-    {
-      "email_addresses": [
-        "steven.wu@ag.ny.gov",
-        "nyoag.nycpdf@ag.ny.gov"
-      ],
-      "name": ":"
+       "name":":",
+       "email_addresses":[
+          "testing4@gexample.com"
+       ]
     }
-  ]
+ ]
 }

--- a/tests/examples/pacer/nda/ca2_4.json
+++ b/tests/examples/pacer/nda/ca2_4.json
@@ -1,5 +1,6 @@
 {
   "case_name": "New York State Telecommunicati v. James",
+  "contains_attachments": false,
   "court_id": "ca2",
   "date_filed": "2022-03-03",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca2_4.json
+++ b/tests/examples/pacer/nda/ca2_4.json
@@ -1,0 +1,102 @@
+{
+  "case_name": "New York State Telecommunicati v. James",
+  "court_id": "ca2",
+  "date_filed": "2022-03-03",
+  "docket_entries": [
+    {
+      "date_filed": "2022-03-03",
+      "description": "DEFECTIVE DOCUMENT,Amicus Brief, [166], on behalf of Amicus Curiae Muticultural Media, Telecom, and Internet Council, and Allvanza, FILED.[3270986] [21-1975]",
+      "document_number": "00208721516",
+      "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208721516?uid=b775e9908ad79ce2",
+      "pacer_case_id": "21-1975",
+      "pacer_doc_id": "00208721516",
+      "pacer_magic_num": null,
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "21-1975",
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "sangstreich@kellogghansen.com",
+        "aoak@kellogghansen.com",
+        "scott-angstreich-1818@ecf.pacerpro.com"
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "tbadgley@uschamber.com"
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "c.k.barthold@gmail.com"
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "mberry@akingump.com"
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "eric.delpozo@ag.ny.gov",
+        "nyoag.nycpdf@ag.ny.gov"
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "agoldsmith@kellogghansen.com",
+        "mswank@kellogghansen.com",
+        "jhois@kellogghansen.com"
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "jlamken@mololamken.com"
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "dmills@cooley.com",
+        "efiling-notice@ecf.pacerpro.com"
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "krussell@goldsteinrussell.com",
+        "eoevans@goldsteinrussell.com"
+
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "andyschwartzman@gmail.com"
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "estallman@clinical.law.berkeley.edu",
+        "estallman@recap.email"
+      ],
+      "name": ":"
+    },
+    {
+      "email_addresses": [
+        "steven.wu@ag.ny.gov",
+        "nyoag.nycpdf@ag.ny.gov"
+      ],
+      "name": ":"
+    }
+  ]
+}

--- a/tests/examples/pacer/nda/ca2_4.json
+++ b/tests/examples/pacer/nda/ca2_4.json
@@ -15,7 +15,7 @@
     }
   ],
   "docket_number": "21-1975",
-  "email_notice_type": "NDA",
+  "appellate": true,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca2_4.txt
+++ b/tests/examples/pacer/nda/ca2_4.txt
@@ -1,0 +1,105 @@
+Return-Path: <cmecf@ca2.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id odsh4lcfklchpcme9irl80uqamqfea2a8641m981
+ for estallman@recap.email;
+ Thu, 03 Mar 2022 16:42:14 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca2.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=cmecf@ca2.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca2.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=cmecf@ca2.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=pass header.from=ca2.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHNnZIaHRzcnpPYjV1TkF0MHM3UXczR09xQ3FZT3FyOThHdHpQaE03bXV5b2ZEN01ZNEw0bDFrbEZlT243cktiTW55OGh4cUlZTFIrVktpMDRBQVJoSzA0UFRsUjVTcE5DdnBLV0hsYjE3WlQxeVpqbE5mRUdTNFE0R3VYdDM2TFg4THVMb0prZ2M2ZTkxK3d5UmdsTE80R25URGV3MUUvMGpmcDFWRVFwd29UUXdFeSt4VjM3U1dZUHgyUUEvWXFhQmJ3MG5pR1V2VXU0dzJxalZiNWFlTU1IeEIzN2JCNVBNTWNyNlM4UlpHYVFYVy9rajNWbjJ1b3Z5V2lvT0t3VUc1YUlabmZTOFc2eTFTUFMrTG94RjloUmkrSm5XbW9wMktRcnZNN0xtN3c9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=Ph3vZmug7sECDWLbSIbTjJmijSx3EhcC5P7iHzjC4AK1ck3WmEPRfYQaugTnb/kFGQVEyft9lyCLL7SZ3xflQWG2v60aisk47NuUvI4fSFkHSZdzgnsSBlarg7Q2fc85INbUPVvYi36HWzs+iM1y96ZU5zuYqr0m8DleCrJLAxQ=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1646325735; v=1; bh=A3brBleyeTehjvYyH/WNqxOcqT4pjPWl7BJgf1cH3jg=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.45
+Received: from ca2db.ca2.gtwy.dcn ([156.119.190.45])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 03 Mar 2022 11:42:13 -0500
+Received: from ca2db.ca2.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca2db.ca2.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 223GfUD4042968
+	for <estallman@recap.email>; Thu, 3 Mar 2022 11:41:30 -0500
+Date: Thu, 3 Mar 2022 11:41:30 -0500
+From: cmecf@ca2.uscourts.gov
+To: estallman@recap.email
+Message-ID: <1809663459.1502.1646325690288.JavaMail.ecf_web@ca2db.ca2.gtwy.dcn>
+Subject: 21-1975 New York State Telecommunicati v. James "Defective Document
+ FILED"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-1975 New York State Telecommunicati v. James "Defective Document FILED"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>Court of Appeals, 2nd Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 03/03/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>New York State Telecommunicati v. James<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=55129">21-1975</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca2.uscourts.gov/docs1/00208721516?uid=b775e9908ad79ce2">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+DEFECTIVE DOCUMENT,Amicus Brief,  [166], on behalf of Amicus Curiae Muticultural Media, Telecom, and Internet Council, and Allvanza, FILED.[3270986] [21-1975]<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+<a name="R0">Mr. Scott Harris Angstreich, -</a>: sangstreich@kellogghansen.com, aoak@kellogghansen.com, scott-angstreich-1818@ecf.pacerpro.com<BR>
+<a name="R1">Tyler S. Badgley, Counsel</a>: tbadgley@uschamber.com<BR>
+<a name="R2">Corbin Barthold, -</a>: c.k.barthold@gmail.com<BR>
+<a name="R4">Matthew B. Berry, -</a>: mberry@akingump.com<BR>
+<a name="R7">Eric Del Pozo, -</a>: eric.delpozo@ag.ny.gov, nyoag.nycpdf@ag.ny.gov<BR>
+<a name="R8">Mr. Andrew Edward Goldsmith, -</a>: agoldsmith@kellogghansen.com, mswank@kellogghansen.com, jhois@kellogghansen.com<BR>
+<a name="R11">Mr. Jeffrey A. Lamken, -</a>: jlamken@mololamken.com<BR>
+<a name="R17">David Mills, -</a>: dmills@cooley.com, efiling-notice@ecf.pacerpro.com<BR>
+<a name="R21">Kevin K. Russell, -</a>: krussell@goldsteinrussell.com, eoevans@goldsteinrussell.com<BR>
+<a name="R22">Mr. Andrew Jay Schwartzman, -</a>: andyschwartzman@gmail.com<BR>
+<a name="R23">Erik Robert Stallman, Assistant Director</a>: estallman@clinical.law.berkeley.edu, estallman@recap.email<BR>
+<a name="R27">Mr. Steven Wu, -</a>: steven.wu@ag.ny.gov, nyoag.nycpdf@ag.ny.gov<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Defective_Document_Notice<BR>
+<STRONG>Original Filename: </STRONG>/opt/ACECF/live/forms/WilsonDudley_211975_3270986_Defective_Document_Notice_142.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1161632333 [Date=03/03/2022] [FileNumber=3270986-0] [0ef250a712db8a82ce9998e0775fde363a3ed603a231dda5403b0d00306ba1f444588dbf1fead21da7024ef8a5372e666fedb7afd3acaa1ee68ddb80b2d7d7f3]]<BR>
+<STRONG>Recipients: </STRONG><UL>
+<LI><a href="#R0">Mr. Scott Harris Angstreich, -</a>
+<LI><a href="#R1">Tyler S. Badgley, Counsel</a>
+<LI><a href="#R2">Corbin Barthold, -</a>
+<LI><a href="#R3">John Bergmayer, -</a>
+<LI><a href="#R4">Matthew B. Berry, -</a>
+<LI><a href="#R5">Mr. Matthew A. Brill, -</a>
+<LI><a href="#R6">Michael Burstein, -</a>
+<LI><a href="#R7">Eric Del Pozo, -</a>
+<LI><a href="#R8">Mr. Andrew Edward Goldsmith, -</a>
+<LI><a href="#R9">Joseph Solomon Hall, -</a>
+<LI><a href="#R10">J. G. Harrington, -</a>
+<LI><a href="#R11">Mr. Jeffrey A. Lamken, -</a>
+<LI><a href="#R12">Peiyin Patty Li, -</a>
+<LI><a href="#R13">Doctor David Scott Louk, -</a>
+<LI><a href="#R14">Jared P. Marx, -</a>
+<LI><a href="#R15">Alexandra Mays, -</a>
+<LI><a href="#R16">Robert M. McDowell, -</a>
+<LI><a href="#R17">David Mills, -</a>
+<LI><a href="#R18">Matthew Murchison, -</a>
+<LI><a href="#R19">Tejas N. Narechania, Professor</a>
+<LI><a href="#R20">Alex Atticus Parkinson, -</a>
+<LI><a href="#R21">Kevin K. Russell, -</a>
+<LI><a href="#R22">Mr. Andrew Jay Schwartzman, -</a>
+<LI><a href="#R23">Erik Robert Stallman, Assistant Director</a>
+<LI><a href="#R24">Jennifer Tatel, -</a>
+<LI><a href="#R25">Mr. Joel Thayer, -</a>
+<LI><a href="#R26">James Tomberlin, -</a>
+<LI><a href="#R27">Mr. Steven Wu, -</a>
+</UL>
+
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca2_4.txt
+++ b/tests/examples/pacer/nda/ca2_4.txt
@@ -53,18 +53,10 @@ The following transaction was filed on 03/03/2022
 DEFECTIVE DOCUMENT,Amicus Brief,  [166], on behalf of Amicus Curiae Muticultural Media, Telecom, and Internet Council, and Allvanza, FILED.[3270986] [21-1975]<BR>
 <BR>
 <STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
-<a name="R0">Mr. Scott Harris Angstreich, -</a>: sangstreich@kellogghansen.com, aoak@kellogghansen.com, scott-angstreich-1818@ecf.pacerpro.com<BR>
-<a name="R1">Tyler S. Badgley, Counsel</a>: tbadgley@uschamber.com<BR>
-<a name="R2">Corbin Barthold, -</a>: c.k.barthold@gmail.com<BR>
-<a name="R4">Matthew B. Berry, -</a>: mberry@akingump.com<BR>
-<a name="R7">Eric Del Pozo, -</a>: eric.delpozo@ag.ny.gov, nyoag.nycpdf@ag.ny.gov<BR>
-<a name="R8">Mr. Andrew Edward Goldsmith, -</a>: agoldsmith@kellogghansen.com, mswank@kellogghansen.com, jhois@kellogghansen.com<BR>
-<a name="R11">Mr. Jeffrey A. Lamken, -</a>: jlamken@mololamken.com<BR>
-<a name="R17">David Mills, -</a>: dmills@cooley.com, efiling-notice@ecf.pacerpro.com<BR>
-<a name="R21">Kevin K. Russell, -</a>: krussell@goldsteinrussell.com, eoevans@goldsteinrussell.com<BR>
-<a name="R22">Mr. Andrew Jay Schwartzman, -</a>: andyschwartzman@gmail.com<BR>
-<a name="R23">Erik Robert Stallman, Assistant Director</a>: estallman@clinical.law.berkeley.edu, estallman@recap.email<BR>
-<a name="R27">Mr. Steven Wu, -</a>: steven.wu@ag.ny.gov, nyoag.nycpdf@ag.ny.gov<BR>
+<a name="R0">Recipient User Test 1, -</a>: testing3@gexample.com, testing3_1@gexample.com, testing3_2@gexample.com<BR>
+<a name="R1">Recipient User Test 2, Counsel</a>: testing1@gexample.com<BR>
+<a name="R2">Recipient User Test 3, -</a>: testing2@gexample.com<BR>
+<a name="R4">Recipient User Test 4, -</a>: testing4@gexample.com<BR>
 <BR><BR>
 The following document(s) are associated with this transaction:<BR>
 <STRONG>Document Description: </STRONG>Defective_Document_Notice<BR>
@@ -72,34 +64,10 @@ The following document(s) are associated with this transaction:<BR>
 <STRONG>Electronic Document Stamp:</STRONG><BR>
 [STAMP acecfStamp_ID=1161632333 [Date=03/03/2022] [FileNumber=3270986-0] [0ef250a712db8a82ce9998e0775fde363a3ed603a231dda5403b0d00306ba1f444588dbf1fead21da7024ef8a5372e666fedb7afd3acaa1ee68ddb80b2d7d7f3]]<BR>
 <STRONG>Recipients: </STRONG><UL>
-<LI><a href="#R0">Mr. Scott Harris Angstreich, -</a>
-<LI><a href="#R1">Tyler S. Badgley, Counsel</a>
-<LI><a href="#R2">Corbin Barthold, -</a>
-<LI><a href="#R3">John Bergmayer, -</a>
-<LI><a href="#R4">Matthew B. Berry, -</a>
-<LI><a href="#R5">Mr. Matthew A. Brill, -</a>
-<LI><a href="#R6">Michael Burstein, -</a>
-<LI><a href="#R7">Eric Del Pozo, -</a>
-<LI><a href="#R8">Mr. Andrew Edward Goldsmith, -</a>
-<LI><a href="#R9">Joseph Solomon Hall, -</a>
-<LI><a href="#R10">J. G. Harrington, -</a>
-<LI><a href="#R11">Mr. Jeffrey A. Lamken, -</a>
-<LI><a href="#R12">Peiyin Patty Li, -</a>
-<LI><a href="#R13">Doctor David Scott Louk, -</a>
-<LI><a href="#R14">Jared P. Marx, -</a>
-<LI><a href="#R15">Alexandra Mays, -</a>
-<LI><a href="#R16">Robert M. McDowell, -</a>
-<LI><a href="#R17">David Mills, -</a>
-<LI><a href="#R18">Matthew Murchison, -</a>
-<LI><a href="#R19">Tejas N. Narechania, Professor</a>
-<LI><a href="#R20">Alex Atticus Parkinson, -</a>
-<LI><a href="#R21">Kevin K. Russell, -</a>
-<LI><a href="#R22">Mr. Andrew Jay Schwartzman, -</a>
-<LI><a href="#R23">Erik Robert Stallman, Assistant Director</a>
-<LI><a href="#R24">Jennifer Tatel, -</a>
-<LI><a href="#R25">Mr. Joel Thayer, -</a>
-<LI><a href="#R26">James Tomberlin, -</a>
-<LI><a href="#R27">Mr. Steven Wu, -</a>
+<LI><a href="#R0">Recipient User Test 1, -</a>
+<LI><a href="#R1">Recipient User Test 2, Counsel</a>
+<LI><a href="#R2">Recipient User Test 3, -</a>
+<LI><a href="#R4">Recipient User Test 4, -</a>
 </UL>
 
 </BODY></HTML>

--- a/tests/examples/pacer/nda/ca2_5.json
+++ b/tests/examples/pacer/nda/ca2_5.json
@@ -1,0 +1,60 @@
+{
+  "case_name": "Elisa W. v. The City of New York",
+  "court_id": "ca2",
+  "date_filed": "2022-08-10",
+  "docket_entries": [
+    {
+      "date_filed": "2022-08-10",
+      "description": "JOINT APPENDIX, volume 7 of 13, (pp. 1711-1995), on behalf of Appellant Dameon C., Thierry E., Mikayla G., Ayanna J., Myls J., Malik M., Tyrone M., Xavion M., Alexandria R., Ana-Maria R., Olivia R., Emmanuel S., Lucas T., Ximena T., Jose T.C., Valentina T.C., Matthew V., Brittney W. and Elisa W., FILED. Service date 08/09/2022 by CM/ECF.[3362641] [22-7]",
+      "document_number": null,
+      "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208962225?uid=8d96e8f0a9737656",
+      "pacer_case_id": "56342",
+      "pacer_doc_id": "00208962225",
+      "pacer_magic_num": "8d96e8f0a9737656",
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "22-7",
+  "appellate": true,
+  "email_recipients": [
+   {
+      "name":"Recipient User Test 1, -:",
+      "email_addresses":[
+         "testing1@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 2, -:",
+      "email_addresses":[
+         "testing2@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 3, -:",
+      "email_addresses":[
+         "testing3@gexample.com",
+         "testing3_1@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 4, -:",
+      "email_addresses":[
+         "testing4@gexample.com",
+         "testing4_1@gexample.com",
+         "testing4_2@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 5, Deputy Clerk:",
+      "email_addresses":[
+         "Testing5@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 5, Case Manager:",
+      "email_addresses":[
+         "Testing_6@gexample.com"
+      ]
+   }
+]
+}

--- a/tests/examples/pacer/nda/ca2_5.json
+++ b/tests/examples/pacer/nda/ca2_5.json
@@ -1,5 +1,6 @@
 {
   "case_name": "Elisa W. v. The City of New York",
+  "contains_attachments": false,
   "court_id": "ca2",
   "date_filed": "2022-08-10",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca2_5.txt
+++ b/tests/examples/pacer/nda/ca2_5.txt
@@ -1,0 +1,71 @@
+Return-Path: <cmecf@ca2.uscourts.gov>
+Received: from icmecf201.gtwy.uscourts.gov (icmecf201.gtwy.uscourts.gov [63.241.40.204])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 21skljc94an8cvg0s19hp68a5f578v9e66v2q4o1
+ for archive@recap.email;
+ Wed, 10 Aug 2022 07:11:28 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca2.uscourts.gov designates 63.241.40.204 as permitted sender) client-ip=63.241.40.204; envelope-from=cmecf@ca2.uscourts.gov; helo=icmecf201.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca2.uscourts.gov designates 63.241.40.204 as permitted sender) client-ip=63.241.40.204; envelope-from=cmecf@ca2.uscourts.gov; helo=icmecf201.gtwy.uscourts.gov;
+ dmarc=none header.from=ca2.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFIelZISWdTWHdLcVd6VXh4RWh2TUtCVEFjR1R2c2lPU1EzL1B1NllkNHNXdWZGMGxOU28vUGdvaVdGRzE0VnY1NStGVEdFSTFQMWMyaFJocmp1TGNaQ0l2S2hZUFhOeTNJSEZFNmdEYjB5dURRdldaclUzU0l6NXVkME51d295WTZyckNhNHRYdVpQam5aM0pnQjREbXBKWFNSTGluWVk3L3BKOHpyNnZ2Q256bS9aSlJtY1VscVpaQjNHcHdaUGl5MWZ5T002M1daOUlvcTFMZEx4VzNWMUl6YUh1MWcyNFFoblArUXpVdEdYbC9jN2Rkb1JpQ2JLVmQwNHdnaVU3UjhpVndKUUpxVFhqM0JvZGtQVi9ncm9wMGc2THRDbnRZRHhBelBXek0xaHc9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=YNv9L1AlT3o1FGLR1prwhl3eDUpcKMs8aMenQ3afkU+Ewdl/91rUufQBt3JAQdthpvw5drnH+85jCyPd9Rl0Wninq/UDh0FsGmu2IXjfvGfyraeyqcRZs+NToOSItLnPltORlD92rS1ZvDworS8yDdhKIP5hW1lGxjUch2NN7MQ=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1660115489; v=1; bh=XJX1yJO1oqMn0FWbRqNhKXq59pjBNoQE0bYxmjjNK8U=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.45
+Received: from ca2db.ca2.gtwy.dcn ([156.119.190.45])
+  by icmecf201.gtwy.uscourts.gov with ESMTP; 10 Aug 2022 03:11:28 -0400
+Received: from ca2db.ca2.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca2db.ca2.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 27A7BOmp088435
+	for <archive@recap.email>; Wed, 10 Aug 2022 03:11:24 -0400
+Date: Wed, 10 Aug 2022 03:11:24 -0400 (EDT)
+From: cmecf@ca2.uscourts.gov
+To: archive@recap.email
+Message-ID: <118177161.3712.1660115484179@ca2db.ca2.gtwy.dcn>
+Subject: 22-7 Elisa W. v. The City of New York "Appendix FILED"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-7 Elisa W. v. The City of New York "Appendix FILED"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>Court of Appeals, 2nd Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 08/10/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Elisa W. v. The City of New York<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=56342">22-7</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca2.uscourts.gov/docs1/00208962225?uid=8d96e8f0a9737656">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+JOINT APPENDIX, volume 7 of 13, (pp. 1711-1995), on behalf of Appellant Dameon C., Thierry E., Mikayla G., Ayanna J., Myls J., Malik M., Tyrone M., Xavion M., Alexandria R., Ana-Maria R., Olivia R., Emmanuel S., Lucas T., Ximena T., Jose T.C., Valentina T.C., Matthew V., Brittney W. and Elisa W., FILED. Service date 08/09/2022 by CM/ECF.[3362641] [22-7]<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Recipient User Test 1, -: testing1@gexample.com<BR>
+Recipient User Test 2, -: testing2@gexample.com<BR>
+Recipient User Test 3, -: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4, -: testing4@gexample.com, testing4_1@gexample.com, testing4_2@gexample.com<BR>
+Recipient User Test 5, Deputy Clerk: Testing5@gexample.com<BR>
+Recipient User Test 5, Case Manager: Testing_6@gexample.com<BR>
+<BR><BR><BR><STRONG>Notice will be stored in the notice cart for:</STRONG><BR><BR>
+Mr. Ronald Willoughby, Case Manager<BR>
+Quality Control 1<BR>
+<BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Appendix FILED<BR>
+<STRONG>Original Filename: </STRONG>VOL. 7 (for filing).pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1161632333 [Date=08/10/2022] [FileNumber=3362641-0] [46b2701c6e47a5048d3822ae754867ee6240f7385590daf75e8fe82e9529406021eb1dbfc96c6b317f4a6fd12a02dd5bd4c3f9bf412f3d4d760cbf46a515ecef]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca2_5.txt
+++ b/tests/examples/pacer/nda/ca2_5.txt
@@ -32,7 +32,7 @@ Content-Transfer-Encoding: 7bit
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-7 Elisa W. v. The City of New York "Appendix FILED"</TITLE>
 </HEAD>
-<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
 <P><STRONG>
 ***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
 <P><CENTER><STRONG>Court of Appeals, 2nd Circuit</STRONG></CENTER>

--- a/tests/examples/pacer/nda/ca3_1.json
+++ b/tests/examples/pacer/nda/ca3_1.json
@@ -6,9 +6,9 @@
     {
       "date_filed": "2022-08-08",
       "description": "ECF FILER: ELECTRONIC SUPPLEMENTAL BRIEF on behalf of Appellee Commissioner Pennsylvania State Police. Certificate of Service dated 08/08/2022 by ECF. [21-1832] (DBM)",
-      "document_number": "003014193380",
+      "document_number": null,
       "document_url": "https://ecf.ca3.uscourts.gov/docs1/003014193380?uid=3594681a19879633",
-      "pacer_case_id": "21-1832",
+      "pacer_case_id": "114792",
       "pacer_doc_id": "003014193380",
       "pacer_magic_num": "3594681a19879633",
       "pacer_seq_no": null

--- a/tests/examples/pacer/nda/ca3_1.json
+++ b/tests/examples/pacer/nda/ca3_1.json
@@ -15,6 +15,6 @@
     }
   ],
   "docket_number": "21-1832",
-  "email_notice_type": "NDA",
+  "appellate": true,
   "email_recipients": []
 }

--- a/tests/examples/pacer/nda/ca3_1.json
+++ b/tests/examples/pacer/nda/ca3_1.json
@@ -10,10 +10,11 @@
       "document_url": "https://ecf.ca3.uscourts.gov/docs1/003014193380?uid=3594681a19879633",
       "pacer_case_id": "21-1832",
       "pacer_doc_id": "003014193380",
-      "pacer_magic_num": null,
+      "pacer_magic_num": "3594681a19879633",
       "pacer_seq_no": null
     }
   ],
   "docket_number": "21-1832",
+  "email_notice_type": "NDA",
   "email_recipients": []
 }

--- a/tests/examples/pacer/nda/ca3_1.json
+++ b/tests/examples/pacer/nda/ca3_1.json
@@ -1,0 +1,19 @@
+{
+  "case_name": "Madison Lara v. Commissioner PA State Police",
+  "court_id": "ca3",
+  "date_filed": "2022-08-08",
+  "docket_entries": [
+    {
+      "date_filed": "2022-08-08",
+      "description": "ECF FILER: ELECTRONIC SUPPLEMENTAL BRIEF on behalf of Appellee Commissioner Pennsylvania State Police. Certificate of Service dated 08/08/2022 by ECF. [21-1832] (DBM)",
+      "document_number": "003014193380",
+      "document_url": "https://ecf.ca3.uscourts.gov/docs1/003014193380?uid=3594681a19879633",
+      "pacer_case_id": "21-1832",
+      "pacer_doc_id": "003014193380",
+      "pacer_magic_num": null,
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "21-1832",
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nda/ca3_1.json
+++ b/tests/examples/pacer/nda/ca3_1.json
@@ -1,5 +1,6 @@
 {
   "case_name": "Madison Lara v. Commissioner PA State Police",
+  "contains_attachments": false,
   "court_id": "ca3",
   "date_filed": "2022-08-08",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca3_1.txt
+++ b/tests/examples/pacer/nda/ca3_1.txt
@@ -1,0 +1,69 @@
+Return-Path: <CMECF_No_Reply@ca3.uscourts.gov>
+Received: from icmecf202.gtwy.uscourts.gov (icmecf202.gtwy.uscourts.gov [63.241.40.205])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id kjsipl4av50k7qu51fu6a1j8d24jfhpr5jvmokg1
+ for archive@recap.email;
+ Mon, 08 Aug 2022 20:48:09 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca3.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=CMECF_No_Reply@ca3.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca3.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=CMECF_No_Reply@ca3.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+ dmarc=none header.from=ca3.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFTW5MRUJuT21qQ3ZGcW1keTgwMU5HQ040ZnJDM2U2ckw4UERMVnB6QlFSSUlPbGtCMGxGSE9PMHlRSzUySXRBdFJ0WkVwckpMOGF3M2UrT0srd1MwbmkyYmZ4NUYxQzlFRmhnZmhOQlBDQ1Vib3FnOXRvODB2ZXBlU09RYmZ4cEJEaDVqYTdVYUpTY1B0R3B0WUYvZUY4SFAySldGbTl5dndjMlZSNHFlVDJJNy8yZDB0c3AwS2RtWHFwa05JNnR3OUYwWFZ6M2JlUWN6S3VBVkIrWEJZVFd4SVY3b2tFc3gyS2hqajJ5My91TTZOTC9sYXZadEErU3FCRisvZGlOR21kdFpqejh3V01OTUEvMWQ5ZzFKT1VGSGQrNmR1ZDBwYXhBcUNzczVqbU9lOSt6cTY2SmszU25iQnhGTFp2aGs9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=HBwDbf/G2QCGk4PCuhe0gYWvx+U4+DREN88tBGz9hqJbIhGfkKeJLfSpRTQ2GNue4lHjRJY7UOAzBq4i5DrUNY5atUYKkoDVo141MLeDI9HV/IH/7qm9kMS00UmuOSGBAXxQ5QnERNphFkerJ89d3MayQreu5M4KmU1N1Odx5Sg=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1659991689; v=1; bh=nH7SPB6jpWvRf+01P22bVhXZG51W3LholiL5Q/9FIng=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.191.41
+Received: from ca3db.ca3.gtwy.dcn ([156.119.191.41])
+  by icmecf202.gtwy.uscourts.gov with ESMTP; 08 Aug 2022 16:48:07 -0400
+Received: from ca3db.ca3.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca3db.ca3.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 278KlYI4077481
+	for <archive@recap.email>; Mon, 8 Aug 2022 16:47:34 -0400
+Date: Mon, 8 Aug 2022 16:47:34 -0400 (EDT)
+From: CMECF_No_Reply@ca3.uscourts.gov
+To: archive@recap.email
+Message-ID: <798611050.1627.1659991654414@ca3db.ca3.gtwy.dcn>
+Subject: 21-1832 Madison Lara, et al v. Commissioner PA State Police
+ "Supplemental Brief"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-1832 Madison Lara, et al v. Commissioner PA State Police "Supplemental Brief"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>Third Circuit Court of Appeals</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 08/08/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Madison Lara, et al v. Commissioner PA State Police<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca3.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=114792">21-1832</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca3.uscourts.gov/docs1/003014193380?uid=3594681a19879633">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+ECF FILER: ELECTRONIC SUPPLEMENTAL BRIEF on behalf of Appellee Commissioner Pennsylvania State Police. Certificate of Service dated 08/08/2022 by ECF. [21-1832] (DBM)<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+David H. Thompson<BR>
+Joshua Prince<BR>
+James P. Davy<BR>
+John D. Ohlendorf<BR>
+Peter A. Patterson<BR>
+Lisa Ebersole<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Supplemental Brief<BR>
+<STRONG>Original Filename: </STRONG>Commissioner's Reply Letter Brief v.FINAL.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1107201326 [Date=08/08/2022] [FileNumber=4984055-0] [82ea32c6f3c06d60b4718e51eb18ac3edbff7982a40e9689ca9b3e458a2a6961f0340a91b3a01a147210680cf2f46c1ab895e24bf269f611311f450ba79c6cc1]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca3_1.txt
+++ b/tests/examples/pacer/nda/ca3_1.txt
@@ -53,12 +53,12 @@ The following transaction was filed on 08/08/2022
 ECF FILER: ELECTRONIC SUPPLEMENTAL BRIEF on behalf of Appellee Commissioner Pennsylvania State Police. Certificate of Service dated 08/08/2022 by ECF. [21-1832] (DBM)<BR>
 <BR>
 <STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
-David H. Thompson<BR>
-Joshua Prince<BR>
-James P. Davy<BR>
-John D. Ohlendorf<BR>
-Peter A. Patterson<BR>
-Lisa Ebersole<BR>
+Recipient User Test 1<BR>
+Recipient User Test 2<BR>
+Recipient U. Test 3<BR>
+Recipient U. Test 4<BR>
+Recipient U. Test 5<BR>
+Recipient U. Test<BR>
 <BR><BR>
 The following document(s) are associated with this transaction:<BR>
 <STRONG>Document Description: </STRONG>Supplemental Brief<BR>

--- a/tests/examples/pacer/nda/ca4_1.json
+++ b/tests/examples/pacer/nda/ca4_1.json
@@ -1,6 +1,7 @@
 {
   "court_id":"ca4",
   "case_name":"Neuhtah Opiotennione v. Bozzuto Management Company",
+  "contains_attachments": false,
   "docket_number":"21-1919",
   "date_filed":"2022-08-19",
   "appellate":true,

--- a/tests/examples/pacer/nda/ca4_1.json
+++ b/tests/examples/pacer/nda/ca4_1.json
@@ -1,0 +1,47 @@
+{
+  "court_id":"ca4",
+  "case_name":"Neuhtah Opiotennione v. Bozzuto Management Company",
+  "docket_number":"21-1919",
+  "date_filed":"2022-08-19",
+  "appellate":true,
+  "docket_entries":[
+     {
+        "date_filed":"2022-08-19",
+        "description":"CASE CONTINUED FROM TENTATIVE CALENDAR. [1001214884] [21-1919] JLC",
+        "document_url":"https://ecf.ca4.uscourts.gov/docs1/00409007652?uid=ee31b72c3fff6b7f",
+        "document_number": null,
+        "pacer_doc_id":"00409007652",
+        "pacer_case_id":"164306",
+        "pacer_seq_no":null,
+        "pacer_magic_num":"ee31b72c3fff6b7f"
+     }
+  ],
+  "email_recipients":[
+    {
+       "name":":",
+       "email_addresses":[
+          "testing3@gexample.com",
+          "testing3_1@gexample.com",
+          "testing3_2@gexample.com"
+       ]
+    },
+    {
+       "name":":",
+       "email_addresses":[
+          "testing1@gexample.com"
+       ]
+    },
+    {
+       "name":":",
+       "email_addresses":[
+          "testing2@gexample.com"
+       ]
+    },
+    {
+       "name":":",
+       "email_addresses":[
+          "testing4@gexample.com"
+       ]
+    }
+ ]
+}

--- a/tests/examples/pacer/nda/ca4_1.txt
+++ b/tests/examples/pacer/nda/ca4_1.txt
@@ -1,0 +1,73 @@
+Return-Path: <ecfnoticing@ca4.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 5prekpvfog97bh7isnfh4jmauobqj405ebdkgtg1
+ for archive@recap.email;
+ Fri, 19 Aug 2022 13:50:16 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca4.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecfnoticing@ca4.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca4.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecfnoticing@ca4.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ca4.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHVVYxSy83Z1BmMDh4c3hmMzlQZmI3bERNS1RSZmhNK0prc2VhcVA1RTdXaFBJZXVZRTA2ZFluN0xBTEZkd2Z0MXp0Q3F2cFhzRk12NG5zaWxwMVlmL1ZSOG9zL3VRZDUyQjdMZXlSMVRvdldKM3lTd05qT2pYdEhxRnVNMG42TmdnWTNubEVRSmlnM25QdG9EZkdKK3RCMys1U2ZLNjZsVU9PV2hYM2NwZWQ0d1Znd0FITHQ4eWFCQ3BUSzdhbzBFNm54aHB1RURHYm94MjJSVCtyT0xtUzA0eVUrT3VOMjdoYU9JZUJGNUJnazhVOHJOc1ZIK0xCYmZ4TlZhOXB3cllwYjlDNW5TaWVibyt3TVRGZVNYdzUzNHk5MnVCcm5aQWRjNW41LzJ3aUE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=WSP8L6VnZ3FgncM25yuzblLo6axmA8BX/lWRYujEWIkVVGKxqWNwIVbSS5LmN6RYLlZcxzKtUVwPLMueWQdxzfMl9muMfQyQE1cvE2KrS4BUjBWAv7XjR1FvWPXIyxK8pZ/BNT9qHb0Lk14LuxvKSCNNbncKLCvCdaaYonXTFx8=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1660917017; v=1; bh=G/XEXi+cmERIK7sSJ5Ba+fVqiGCka0N3b/Z6Oyss/54=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.41
+Received: from ca4db.ca4.gtwy.dcn ([156.119.190.41])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 19 Aug 2022 09:50:16 -0400
+Received: from ca4db.ca4.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca4db.ca4.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 27JDoCgP092939
+	for <archive@recap.email>; Fri, 19 Aug 2022 09:50:12 -0400
+Date: Fri, 19 Aug 2022 09:50:12 -0400 (EDT)
+From: ecfnoticing@ca4.uscourts.gov
+To: archive@recap.email
+Message-ID: <349257739.509.1660917012783@ca4db.ca4.gtwy.dcn>
+Subject: 21-1919 Neuhtah Opiotennione v. Bozzuto Management Company "Case
+ continued from tentative calendar"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-1919 Neuhtah Opiotennione v. Bozzuto Management Company "Case continued from tentative calendar"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Fourth Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was entered on 08/19/2022 at 9:48:53 AM Eastern Daylight Time and filed on 08/19/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Neuhtah Opiotennione v. Bozzuto Management Company<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=164306">21-1919</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca4.uscourts.gov/docs1/00409007652?uid=ee31b72c3fff6b7f">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+CASE CONTINUED FROM TENTATIVE CALENDAR. [1001214884] [21-1919] JLC<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+<a name="R0">Recipient User Test 1, -</a>: testing3@gexample.com, testing3_1@gexample.com, testing3_2@gexample.com<BR>
+<a name="R1">Recipient User Test 2, Counsel</a>: testing1@gexample.com<BR>
+<a name="R2">Recipient User Test 3, -</a>: testing2@gexample.com<BR>
+<a name="R4">Recipient User Test 4, -</a>: testing4@gexample.com<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG><BR>
+<STRONG>Original Filename: </STRONG>/opt/ACECF/live/forms/JosephColeman_211919_1001214884_TENTCALCaseContinued_847.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1105645354 [Date=08/19/2022] [FileNumber=1001214884-0] [9bab2a7ccaa885cc1ef52801aa13c554171274c1cb5609eab86f73271a3027deb4e84b0dd2ba074473fbb527d0bff55aae778b086c0a980fbde23686c5b85fac]]<BR>
+<STRONG>Recipients: </STRONG><UL>
+<LI><a href="#R0">Recipient User Test 1, -</a>
+<LI><a href="#R1">Recipient User Test 2, Counsel</a>
+<LI><a href="#R2">Recipient User Test 3, -</a>
+<LI><a href="#R4">Recipient User Test 4, -</a>
+</UL>
+
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca4_1.txt
+++ b/tests/examples/pacer/nda/ca4_1.txt
@@ -33,7 +33,7 @@ Content-Transfer-Encoding: 7bit
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-1919 Neuhtah Opiotennione v. Bozzuto Management Company "Case continued from tentative calendar"</TITLE>
 </HEAD>
-<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
 <P><STRONG>
 ***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
 <P><CENTER><STRONG>United States Court of Appeals for the Fourth Circuit</STRONG></CENTER>

--- a/tests/examples/pacer/nda/ca4_2.json
+++ b/tests/examples/pacer/nda/ca4_2.json
@@ -1,22 +1,22 @@
 {
-  "case_name": "Mackenzie Brown v. State of Arizona",
-  "court_id": "ca9",
-  "date_filed": "2022-08-08",
-  "docket_entries": [
-    {
-      "date_filed": "2022-08-08",
-      "description": "COURT DELETED INCORRECT ENTRY. Entered in error (already listed on docket).Notice about deletion sent to case participants registered for electronic filing. Original Text: Entered appearance of Amicus Curiae USA. [12511871] (SML)",
-      "document_number": null,
-      "document_url": null,
-      "pacer_case_id": "320925",
-      "pacer_doc_id": null,
-      "pacer_magic_num": null,
-      "pacer_seq_no": null
-    }
+  "court_id":"ca4",
+  "case_name":"Neuhtah Opiotennione v. Bozzuto Management Company",
+  "docket_number":"21-1919",
+  "date_filed":"2022-08-18",
+  "appellate":true,
+  "docket_entries":[
+     {
+        "date_filed":"2022-08-18",
+        "description":"NOTICE re: Notice re: Regarding Resolution of Conflict with Proposed Argument dates by Bozzuto Management Company. [1001214590] [21-1919] Lynn Calkins",
+        "document_url":"https://ecf.ca4.uscourts.gov/docs1/00409006913?uid=55e8d970a5a88b7a",
+        "document_number": null,
+        "pacer_doc_id":"00409006913",
+        "pacer_case_id":"164306",
+        "pacer_seq_no":null,
+        "pacer_magic_num":"55e8d970a5a88b7a"
+     }
   ],
-  "docket_number": "20-15568",
-  "appellate": true,
-  "email_recipients": [
+  "email_recipients":[
     {
        "name":"Recipient User Test 1:",
        "email_addresses":[

--- a/tests/examples/pacer/nda/ca4_2.json
+++ b/tests/examples/pacer/nda/ca4_2.json
@@ -1,6 +1,7 @@
 {
   "court_id":"ca4",
   "case_name":"Neuhtah Opiotennione v. Bozzuto Management Company",
+  "contains_attachments": false,
   "docket_number":"21-1919",
   "date_filed":"2022-08-18",
   "appellate":true,

--- a/tests/examples/pacer/nda/ca4_2.txt
+++ b/tests/examples/pacer/nda/ca4_2.txt
@@ -1,0 +1,69 @@
+Return-Path: <ecfnoticing@ca4.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id i0ejmtd1fkq36a5h29kmdcho0fh5ooev7pgf7j81
+ for archive@recap.email;
+ Thu, 18 Aug 2022 19:37:30 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca4.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecfnoticing@ca4.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca4.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecfnoticing@ca4.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ca4.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFGSlQ1YUc5ZUd0SHJ6LzFGa0hzUFdaMTA1RGdTZytJV01CVGRmekJJdjlCUUN3VGRzcm4xTzdwZG1zTjIrNzNLSDYzSEdOS2FJaWZNSk92YVZ0NWlBR2tvU21NUzFBTEY0TmMrTHpycUw5ZWVSMjVtbDc2QlhwL1U2cG50cG05RGFiTEZrNTRGVG9zMW5ockRmZittb0tzblIrbFJYSWVBNnNpd1kxbWoxY2s4a09WL1o3MFFkUU9qZ2JQNXVqQUFxeDFodU9VamI2Z0kwM3p4MXFzU2t2aWp0V2ZHbnd1bFhZUFRvQlFER3pJUjVmZy9ocnl0Z3V6OWJqcUJWZzUvem54MDBQOXhpVy9jMTlSa1BXVGVTRnNQZ3RTOGFsZm1YWmRoWTRDWTA1TVE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=jzFPhJH48ahe83BqXpvjz8puEBY3KC1b1NkUmfGSXcuipMWSWIrISYua6Eg5ZgN5TLtCOhtF5jzqd7aJfZHeOMhWhwtCXBWuMnVCqPE+F0feRP8nELaeQL/2LfXAOxTPEXqqkXJlaobKWSZai4DRkJfF5dNNbqOf62+UlACVhPg=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1660851450; v=1; bh=WOQiYoeHKCcRpI4S5sNVy9we9SJ2dmiz8apQvvYk+sU=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.41
+Received: from ca4db.ca4.gtwy.dcn ([156.119.190.41])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 18 Aug 2022 15:37:29 -0400
+Received: from ca4db.ca4.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca4db.ca4.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 27IJb8nJ025165
+	for <archive@recap.email>; Thu, 18 Aug 2022 15:37:09 -0400
+Date: Thu, 18 Aug 2022 15:37:08 -0400 (EDT)
+From: ecfnoticing@ca4.uscourts.gov
+To: archive@recap.email
+Message-ID: <624901235.1665.1660851429179@ca4db.ca4.gtwy.dcn>
+Subject: 21-1919 Neuhtah Opiotennione v. Bozzuto Management Company "Notice
+ re:"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-1919 Neuhtah Opiotennione v. Bozzuto Management Company "Notice re:"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Fourth Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was entered on 08/18/2022 at 3:37:08 PM Eastern Daylight Time and filed on 08/18/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Neuhtah Opiotennione v. Bozzuto Management Company<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=164306">21-1919</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca4.uscourts.gov/docs1/00409006913?uid=55e8d970a5a88b7a">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+NOTICE re: Notice re: Regarding Resolution of Conflict with Proposed Argument dates by Bozzuto Management Company.
+ [1001214590] [21-1919] Lynn Calkins<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Recipient User Test 1: testing1@gexample.com, testing1_1@gexample.com<BR>
+Recipient User Test 2: testing2@gexample.com, testing2_1@gexample.com<BR>
+Recipient User Test 3: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4: testing4@gexample.com, testing4_1@gexample.com, testing4_1@gexample.com<BR>
+Recipient User Test 5: testing5@gexample.com, testing5_1@gexample.com, testing5_1@gexample.com<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Notice re: Regarding Resolution of Conflict with Proposed Argument dates<BR>
+<STRONG>Original Filename: </STRONG>Notice of Resolution of Conflict Unavailability(176961085.1)(177062886.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1105645354 [Date=08/18/2022] [FileNumber=1001214590-0] [323d25f8ec9ee5ac1b6c83e7a42395b9df29dbf51b6c52d537437b445f83fdbf89169d19b859942b66c80c80f765f0fc8a4494f1478ea2c00636689d7d7300b1]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca4_2.txt
+++ b/tests/examples/pacer/nda/ca4_2.txt
@@ -33,7 +33,7 @@ Content-Transfer-Encoding: 7bit
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-1919 Neuhtah Opiotennione v. Bozzuto Management Company "Notice re:"</TITLE>
 </HEAD>
-<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
 <P><STRONG>
 ***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
 <P><CENTER><STRONG>United States Court of Appeals for the Fourth Circuit</STRONG></CENTER>

--- a/tests/examples/pacer/nda/ca5_1.json
+++ b/tests/examples/pacer/nda/ca5_1.json
@@ -1,22 +1,22 @@
 {
-  "case_name": "Mackenzie Brown v. State of Arizona",
-  "court_id": "ca9",
-  "date_filed": "2022-08-08",
-  "docket_entries": [
-    {
-      "date_filed": "2022-08-08",
-      "description": "COURT DELETED INCORRECT ENTRY. Entered in error (already listed on docket).Notice about deletion sent to case participants registered for electronic filing. Original Text: Entered appearance of Amicus Curiae USA. [12511871] (SML)",
-      "document_number": null,
-      "document_url": null,
-      "pacer_case_id": "320925",
-      "pacer_doc_id": null,
-      "pacer_magic_num": null,
-      "pacer_seq_no": null
-    }
+  "court_id":"ca5",
+  "case_name":"Certain Underwriters v. Cox Operating",
+  "docket_number":"22-30371",
+  "date_filed":"2022-08-16",
+  "appellate":true,
+  "docket_entries":[
+     {
+        "date_filed":"2022-08-16",
+        "description":"RECORD EXCERPTS FILED by Appellant Certain Underwriters at Lloyds London. Date of service: 08/16/2022 via email - Attorney for Appellants: Bohman, Morse Attorney for Appellees: Lowe, Shipman [22-30371] (Harry E. Morse )",
+        "document_url":"https://ecf.ca5.uscourts.gov/docs1/00506433781?uid=12e61e2debdbca3f",
+        "document_number": null,
+        "pacer_doc_id":"00506433781",
+        "pacer_case_id":"208667",
+        "pacer_seq_no":null,
+        "pacer_magic_num":"12e61e2debdbca3f"
+     }
   ],
-  "docket_number": "20-15568",
-  "appellate": true,
-  "email_recipients": [
+  "email_recipients":[
     {
        "name":"Recipient User Test 1:",
        "email_addresses":[

--- a/tests/examples/pacer/nda/ca5_1.json
+++ b/tests/examples/pacer/nda/ca5_1.json
@@ -1,6 +1,7 @@
 {
   "court_id":"ca5",
   "case_name":"Certain Underwriters v. Cox Operating",
+  "contains_attachments": false,
   "docket_number":"22-30371",
   "date_filed":"2022-08-16",
   "appellate":true,

--- a/tests/examples/pacer/nda/ca5_1.txt
+++ b/tests/examples/pacer/nda/ca5_1.txt
@@ -33,7 +33,7 @@ Content-Transfer-Encoding: 7bit
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-30371 Certain Underwriters v. Cox Operating "Record Excerpts Filed"</TITLE>
 </HEAD>
-<BODY BGCOLOR="#DAF4F0" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<BODY BGCOLOR="#DAF4F0" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
 <P><STRONG>
 ***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
 </STRONG><BR>

--- a/tests/examples/pacer/nda/ca5_1.txt
+++ b/tests/examples/pacer/nda/ca5_1.txt
@@ -1,0 +1,70 @@
+Return-Path: <cmecf_caseprocessing@ca5.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 4ahb8helrkdlpp7i3p67vvho8iihmcu7jmd0ido1
+ for archive@recap.email;
+ Tue, 16 Aug 2022 15:21:59 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca5.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=cmecf_caseprocessing@ca5.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca5.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=cmecf_caseprocessing@ca5.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=ca5.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHNHJlc0lFV3dkcWlUMU1TOEovY3FVOXdJSW9HaUplaUI2Y2t5eEdYTFVzVjFNVWVWaWxWWDNRQUJnRUxGTytwM21aOHhxVXlZUUdpdklZcy80cTgxZExTU2hoeHJRUEdkR0V5R3VKRVVvTDBNZVl6Mk9ZbjFBUk1UbFBuVGN4ZDFXWlZ3TlJzMTd3WVFXcFNLNldLWThaRUNrd1Axcy9YaVVhWGc5M3lqOXhadFVra2NtTnNUZWk3OGtSQkNmWXpMVEJoYzUyd05mb0tuUm13dGx2S2hFOTg3bzE1RmNnOTlKeVRzdUhXY2h2bmZZR3U4U1RzYnFadGN6MWVjSEhKbVBHcDI0TGsxR0JCQWZ4ZFFDMGtnU2NCS2RJWEFubjh4ZVFodGVWY3lTOXhXY2NubkI3T1NqRmJBTDhqd0U1RWs9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=GGy2+j8LpIE76oa2v6gbeEcIhHiFv3LGcDhyuy6dz9ZiQRKUPDFEinc/ClJwi/2RH5dH3FHHFc1jlZg112/CUhBs2NDR1xH7Cv03UvdJ2lpU2PeleubQL2F9aDIvj/pKuExOz1vZxFiFbpwuQnM3K+b+dinSfywyqpZEUwfpkb8=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1660663319; v=1; bh=nrcYy2xamooM+GpbEZyWa0NRVF44lFK1a8oIB3kYQqs=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.56.85
+Received: from ca5db.ca5.gtwy.dcn ([156.119.56.85])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 16 Aug 2022 11:21:58 -0400
+Received: from ca5db.ca5.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca5db.ca5.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 27GFLPoU121329
+	for <archive@recap.email>; Tue, 16 Aug 2022 10:21:25 -0500
+Date: Tue, 16 Aug 2022 10:21:25 -0500 (CDT)
+From: cmecf_caseprocessing@ca5.uscourts.gov
+To: archive@recap.email
+Message-ID: <1803106173.981.1660663285411@ca5db.ca5.gtwy.dcn>
+Subject: 22-30371 Certain Underwriters v. Cox Operating "Record Excerpts
+ Filed"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-30371 Certain Underwriters v. Cox Operating "Record Excerpts Filed"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#DAF4F0" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+</STRONG><BR>
+<P><STRONG>
+PLEASE DO NOT REPLY TO THIS EMAIL AS IT ORIGINATES FROM AN UNATTENDED EMAIL ADDRESS.<P><CENTER><STRONG>United States Court of Appeals for the Fifth Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was entered on 08/16/2022 at 10:21:24 AM Central Daylight Time and filed on 08/16/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Certain Underwriters v. Cox Operating<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca5.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=208667">22-30371</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca5.uscourts.gov/docs1/00506433781?uid=12e61e2debdbca3f">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+RECORD EXCERPTS FILED by Appellant Certain Underwriters at Lloyds London. Date of service: 08/16/2022 via email - Attorney for Appellants: Bohman, Morse; Attorney for Appellees: Lowe, Shipman [22-30371] (Harry E. Morse )<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Recipient User Test 1: testing1@gexample.com, testing1_1@gexample.com<BR>
+Recipient User Test 2: testing2@gexample.com, testing2_1@gexample.com<BR>
+Recipient User Test 3: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4: testing4@gexample.com, testing4_1@gexample.com, testing4_1@gexample.com<BR>
+Recipient User Test 5: testing5@gexample.com, testing5_1@gexample.com, testing5_1@gexample.com<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Record Excerpts Filed<BR>
+<STRONG>Original Filename: </STRONG>2022.08.16_RECORD EXCERPTS by Appellant.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1105048708 [Date=08/16/2022] [FileNumber=9916826-0] [5f8402f042a386c355d9e8365b067f818b65469c403b9489e634dfdf9e91859d4d24ba8e12645f6d8522a576a8b01fcbf23402ed556f12252c4b0a3e8ad3b532]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca6_1.json
+++ b/tests/examples/pacer/nda/ca6_1.json
@@ -1,6 +1,7 @@
 {
   "court_id":"ca6",
   "case_name":"Andrea Goldblum v. UC",
+  "contains_attachments": false,
   "docket_number":"22-3289",
   "date_filed":"2022-08-15",
   "appellate":true,

--- a/tests/examples/pacer/nda/ca6_1.json
+++ b/tests/examples/pacer/nda/ca6_1.json
@@ -1,0 +1,42 @@
+{
+  "court_id":"ca6",
+  "case_name":"Andrea Goldblum v. UC",
+  "docket_number":"22-3289",
+  "date_filed":"2022-08-15",
+  "appellate":true,
+  "docket_entries":[
+     {
+        "date_filed":"2022-08-15",
+        "description":"MOTION filed by Ms. Marissa J. Palumbo for UC to extend time to file brief. Certificate of Service: 08/15/2022. [22-3289] (MJP)",
+        "document_url":"https://ecf.ca6.uscourts.gov/docs1/006014767502?uid=e957a05e64b3113b",
+        "document_number": null,
+        "pacer_doc_id":"006014767502",
+        "pacer_case_id":"143725",
+        "pacer_seq_no":null,
+        "pacer_magic_num":"e957a05e64b3113b"
+     }
+  ],
+  "email_recipients":[
+   {
+      "name":"Recipient User Test 1:",
+      "email_addresses":[
+         "testing1@gexample.com",
+         "testing1_1@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 2:",
+      "email_addresses":[
+         "testing2@gexample.com",
+         "testing2_1@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 3:",
+      "email_addresses":[
+         "testing3@gexample.com",
+         "testing3_1@gexample.com"
+      ]
+   }
+]
+}

--- a/tests/examples/pacer/nda/ca6_1.txt
+++ b/tests/examples/pacer/nda/ca6_1.txt
@@ -32,7 +32,7 @@ Content-Transfer-Encoding: 7bit
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-3289 Andrea Goldblum v. UC "motion extend time to file brief"</TITLE>
 </HEAD>
-<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
 <P><STRONG>
 ***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
 <P><CENTER><STRONG>United States Court of Appeals for the Sixth Circuit</STRONG></CENTER>

--- a/tests/examples/pacer/nda/ca6_1.txt
+++ b/tests/examples/pacer/nda/ca6_1.txt
@@ -1,0 +1,67 @@
+Return-Path: <ca06-ecf-noticedesk@ca6.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 95ka5h1mdj60k89id01o3ke6ce13o49ep7l7iho1
+ for archive@recap.email;
+ Mon, 15 Aug 2022 19:22:19 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca6.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=ca06-ecf-noticedesk@ca6.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca6.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=ca06-ecf-noticedesk@ca6.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=ca6.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHRDJWMTlBZ2dRek82SkIrMm5NdXd3TFpoSWFvYXJTd21FblZNbERlNGppbDhINFdwc25qb2pBN3BoeW1ZZk93WUxrOVZDSVhub1JkSVVLUWh5eXEraWpIa3hXV0Qrd3lPSnpjZTZ2M09qSmtXTnN0SmduMG1tTitVeEduUnVialBlZlVhYjNYQWFvOGtVU0IrclFEbkFxK3FjSlVCUFBOS28vamJGSlU2VTJLUWEyd0xybDVJeXplK3JaYU5ocW5MdHg0R0pYUzZWUFp1azhlejF1Z1lBbUZ3aG1RZkFOVjBxd0ZMd1JhQ2hMZVk2UHFMWE1kenBDSmM0WDFoR0xzVCtzV2IyeUp2U3JWSHpmZEs5MVdtTmV1WEE5bEgwK3UxOU9XeFgyM0lINk1rTGxNUm5lOTR6Y2RPWkNITkE1K2s9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=ACp0IkKVjRQdoMAAU7cogEzG0Unl9NZVl1ECeoWUxrgD1cw3IDphk9FoPvdvo1wFi/0fU5wDh/nj+uroLu0PNkEjOhMd8kx90RiYQ+GkhK7IhVSNenaI+FtTYN31zEQUQuiHC7vdBCt2pcxSfTbcAVHi1Lz+JCY0s4YF27F2dkQ=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1660591340; v=1; bh=OlVOigwZR6sp7i0jZY8Dp68+6rZ/djwJp/s0y5igD5w=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.128
+Received: from ca6db.ca6.gtwy.dcn ([156.119.190.128])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 15 Aug 2022 15:22:18 -0400
+Received: from ca6db.ca6.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca6db.ca6.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 27FJLwci027711
+	for <archive@recap.email>; Mon, 15 Aug 2022 15:21:58 -0400
+Date: Mon, 15 Aug 2022 15:21:58 -0400 (EDT)
+From: ca06-ecf-noticedesk@ca6.uscourts.gov
+To: archive@recap.email
+Message-ID: <1358103913.1670.1660591318437@ca6db.ca6.gtwy.dcn>
+Subject: 22-3289 Andrea Goldblum v. UC "motion extend time to file brief"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-3289 Andrea Goldblum v. UC "motion extend time to file brief"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Sixth Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 08/15/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Andrea Goldblum v. UC<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=143725">22-3289</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca6.uscourts.gov/docs1/006014767502?uid=e957a05e64b3113b">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+MOTION filed by Ms. Marissa J. Palumbo for UC to extend time to file brief. Certificate of Service: 08/15/2022. [22-3289] (MJP)<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Recipient User Test 1: testing1@gexample.com, testing1_1@gexample.com<BR>
+Recipient User Test 2: testing2@gexample.com, testing2_1@gexample.com<BR>
+Recipient User Test 3: testing3@gexample.com, testing3_1@gexample.com<BR>
+<BR><BR><BR><STRONG>Notice will be stored in the notice cart for:</STRONG><BR><BR>
+Ms. Michelle R. Lambert, Admin and/or Clerical Support<BR>
+<BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>motion<BR>
+<STRONG>Original Filename: </STRONG>2022-08-15 Def's Unopposed Second MET to File Merit Brief.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1105031299 [Date=08/15/2022] [FileNumber=6851219-0] [9926ad66b23e4198e368a871ffa88227eb9a5f23a5462cf92301e60a808a0e4dcb8eed64f7212bd59a8eb409621a2c76878557682f9c94a8ba816ba11ec9ad0f]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca6_2.json
+++ b/tests/examples/pacer/nda/ca6_2.json
@@ -1,6 +1,7 @@
 {
   "court_id":"ca6",
   "case_name":"Anthony Eid v. Wayne State University",
+  "contains_attachments": false,
   "docket_number":"22-1458",
   "date_filed":"2022-08-17",
   "appellate":true,

--- a/tests/examples/pacer/nda/ca6_2.json
+++ b/tests/examples/pacer/nda/ca6_2.json
@@ -1,0 +1,47 @@
+{
+  "court_id":"ca6",
+  "case_name":"Anthony Eid v. Wayne State University",
+  "docket_number":"22-1458",
+  "date_filed":"2022-08-17",
+  "appellate":true,
+  "docket_entries":[
+     {
+        "date_filed":"2022-08-17",
+        "description":"RULING LETTER SENT granting motion to extend time to file brief [18] filed by Mr. David Andrew Porter. 30 day extension of time granted. Resetting briefing schedule: appellee brief now due 10/19/2022. (REO)",
+        "document_url":"https://ecf.ca6.uscourts.gov/docs1/006014769961?uid=271f3379c94d3ba7",
+        "document_number": null,
+        "pacer_doc_id":"006014769961",
+        "pacer_case_id":"144305",
+        "pacer_seq_no":null,
+        "pacer_magic_num":"271f3379c94d3ba7"
+     }
+  ],
+  "email_recipients":[
+   {
+      "name":":",
+      "email_addresses":[
+         "testing3@gexample.com",
+         "testing3_1@gexample.com",
+         "testing3_2@gexample.com"
+      ]
+   },
+   {
+      "name":":",
+      "email_addresses":[
+         "testing1@gexample.com"
+      ]
+   },
+   {
+      "name":":",
+      "email_addresses":[
+         "testing2@gexample.com"
+      ]
+   },
+   {
+      "name":":",
+      "email_addresses":[
+         "testing4@gexample.com"
+      ]
+   }
+]
+}

--- a/tests/examples/pacer/nda/ca6_2.txt
+++ b/tests/examples/pacer/nda/ca6_2.txt
@@ -33,7 +33,7 @@ Content-Transfer-Encoding: 7bit
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-1458 Anthony Eid v. Wayne State University, et al "ruling letter sent"</TITLE>
 </HEAD>
-<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
 <P><STRONG>
 ***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
 <P><CENTER><STRONG>United States Court of Appeals for the Sixth Circuit</STRONG></CENTER>

--- a/tests/examples/pacer/nda/ca6_2.txt
+++ b/tests/examples/pacer/nda/ca6_2.txt
@@ -1,0 +1,73 @@
+Return-Path: <ca06-ecf-noticedesk@ca6.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id frjmi830qhhah7l6u0qde9ciosj9heh12e902fo1
+ for archive@recap.email;
+ Wed, 17 Aug 2022 19:38:06 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca6.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=ca06-ecf-noticedesk@ca6.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca6.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=ca06-ecf-noticedesk@ca6.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=ca6.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFIKy9kNHg1U0pBaUJ4RFNsdXM4U3NEcXBFVndqa1JqYXpDa25ZUStvKzZXcThONzJ6cHhpejBid09HK0pkRWszdXFJaVhsMjQyR3NMbTdad3VXWW5vNlVJTnhReUVXdk5WUUVUZEgwL0RnYmZrYXZ5dlM3NjVwcENOZGJQdmh1L1VXQklRZ0czTCsrVEFOS1dFaVFPSHBybEN1WWZRR01Obzd0WnpkSXRLWHJ2RmRzU2tzL3FYTmc2bkkrd3NkOHphekljbCtTbCs3NGxyQTJiOGQ3c2lhV1RSZjJNRGlqemNxSS9FQ2ZkTWMxZGg3dWRGNXpJZFhTZ21aTlBPZlBXcWFSQ3ZYNUNlMFZvS1lsbFZMWHRTVGhmZlhvbHMyMVBZcjZGWFI1NnVxc0VJcE40ZVNiM0ZtakRwdGhEb084eE09
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=Tx6U4a8eha3SVJoM27sZlQMsQH5vFTL80+a76oA+kxToLx26CwoXpXr6F+PQs7xeXfhe56Qq0zeToZf4qqebn1pJ3+L0x6invnl+j5dhlwfRBXEGUY6GWxOxfJ5PfRFytnI3X3giVt31k0FNnCzv3oHdgabYtozbw7gCXM3y9/E=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1660765087; v=1; bh=fv1bh4vW8AtCxYlmwJAwtNf/jTsAr63QAyQv0kfFvNY=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.128
+Received: from ca6db.ca6.gtwy.dcn ([156.119.190.128])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 17 Aug 2022 15:38:05 -0400
+Received: from ca6db.ca6.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca6db.ca6.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 27HJbMGc092507
+	for <archive@recap.email>; Wed, 17 Aug 2022 15:37:22 -0400
+Date: Wed, 17 Aug 2022 15:37:22 -0400 (EDT)
+From: ca06-ecf-noticedesk@ca6.uscourts.gov
+To: archive@recap.email
+Message-ID: <1906273915.1457.1660765042406@ca6db.ca6.gtwy.dcn>
+Subject: 22-1458 Anthony Eid v. Wayne State University, et al "ruling letter
+ sent"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-1458 Anthony Eid v. Wayne State University, et al "ruling letter sent"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#CCCCFF" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Sixth Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 08/17/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Anthony Eid v. Wayne State University, et al<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=144305">22-1458</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca6.uscourts.gov/docs1/006014769961?uid=271f3379c94d3ba7">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+RULING LETTER SENT granting motion to extend time to file brief [18] filed by Mr. David Andrew Porter. 30 day extension of time granted. Resetting briefing schedule: appellee brief now due 10/19/2022. (REO)<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+<a name="R0">Recipient User Test 1</a>: testing3@gexample.com, testing3_1@gexample.com, testing3_2@gexample.com<BR>
+<a name="R1">Recipient User Test 2</a>: testing1@gexample.com<BR>
+<a name="R2">Recipient User Test 3</a>: testing2@gexample.com<BR>
+<a name="R4">Recipient User Test 4</a>: testing4@gexample.com<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Reset Briefing Schedule Letter<BR>
+<STRONG>Original Filename: </STRONG>/opt/ACECF/live/forms/RyanOrme_221458_6852669_ResetBriefingScheduleLetterECF.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1105031299 [Date=08/17/2022] [FileNumber=6852669-0] [a7824fdf4358d8d83e2649fcbcff0d2360f4cb5a24686df127f0572783af63bdecb98813a93468c78d360dc93890f48103fa0f980c5a146689b55a6efbf7848c]]<BR>
+<STRONG>Recipients: </STRONG><UL>
+<LI><a href="#R0">Recipient User Test 1</a>
+<LI><a href="#R1">Recipient User Test 2</a>
+<LI><a href="#R2">Recipient User Test 3</a>
+<LI><a href="#R4">Recipient User Test 4</a>
+</UL>
+
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca9_1.json
+++ b/tests/examples/pacer/nda/ca9_1.json
@@ -6,9 +6,9 @@
     {
       "date_filed": "2022-08-08",
       "description": "Filed (ECF) Appellants Jenny Lin, Deillo Richards, Kisha Skipper, Jazmine Spencer and Rosemarie Vargas Correspondence: Appellants' Response to Appellee Facebook's July 29, 2022 letter. Date of service: 08/08/2022 [12512322] [21-16499] (Seplow, Michael)",
-      "document_number": "009033568259",
+      "document_number": null,
       "document_url": "https://ecf.ca9.uscourts.gov/docs1/009033568259?uid=337433b9bebbd7c7",
-      "pacer_case_id": "21-16499",
+      "pacer_case_id": "334146",
       "pacer_doc_id": "009033568259",
       "pacer_magic_num": "337433b9bebbd7c7",
       "pacer_seq_no": null
@@ -18,40 +18,41 @@
   "appellate": true,
   "email_recipients": [
     {
-      "email_addresses": [
-        "rring@gibsondunn.com",
-        "smaruschak@gibsondunn.com"
-      ],
-      "name": "Rosemarie T. Ring:"
+       "name":"Recipient User Test 1:",
+       "email_addresses":[
+          "testing1@gexample.com",
+          "testing1_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "wharris@sshhzlaw.com",
-        "kakopyan@sshhzlaw.com",
-        "srodriguez@sshhzlaw.com"
-      ],
-      "name": "Mr. Wilmer J. Harris:"
+       "name":"Recipient User Test 2:",
+       "email_addresses":[
+          "testing2@gexample.com",
+          "testing2_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "mseplow@sshhzlaw.com",
-        "cgallegos@sshhzlaw.com"
-      ],
-      "name": "Mr. Michael Seplow, Attorney:"
+       "name":"Recipient User Test 3:",
+       "email_addresses":[
+          "testing3@gexample.com",
+          "testing3_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "jimdavy@allriselaw.org",
-        "archive@recap.email"
-      ],
-      "name": "Jim Davy:"
+       "name":"Recipient User Test 4:",
+       "email_addresses":[
+          "testing4@gexample.com",
+          "testing4_1@gexample.com",
+          "testing4_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "mgetz@gibsondunn.com",
-        "mattagetz@gmail.com"
-      ],
-      "name": "Mr. Matt Aidan Getz:"
+       "name":"Recipient User Test 5:",
+       "email_addresses":[
+          "testing5@gexample.com",
+          "testing5_1@gexample.com",
+          "testing5_1@gexample.com"
+       ]
     }
-  ]
+ ]
 }

--- a/tests/examples/pacer/nda/ca9_1.json
+++ b/tests/examples/pacer/nda/ca9_1.json
@@ -15,7 +15,7 @@
     }
   ],
   "docket_number": "21-16499",
-  "email_notice_type": "NDA",
+  "appellate": true,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca9_1.json
+++ b/tests/examples/pacer/nda/ca9_1.json
@@ -10,11 +10,12 @@
       "document_url": "https://ecf.ca9.uscourts.gov/docs1/009033568259?uid=337433b9bebbd7c7",
       "pacer_case_id": "21-16499",
       "pacer_doc_id": "009033568259",
-      "pacer_magic_num": null,
+      "pacer_magic_num": "337433b9bebbd7c7",
       "pacer_seq_no": null
     }
   ],
   "docket_number": "21-16499",
+  "email_notice_type": "NDA",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca9_1.json
+++ b/tests/examples/pacer/nda/ca9_1.json
@@ -1,0 +1,56 @@
+{
+  "case_name": "Rosemarie Vargas v. Facebook, Inc.",
+  "court_id": "ca9",
+  "date_filed": "2022-08-08",
+  "docket_entries": [
+    {
+      "date_filed": "2022-08-08",
+      "description": "Filed (ECF) Appellants Jenny Lin, Deillo Richards, Kisha Skipper, Jazmine Spencer and Rosemarie Vargas Correspondence: Appellants' Response to Appellee Facebook's July 29, 2022 letter. Date of service: 08/08/2022 [12512322] [21-16499] (Seplow, Michael)",
+      "document_number": "009033568259",
+      "document_url": "https://ecf.ca9.uscourts.gov/docs1/009033568259?uid=337433b9bebbd7c7",
+      "pacer_case_id": "21-16499",
+      "pacer_doc_id": "009033568259",
+      "pacer_magic_num": null,
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "21-16499",
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "rring@gibsondunn.com",
+        "smaruschak@gibsondunn.com"
+      ],
+      "name": "Rosemarie T. Ring:"
+    },
+    {
+      "email_addresses": [
+        "wharris@sshhzlaw.com",
+        "kakopyan@sshhzlaw.com",
+        "srodriguez@sshhzlaw.com"
+      ],
+      "name": "Mr. Wilmer J. Harris:"
+    },
+    {
+      "email_addresses": [
+        "mseplow@sshhzlaw.com",
+        "cgallegos@sshhzlaw.com"
+      ],
+      "name": "Mr. Michael Seplow, Attorney:"
+    },
+    {
+      "email_addresses": [
+        "jimdavy@allriselaw.org",
+        "archive@recap.email"
+      ],
+      "name": "Jim Davy:"
+    },
+    {
+      "email_addresses": [
+        "mgetz@gibsondunn.com",
+        "mattagetz@gmail.com"
+      ],
+      "name": "Mr. Matt Aidan Getz:"
+    }
+  ]
+}

--- a/tests/examples/pacer/nda/ca9_1.json
+++ b/tests/examples/pacer/nda/ca9_1.json
@@ -1,5 +1,6 @@
 {
   "case_name": "Rosemarie Vargas v. Facebook, Inc.",
+  "contains_attachments": false,
   "court_id": "ca9",
   "date_filed": "2022-08-08",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca9_1.txt
+++ b/tests/examples/pacer/nda/ca9_1.txt
@@ -1,0 +1,68 @@
+Return-Path: <ca9_ecfnoticing@ca9.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 380mgptnphuf24mbk0s1ci1277c6d5mh9egj4301
+ for archive@recap.email;
+ Mon, 08 Aug 2022 22:21:33 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca9.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ca9_ecfnoticing@ca9.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca9.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ca9_ecfnoticing@ca9.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ca9.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFQWVyd2FaSmJPMnQ0SHR4d3RUZFdSUzN1VVo5S29qTXpRbFJrMExzVjEwQy9DYkhFTW9qbmZpTE5MZUEwSHF1RC90bTAvWjJBSTVEU3BJdDhUUVFNbm9CN0JVbHdTYWphRFE2M1RQa2s0VCszRDVjbkRiajR3WXF1dzl0aUQwSzZBUnJOUkI2QzVaN25vbnh4REpHODZEVW5wM3hWbjFyMUZWaHZEOW0yUlJuU0pJeCthaldhSXk5S1pJci84TGxaczJ3NWdDSSszOFRpbEV5c3BDZmc5R2Rib1VqSkFyYzROY09lTjc2dW4xaTJ2V2pCUnJTQmdLRW4waUZVVzhIVXdvZ1FWVER5bUVxRTU1OGw0cmwrYldIREhCSG1ISTBybzdGa1FKbWNtWnNlUkpjc0ovVHlnMDU5V2xud2ZWam89
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=FBYIMN/iiSzZwTt56Nd3/DCTq42xmeOBeM49zlqGJ0PWNwUo/PkTGyd8btCEcp1R3hul5H4vA0Jfb5nXv5tlzmKaaNXH7lATnmXrMIMiwDZ+en/l9/vHTehYjjrnU089a1gqb+uQ/HOqT8SWc8iOmdFErGrvdOPW3J1xD0v3HY4=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1659997294; v=1; bh=ua31659sYxBYrPtX6NcKCYoLfyn4iImZX2qe3mObIEE=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.56.100
+Received: from ca9db.ca9.gtwy.dcn ([156.119.56.100])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 08 Aug 2022 18:21:32 -0400
+Received: from ca9db.ca9.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca9db.ca9.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 278MKxUr099810
+	for <archive@recap.email>; Mon, 8 Aug 2022 15:20:59 -0700
+Date: Mon, 8 Aug 2022 15:20:59 -0700 (PDT)
+From: ca9_ecfnoticing@ca9.uscourts.gov
+To: archive@recap.email
+Message-ID: <1066811685.6583.1659997259208@ca9db.ca9.gtwy.dcn>
+Subject: 21-16499 Rosemarie Vargas, et al v. Facebook, Inc.
+ "Correspondence/Letter to Court"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-16499 Rosemarie Vargas, et al v. Facebook, Inc. "Correspondence/Letter to Court"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#F8F8F8" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Ninth Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was entered on 08/08/2022 at 3:20:58 PM Pacific Daylight Time and filed on 08/08/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Rosemarie Vargas, et al v. Facebook, Inc.<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca9.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=334146">21-16499</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca9.uscourts.gov/docs1/009033568259?uid=337433b9bebbd7c7">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+Filed (ECF) Appellants Jenny Lin, Deillo Richards, Kisha Skipper, Jazmine Spencer and Rosemarie Vargas Correspondence: Appellants' Response to Appellee Facebook's July 29, 2022 letter. Date of service: 08/08/2022 [12512322] [21-16499] (Seplow, Michael)<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Rosemarie T. Ring: rring@gibsondunn.com, smaruschak@gibsondunn.com<BR>
+Mr. Wilmer J. Harris: wharris@sshhzlaw.com, kakopyan@sshhzlaw.com, srodriguez@sshhzlaw.com<BR>
+Mr. Michael Seplow, Attorney: mseplow@sshhzlaw.com, cgallegos@sshhzlaw.com<BR>
+Jim Davy: jimdavy@allriselaw.org, archive@recap.email<BR>
+Mr. Matt Aidan Getz: mgetz@gibsondunn.com, mattagetz@gmail.com<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Appellants' Response to Appellee Facebook's July 29, 2022 letter<BR>
+<STRONG>Original Filename: </STRONG>Vargas v. Facebook -- Appellants' Response to Appellee's R 28(j) Letter 08-08-2022_FINAL.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1106763461 [Date=08/08/2022] [FileNumber=12512322-0] [5fdc6cc285a2602a878aeac7a4aa8dc30d6d68fedf29ccbe7da54fd2b21706353fec96731d0e8d2d8495fa0c2e7932c55018ee48d2e6832e8a99c4dc74bae321]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca9_1.txt
+++ b/tests/examples/pacer/nda/ca9_1.txt
@@ -53,11 +53,11 @@ The following transaction was entered on 08/08/2022 at 3:20:58 PM Pacific Daylig
 Filed (ECF) Appellants Jenny Lin, Deillo Richards, Kisha Skipper, Jazmine Spencer and Rosemarie Vargas Correspondence: Appellants' Response to Appellee Facebook's July 29, 2022 letter. Date of service: 08/08/2022 [12512322] [21-16499] (Seplow, Michael)<BR>
 <BR>
 <STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
-Rosemarie T. Ring: rring@gibsondunn.com, smaruschak@gibsondunn.com<BR>
-Mr. Wilmer J. Harris: wharris@sshhzlaw.com, kakopyan@sshhzlaw.com, srodriguez@sshhzlaw.com<BR>
-Mr. Michael Seplow, Attorney: mseplow@sshhzlaw.com, cgallegos@sshhzlaw.com<BR>
-Jim Davy: jimdavy@allriselaw.org, archive@recap.email<BR>
-Mr. Matt Aidan Getz: mgetz@gibsondunn.com, mattagetz@gmail.com<BR>
+Recipient User Test 1: testing1@gexample.com, testing1_1@gexample.com<BR>
+Recipient User Test 2: testing2@gexample.com, testing2_1@gexample.com<BR>
+Recipient User Test 3: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4: testing4@gexample.com, testing4_1@gexample.com, testing4_1@gexample.com<BR>
+Recipient User Test 5: testing5@gexample.com, testing5_1@gexample.com, testing5_1@gexample.com<BR>
 <BR><BR>
 The following document(s) are associated with this transaction:<BR>
 <STRONG>Document Description: </STRONG>Appellants' Response to Appellee Facebook's July 29, 2022 letter<BR>

--- a/tests/examples/pacer/nda/ca9_2.json
+++ b/tests/examples/pacer/nda/ca9_2.json
@@ -10,11 +10,12 @@
       "document_url": "https://ecf.ca9.uscourts.gov/docs1/009033566943?uid=cf70d9ec8f85b22f",
       "pacer_case_id": "20-15568",
       "pacer_doc_id": "009033566943",
-      "pacer_magic_num": null,
+      "pacer_magic_num": "cf70d9ec8f85b22f",
       "pacer_seq_no": null
     }
   ],
   "docket_number": "20-15568",
+  "email_notice_type": "NDA",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca9_2.json
+++ b/tests/examples/pacer/nda/ca9_2.json
@@ -1,5 +1,6 @@
 {
   "case_name": "Mackenzie Brown v. State of Arizona",
+  "contains_attachments": false,
   "court_id": "ca9",
   "date_filed": "2022-08-08",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca9_2.json
+++ b/tests/examples/pacer/nda/ca9_2.json
@@ -1,0 +1,62 @@
+{
+  "case_name": "Mackenzie Brown v. State of Arizona",
+  "court_id": "ca9",
+  "date_filed": "2022-08-08",
+  "docket_entries": [
+    {
+      "date_filed": "2022-08-08",
+      "description": "Submitted (ECF) Amicus brief for review (by government or with consent per FRAP 29(a)). Submitted by United States. Date of service: 08/08/2022. [12511705] [20-15568] (Lee, Jason)",
+      "document_number": "009033566943",
+      "document_url": "https://ecf.ca9.uscourts.gov/docs1/009033566943?uid=cf70d9ec8f85b22f",
+      "pacer_case_id": "20-15568",
+      "pacer_doc_id": "009033566943",
+      "pacer_magic_num": null,
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "20-15568",
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "isabel@hhylaw.com",
+        "stacey@hhylaw.com"
+      ],
+      "name": "Ms. Isabel M. Humphrey, Attorney:"
+    },
+    {
+      "email_addresses": [
+        "akimmel@publicjustice.net"
+      ],
+      "name": "Ms. Adele P. Kimmel, Managing Attorney:"
+    },
+    {
+      "email_addresses": [
+        "Claudia.Collings@azag.gov",
+        "sara.franz@azag.gov",
+        "thomas.maleta@azag.gov",
+        "defensetuc@azag.gov"
+      ],
+      "name": "Claudia Acosta Collings, Assistant Attorney General:"
+    },
+    {
+      "email_addresses": [
+        "clune@hbcboulder.com",
+        "gault@hbcboulder.com"
+      ],
+      "name": "Mr. John Clune:"
+    },
+    {
+      "email_addresses": [
+        "jimdavy@allriselaw.org",
+        "archive@recap.email"
+      ],
+      "name": "Jim Davy:"
+    },
+    {
+      "email_addresses": [
+        "mberkowitz@publicjustice.net"
+      ],
+      "name": "Mollie Berkowitz:"
+    }
+  ]
+}

--- a/tests/examples/pacer/nda/ca9_2.json
+++ b/tests/examples/pacer/nda/ca9_2.json
@@ -6,9 +6,9 @@
     {
       "date_filed": "2022-08-08",
       "description": "Submitted (ECF) Amicus brief for review (by government or with consent per FRAP 29(a)). Submitted by United States. Date of service: 08/08/2022. [12511705] [20-15568] (Lee, Jason)",
-      "document_number": "009033566943",
+      "document_number": null,
       "document_url": "https://ecf.ca9.uscourts.gov/docs1/009033566943?uid=cf70d9ec8f85b22f",
-      "pacer_case_id": "20-15568",
+      "pacer_case_id": "320925",
       "pacer_doc_id": "009033566943",
       "pacer_magic_num": "cf70d9ec8f85b22f",
       "pacer_seq_no": null
@@ -16,48 +16,43 @@
   ],
   "docket_number": "20-15568",
   "appellate": true,
-  "email_recipients": [
+  "email_recipients":[
     {
-      "email_addresses": [
-        "isabel@hhylaw.com",
-        "stacey@hhylaw.com"
-      ],
-      "name": "Ms. Isabel M. Humphrey, Attorney:"
+       "name":"Recipient User Test 1:",
+       "email_addresses":[
+          "testing1@gexample.com",
+          "testing1_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "akimmel@publicjustice.net"
-      ],
-      "name": "Ms. Adele P. Kimmel, Managing Attorney:"
+       "name":"Recipient User Test 2:",
+       "email_addresses":[
+          "testing2@gexample.com",
+          "testing2_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "Claudia.Collings@azag.gov",
-        "sara.franz@azag.gov",
-        "thomas.maleta@azag.gov",
-        "defensetuc@azag.gov"
-      ],
-      "name": "Claudia Acosta Collings, Assistant Attorney General:"
+       "name":"Recipient User Test 3:",
+       "email_addresses":[
+          "testing3@gexample.com",
+          "testing3_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "clune@hbcboulder.com",
-        "gault@hbcboulder.com"
-      ],
-      "name": "Mr. John Clune:"
+       "name":"Recipient User Test 4:",
+       "email_addresses":[
+          "testing4@gexample.com",
+          "testing4_1@gexample.com",
+          "testing4_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "jimdavy@allriselaw.org",
-        "archive@recap.email"
-      ],
-      "name": "Jim Davy:"
-    },
-    {
-      "email_addresses": [
-        "mberkowitz@publicjustice.net"
-      ],
-      "name": "Mollie Berkowitz:"
+       "name":"Recipient User Test 5:",
+       "email_addresses":[
+          "testing5@gexample.com",
+          "testing5_1@gexample.com",
+          "testing5_1@gexample.com"
+       ]
     }
-  ]
+ ]
 }

--- a/tests/examples/pacer/nda/ca9_2.json
+++ b/tests/examples/pacer/nda/ca9_2.json
@@ -15,7 +15,7 @@
     }
   ],
   "docket_number": "20-15568",
-  "email_notice_type": "NDA",
+  "appellate": true,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca9_2.txt
+++ b/tests/examples/pacer/nda/ca9_2.txt
@@ -53,12 +53,11 @@ The following transaction was entered on 08/08/2022 at 10:54:23 AM Pacific Dayli
 Submitted (ECF) Amicus brief for review (by government or with consent per FRAP 29(a)). Submitted by United States. Date of service: 08/08/2022. [12511705] [20-15568] (Lee, Jason)<BR>
 <BR>
 <STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
-Ms. Isabel M. Humphrey, Attorney: isabel@hhylaw.com, stacey@hhylaw.com<BR>
-Ms. Adele P. Kimmel, Managing Attorney: akimmel@publicjustice.net<BR>
-Claudia Acosta Collings, Assistant Attorney General: Claudia.Collings@azag.gov, sara.franz@azag.gov, thomas.maleta@azag.gov, defensetuc@azag.gov<BR>
-Mr. John Clune: clune@hbcboulder.com, gault@hbcboulder.com<BR>
-Jim Davy: jimdavy@allriselaw.org, archive@recap.email<BR>
-Mollie Berkowitz: mberkowitz@publicjustice.net<BR>
+Recipient User Test 1: testing1@gexample.com, testing1_1@gexample.com<BR>
+Recipient User Test 2: testing2@gexample.com, testing2_1@gexample.com<BR>
+Recipient User Test 3: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4: testing4@gexample.com, testing4_1@gexample.com, testing4_1@gexample.com<BR>
+Recipient User Test 5: testing5@gexample.com, testing5_1@gexample.com, testing5_1@gexample.com<BR>
 <BR><BR>
 The following document(s) are associated with this transaction:<BR>
 <STRONG>Document Description: </STRONG>Main Document<BR>

--- a/tests/examples/pacer/nda/ca9_2.txt
+++ b/tests/examples/pacer/nda/ca9_2.txt
@@ -1,0 +1,69 @@
+Return-Path: <ca9_ecfnoticing@ca9.uscourts.gov>
+Received: from icmecf202.gtwy.uscourts.gov (icmecf202.gtwy.uscourts.gov [63.241.40.205])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id bk7takt74gqk40du15k0ae0j534nf1mlc8hb33o1
+ for archive@recap.email;
+ Mon, 08 Aug 2022 17:55:09 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca9.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=ca9_ecfnoticing@ca9.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca9.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=ca9_ecfnoticing@ca9.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+ dmarc=none header.from=ca9.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFUGM0bWREYnFseDFOZDl2d0ljWkNCMXY2Z0RENEp5a1FERXJNYTY5VElhbnNBeUV3MmNOSlhXVkVCcXVSaHVyRHJRdHREV2VXVTQ5T3JVanViWk51Y2swMjVPQXZWVU9Zbi96aWJxYnRFUlNYVXN2RWwwUXh2RVJ3cGVlbjl2cDhXKy8yaWdDcXVaZW9YeVc1dS9DSVdab0JNWUtRVDhYUVRwNCtraUJUdXlUeXFKeHBhdk8xZFhHWHhTWWMrNDFuQVpTOExKSkJUdC9ibmhPOGZON3NUTGd0WU9zSHQ5OHg3c0U5Ukc3T0ZlVDhPOTNaUGhTVDRJaTg0b0xkQWtSV2trelhSMEdtR0MvVzk1S2VQS2FzWTcwcyt0aTZOK2lhN1BLdnZpZ29wMzlTWnJpR2ZzekRoNFcrVURJcFliajA9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=eOXVhcrX/gvJi5GvlSF7cxNY41+ESXqXwk0SGjkCw1ArZJz5AorZdkVJjovRfJ2lquCLTQ9x/d0dJxp9heVFIJik+Q5HIIorIY9JOahl3mUFwuR1K4laJYB5EZGPB3ATsXzmz+a4MX1hAdkdI1dMLoiapjxV5LTumpQOLuIE0FM=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1659981310; v=1; bh=eENLqgCr/twTtsY3ck5GQIlzE1D1oZY3hKypUNlMYBY=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.56.100
+Received: from ca9db.ca9.gtwy.dcn ([156.119.56.100])
+  by icmecf202.gtwy.uscourts.gov with ESMTP; 08 Aug 2022 13:55:08 -0400
+Received: from ca9db.ca9.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca9db.ca9.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 278HsOMm077347
+	for <archive@recap.email>; Mon, 8 Aug 2022 10:54:24 -0700
+Date: Mon, 8 Aug 2022 10:54:24 -0700 (PDT)
+From: ca9_ecfnoticing@ca9.uscourts.gov
+To: archive@recap.email
+Message-ID: <1303272048.2939.1659981264433@ca9db.ca9.gtwy.dcn>
+Subject: 20-15568 Mackenzie  Brown, et al v. State of Arizona, et al "Amicus
+ Brief by Government or with Consent"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>20-15568 Mackenzie  Brown, et al v. State of Arizona, et al "Amicus Brief by Government or with Consent"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#F8F8F8" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Ninth Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was entered on 08/08/2022 at 10:54:23 AM Pacific Daylight Time and filed on 08/08/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Mackenzie  Brown, et al v. State of Arizona, et al<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca9.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=320925">20-15568</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca9.uscourts.gov/docs1/009033566943?uid=cf70d9ec8f85b22f">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+Submitted (ECF) Amicus brief for review (by government or with consent per FRAP 29(a)). Submitted by United States. Date of service: 08/08/2022. [12511705] [20-15568] (Lee, Jason)<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Ms. Isabel M. Humphrey, Attorney: isabel@hhylaw.com, stacey@hhylaw.com<BR>
+Ms. Adele P. Kimmel, Managing Attorney: akimmel@publicjustice.net<BR>
+Claudia Acosta Collings, Assistant Attorney General: Claudia.Collings@azag.gov, sara.franz@azag.gov, thomas.maleta@azag.gov, defensetuc@azag.gov<BR>
+Mr. John Clune: clune@hbcboulder.com, gault@hbcboulder.com<BR>
+Jim Davy: jimdavy@allriselaw.org, archive@recap.email<BR>
+Mollie Berkowitz: mberkowitz@publicjustice.net<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Main Document<BR>
+<STRONG>Original Filename: </STRONG>Brown (9th Cir.)_US Amicus Brief.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1106763461 [Date=08/08/2022] [FileNumber=12511705-0] [17b4cbc4ba5881db4c0265bf0b9c71e53dd4f033d390a7d6c67acfebfbe492e378b73c8b4b6a53ddb61a1554090fe4b4cb7678bc4ad87a8c60d0dc94ce7a1950]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca9_3.json
+++ b/tests/examples/pacer/nda/ca9_3.json
@@ -15,7 +15,7 @@
     }
   ],
   "docket_number": "21-16499",
-  "email_notice_type": "NDA",
+  "appellate": true,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca9_3.json
+++ b/tests/examples/pacer/nda/ca9_3.json
@@ -1,5 +1,6 @@
 {
   "case_name": "Rosemarie Vargas v. Facebook, Inc.",
+  "contains_attachments": false,
   "court_id": "ca9",
   "date_filed": "2022-08-08",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca9_3.json
+++ b/tests/examples/pacer/nda/ca9_3.json
@@ -10,11 +10,12 @@
       "document_url": "https://ecf.ca9.uscourts.gov/docs1/009033568331?uid=472bdf5935654af5",
       "pacer_case_id": "21-16499",
       "pacer_doc_id": "009033568331",
-      "pacer_magic_num": null,
+      "pacer_magic_num": "472bdf5935654af5",
       "pacer_seq_no": null
     }
   ],
   "docket_number": "21-16499",
+  "email_notice_type": "NDA",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca9_3.json
+++ b/tests/examples/pacer/nda/ca9_3.json
@@ -6,9 +6,9 @@
     {
       "date_filed": "2022-08-08",
       "description": "Filed (ECF) Appellants Jenny Lin, Deillo Richards, Kisha Skipper, Jazmine Spencer and Rosemarie Vargas citation of supplemental authorities. Date of service: 08/08/2022. [12512349]--[COURT ENTERED FILING to correct entry [53].] (SLM)",
-      "document_number": "009033568331",
+      "document_number": null,
       "document_url": "https://ecf.ca9.uscourts.gov/docs1/009033568331?uid=472bdf5935654af5",
-      "pacer_case_id": "21-16499",
+      "pacer_case_id": "334146",
       "pacer_doc_id": "009033568331",
       "pacer_magic_num": "472bdf5935654af5",
       "pacer_seq_no": null
@@ -18,47 +18,41 @@
   "appellate": true,
   "email_recipients": [
     {
-      "email_addresses": [
-        "razad@gibsondunn.com",
-        "shoang@gibsondunn.com"
-      ],
-      "name": "Mr. Ryan Azad:"
+       "name":"Recipient User Test 1:",
+       "email_addresses":[
+          "testing1@gexample.com",
+          "testing1_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "jimdavy@allriselaw.org",
-        "archive@recap.email"
-      ],
-      "name": "Jim Davy:"
+       "name":"Recipient User Test 2:",
+       "email_addresses":[
+          "testing2@gexample.com",
+          "testing2_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "mgetz@gibsondunn.com",
-        "mattagetz@gmail.com"
-      ],
-      "name": "Mr. Matt Aidan Getz:"
+       "name":"Recipient User Test 3:",
+       "email_addresses":[
+          "testing3@gexample.com",
+          "testing3_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "wharris@sshhzlaw.com",
-        "kakopyan@sshhzlaw.com",
-        "srodriguez@sshhzlaw.com"
-      ],
-      "name": "Mr. Wilmer J. Harris:"
+       "name":"Recipient User Test 4:",
+       "email_addresses":[
+          "testing4@gexample.com",
+          "testing4_1@gexample.com",
+          "testing4_1@gexample.com"
+       ]
     },
     {
-      "email_addresses": [
-        "rring@gibsondunn.com",
-        "smaruschak@gibsondunn.com"
-      ],
-      "name": "Rosemarie T. Ring:"
-    },
-    {
-      "email_addresses": [
-        "mseplow@sshhzlaw.com",
-        "cgallegos@sshhzlaw.com"
-      ],
-      "name": "Mr. Michael Seplow, Attorney:"
+       "name":"Recipient User Test 5:",
+       "email_addresses":[
+          "testing5@gexample.com",
+          "testing5_1@gexample.com",
+          "testing5_1@gexample.com"
+       ]
     }
-  ]
+ ]
 }

--- a/tests/examples/pacer/nda/ca9_3.json
+++ b/tests/examples/pacer/nda/ca9_3.json
@@ -1,0 +1,63 @@
+{
+  "case_name": "Rosemarie Vargas v. Facebook, Inc.",
+  "court_id": "ca9",
+  "date_filed": "2022-08-08",
+  "docket_entries": [
+    {
+      "date_filed": "2022-08-08",
+      "description": "Filed (ECF) Appellants Jenny Lin, Deillo Richards, Kisha Skipper, Jazmine Spencer and Rosemarie Vargas citation of supplemental authorities. Date of service: 08/08/2022. [12512349]--[COURT ENTERED FILING to correct entry [53].] (SLM)",
+      "document_number": "009033568331",
+      "document_url": "https://ecf.ca9.uscourts.gov/docs1/009033568331?uid=472bdf5935654af5",
+      "pacer_case_id": "21-16499",
+      "pacer_doc_id": "009033568331",
+      "pacer_magic_num": null,
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "21-16499",
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "razad@gibsondunn.com",
+        "shoang@gibsondunn.com"
+      ],
+      "name": "Mr. Ryan Azad:"
+    },
+    {
+      "email_addresses": [
+        "jimdavy@allriselaw.org",
+        "archive@recap.email"
+      ],
+      "name": "Jim Davy:"
+    },
+    {
+      "email_addresses": [
+        "mgetz@gibsondunn.com",
+        "mattagetz@gmail.com"
+      ],
+      "name": "Mr. Matt Aidan Getz:"
+    },
+    {
+      "email_addresses": [
+        "wharris@sshhzlaw.com",
+        "kakopyan@sshhzlaw.com",
+        "srodriguez@sshhzlaw.com"
+      ],
+      "name": "Mr. Wilmer J. Harris:"
+    },
+    {
+      "email_addresses": [
+        "rring@gibsondunn.com",
+        "smaruschak@gibsondunn.com"
+      ],
+      "name": "Rosemarie T. Ring:"
+    },
+    {
+      "email_addresses": [
+        "mseplow@sshhzlaw.com",
+        "cgallegos@sshhzlaw.com"
+      ],
+      "name": "Mr. Michael Seplow, Attorney:"
+    }
+  ]
+}

--- a/tests/examples/pacer/nda/ca9_3.txt
+++ b/tests/examples/pacer/nda/ca9_3.txt
@@ -53,12 +53,11 @@ The following transaction was entered on 08/08/2022 at 3:31:31 PM Pacific Daylig
 Filed (ECF) Appellants Jenny Lin, Deillo Richards, Kisha Skipper, Jazmine Spencer and Rosemarie Vargas citation of supplemental authorities. Date of service: 08/08/2022. [12512349]--[COURT ENTERED FILING to correct entry [53].] (SLM)<BR>
 <BR>
 <STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
-Mr. Ryan Azad: razad@gibsondunn.com, shoang@gibsondunn.com<BR>
-Jim Davy: jimdavy@allriselaw.org, archive@recap.email<BR>
-Mr. Matt Aidan Getz: mgetz@gibsondunn.com, mattagetz@gmail.com<BR>
-Mr. Wilmer J. Harris: wharris@sshhzlaw.com, kakopyan@sshhzlaw.com, srodriguez@sshhzlaw.com<BR>
-Rosemarie T. Ring: rring@gibsondunn.com, smaruschak@gibsondunn.com<BR>
-Mr. Michael Seplow, Attorney: mseplow@sshhzlaw.com, cgallegos@sshhzlaw.com<BR>
+Recipient User Test 1: testing1@gexample.com, testing1_1@gexample.com<BR>
+Recipient User Test 2: testing2@gexample.com, testing2_1@gexample.com<BR>
+Recipient User Test 3: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4: testing4@gexample.com, testing4_1@gexample.com, testing4_1@gexample.com<BR>
+Recipient User Test 5: testing5@gexample.com, testing5_1@gexample.com, testing5_1@gexample.com<BR>
 <BR><BR>
 The following document(s) are associated with this transaction:<BR>
 <STRONG>Document Description: </STRONG>Main Document<BR>

--- a/tests/examples/pacer/nda/ca9_3.txt
+++ b/tests/examples/pacer/nda/ca9_3.txt
@@ -1,0 +1,69 @@
+Return-Path: <ca9_ecfnoticing@ca9.uscourts.gov>
+Received: from icmecf202.gtwy.uscourts.gov (icmecf202.gtwy.uscourts.gov [63.241.40.205])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id gn83ofsnikvqa7t8ir9r992j8uj1hq5lkoa8fe81
+ for archive@recap.email;
+ Mon, 08 Aug 2022 22:31:54 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca9.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=ca9_ecfnoticing@ca9.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca9.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=ca9_ecfnoticing@ca9.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+ dmarc=none header.from=ca9.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFTnMveWhyUDlaRzhSZk9paW84ekNHU3lQMFQ5QTd4VnRIekVmUnVUdXhNZHdCKzA5OG5rWjJuMkpUZStBMzVWOFNLclFzWjdoZVdPTUF2ODBTaFZObXhNaFE0SDdsdTl0a0gzUzZiRFpobVc2OURqYU8rS1dXR2lwRm1TRzc5YnVDNUdqRHUweVFTYXBKZm4xTUhWRlQvbUx6YTJ0WFcwdFNRNFJZb0gzY1R3L0JNMGFGRGRXSzNUajZFNHVLd0N1TkQxVmxQOS84V3NUVDFaY1Y1eGZxTTBxRjJQT3lnSjlveTZqQ3R2RWxWSENiWVJCdmRLQkdSa0lFci80QzVMYnBXTG5wM1IwN1BnWVgrMkhyKzV1OHZDTmZKRUdrWmRpMVg5clZuUE9qT3EzRi9NVnZZT050OExDRXUwWWVWWW89
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=Ce/p/s0oUhyv2M0opWFUFAFo1BuMoJJ3NoH7bkVzRVTSybgypb32yuCuN0TpHs9a3UNjjfoxe7vYEb4LM2SO8gh/CYXkd3BUyU1vWkx8h+IR5ewDcpOhbN72K9KFqRevOiWSVu7SVRsPvnXw9PjLtkDTJuEcgvCCRlmqYmeJfZU=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1659997914; v=1; bh=6saUJSbPWdxHyhJRfT8dxFMCzLr3btvUPb2y1E++2uM=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.56.100
+Received: from ca9db.ca9.gtwy.dcn ([156.119.56.100])
+  by icmecf202.gtwy.uscourts.gov with ESMTP; 08 Aug 2022 18:31:53 -0400
+Received: from ca9db.ca9.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca9db.ca9.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 278MVhAe119754
+	for <archive@recap.email>; Mon, 8 Aug 2022 15:31:43 -0700
+Date: Mon, 8 Aug 2022 15:31:43 -0700 (PDT)
+From: ca9_ecfnoticing@ca9.uscourts.gov
+To: archive@recap.email
+Message-ID: <851424647.6730.1659997903289@ca9db.ca9.gtwy.dcn>
+Subject: 21-16499 Rosemarie Vargas, et al v. Facebook, Inc. "28(j) Letter
+ (Citation of Supplemental Authorities)"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>21-16499 Rosemarie Vargas, et al v. Facebook, Inc. "28(j) Letter (Citation of Supplemental Authorities)"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#F8F8F8" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Ninth Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was entered on 08/08/2022 at 3:31:31 PM Pacific Daylight Time and filed on 08/08/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Rosemarie Vargas, et al v. Facebook, Inc.<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca9.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=334146">21-16499</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca9.uscourts.gov/docs1/009033568331?uid=472bdf5935654af5">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+Filed (ECF) Appellants Jenny Lin, Deillo Richards, Kisha Skipper, Jazmine Spencer and Rosemarie Vargas citation of supplemental authorities. Date of service: 08/08/2022. [12512349]--[COURT ENTERED FILING to correct entry [53].] (SLM)<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Mr. Ryan Azad: razad@gibsondunn.com, shoang@gibsondunn.com<BR>
+Jim Davy: jimdavy@allriselaw.org, archive@recap.email<BR>
+Mr. Matt Aidan Getz: mgetz@gibsondunn.com, mattagetz@gmail.com<BR>
+Mr. Wilmer J. Harris: wharris@sshhzlaw.com, kakopyan@sshhzlaw.com, srodriguez@sshhzlaw.com<BR>
+Rosemarie T. Ring: rring@gibsondunn.com, smaruschak@gibsondunn.com<BR>
+Mr. Michael Seplow, Attorney: mseplow@sshhzlaw.com, cgallegos@sshhzlaw.com<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Main Document<BR>
+<STRONG>Original Filename: </STRONG>21-16499 C 54.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1106763461 [Date=08/08/2022] [FileNumber=12512349-0] [17ce8b8d28136a4e6c7b341c6470405eb4be5b5db979413d05d51c9eebd7af06642ec56b7a92a7aa222fca94645794a6a58c2b1026c359df9e9e34de5ff6aaeb]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca9_4.json
+++ b/tests/examples/pacer/nda/ca9_4.json
@@ -1,5 +1,6 @@
 {
   "case_name": "Mackenzie Brown v. State of Arizona",
+  "contains_attachments": false,
   "court_id": "ca9",
   "date_filed": "2022-08-08",
   "docket_entries": [

--- a/tests/examples/pacer/nda/ca9_4.json
+++ b/tests/examples/pacer/nda/ca9_4.json
@@ -1,0 +1,63 @@
+{
+  "case_name": "Mackenzie Brown v. State of Arizona",
+  "court_id": "ca9",
+  "date_filed": "2022-08-08",
+  "docket_entries": [
+    {
+      "date_filed": "2022-08-08",
+      "description": "COURT DELETED INCORRECT ENTRY. Entered in error (already listed on docket).Notice about deletion sent to case participants registered for electronic filing. Original Text: Entered appearance of Amicus Curiae USA. [12511871] (SML)",
+      "document_number": null,
+      "document_url": null,
+      "pacer_case_id": "20-15568",
+      "pacer_doc_id": null,
+      "pacer_magic_num": null,
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "20-15568",
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "Claudia.Collings@azag.gov",
+        "sara.franz@azag.gov",
+        "thomas.maleta@azag.gov",
+        "defensetuc@azag.gov"
+      ],
+      "name": "Claudia Acosta Collings, Assistant Attorney General:"
+    },
+    {
+      "email_addresses": [
+        "mberkowitz@publicjustice.net"
+      ],
+      "name": "Mollie Berkowitz:"
+    },
+    {
+      "email_addresses": [
+        "clune@hbcboulder.com",
+        "gault@hbcboulder.com"
+      ],
+      "name": "Mr. John Clune:"
+    },
+    {
+      "email_addresses": [
+        "jimdavy@allriselaw.org",
+        "archive@recap.email"
+      ],
+      "name": "Jim Davy:"
+    },
+    {
+      "email_addresses": [
+        "isabel@hhylaw.com",
+        "stacey@hhylaw.com"
+      ],
+      "name": "Ms. Isabel M. Humphrey, Attorney:"
+    },
+    {
+      "email_addresses": [
+        "akimmel@publicjustice.net"
+      ],
+      "name": "Ms. Adele P. Kimmel, Managing Attorney:"
+    }
+
+  ]
+}

--- a/tests/examples/pacer/nda/ca9_4.json
+++ b/tests/examples/pacer/nda/ca9_4.json
@@ -15,7 +15,7 @@
     }
   ],
   "docket_number": "20-15568",
-  "email_notice_type": "NDA",
+  "appellate": true,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca9_4.json
+++ b/tests/examples/pacer/nda/ca9_4.json
@@ -15,6 +15,7 @@
     }
   ],
   "docket_number": "20-15568",
+  "email_notice_type": "NDA",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nda/ca9_4.txt
+++ b/tests/examples/pacer/nda/ca9_4.txt
@@ -1,0 +1,63 @@
+Return-Path: <ca9_ecfnoticing@ca9.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 439p0i284ss1469e8dneefeivgeq6kji8cf8rco1
+ for archive@recap.email;
+ Mon, 08 Aug 2022 19:25:14 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca9.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ca9_ecfnoticing@ca9.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca9.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ca9_ecfnoticing@ca9.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ca9.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFaHBkd1N4a3pPbzNLOWFVbDltaHExT3JqeEM5RzdCK3N2M0JpdHFoWkVTd2pPQkg1eUFqY0FKOGZ1dlBLM1BqbGZSR3EvVk1QRmRyU3c3UXlRaWhMaHUxSkJEWmZNT0xHNVduUWZnRkNUbHZSdEpWbnlBUHRVQkVXSisxMTdLQW56S1h4djBpOUQwZjdFVHNZYWxiUFhwZkNxcS9yZTI0MnprTFhyS0FVQ0FYT0FPZXVDWE9mUmo1b0d5MEhBbU5HM0lZdjdkSFRCQWtUYXM1UW42bTFjUjR0Mk42ZXlOaDU3VEtoclYyOWNuT0hTNkdPZWFIeUFMNmVLWlIyQ3dmbEtVb3pwNFBYZElyWmFKdXZQRThkaDRsa1NHVDIwQThuT3NXMnhDWlZWdHB4bWYrMmsraW1OYklUZjZIRGJxWU09
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=CyxNzZrjMaaGthwDiCwt0mG7FFXfZZLapVxzfWVhS5CV6km4mLmuLIMtDlAF+IAR7jNovTtkyKl23/+wKkp9oAeszsWwR62cB2FZ6zIepGGaaZ8XfNhBD0OhxI0TYu67SIo5GsMGs/0G6TsAHYrJNjcDas7X4QSvEp0QBM773Ng=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1659986715; v=1; bh=82CcWY1a7REAp4N7phtCbsBh6YyV4q+9ra3in7rDFc4=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.56.100
+Received: from ca9db.ca9.gtwy.dcn ([156.119.56.100])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 08 Aug 2022 15:25:14 -0400
+Received: from ca9db.ca9.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca9db.ca9.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 278JOno4065824
+	for <archive@recap.email>; Mon, 8 Aug 2022 12:24:49 -0700
+Date: Mon, 8 Aug 2022 12:24:49 -0700 (PDT)
+From: ca9_ecfnoticing@ca9.uscourts.gov
+To: archive@recap.email
+Message-ID: <1037275041.4166.1659986689643@ca9db.ca9.gtwy.dcn>
+Subject: Re-send: 20-15568 Mackenzie  Brown, et al v. State of Arizona, et
+ al "Deleted Entry"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>Re-send: 20-15568 Mackenzie  Brown, et al v. State of Arizona, et al "Deleted Entry"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#F8F8F8" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Ninth Circuit</STRONG></CENTER>
+<P><STRONG>Amended 08/08/2022 12:24:49: Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was entered on 08/08/2022 at 12:08:21 PM Pacific Daylight Time and filed on 08/08/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Mackenzie  Brown, et al v. State of Arizona, et al<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca9.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=320925">20-15568</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+COURT DELETED INCORRECT ENTRY. Entered in error (already listed on docket).Notice about deletion sent to case participants registered for electronic filing. Original Text:
+Entered appearance of Amicus Curiae USA. [12511871] (SML)<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Claudia Acosta Collings, Assistant Attorney General: Claudia.Collings@azag.gov, sara.franz@azag.gov, thomas.maleta@azag.gov, defensetuc@azag.gov<BR>
+Mollie Berkowitz: mberkowitz@publicjustice.net<BR>
+Mr. John Clune: clune@hbcboulder.com, gault@hbcboulder.com<BR>
+Jim Davy: jimdavy@allriselaw.org, archive@recap.email<BR>
+Ms. Isabel M. Humphrey, Attorney: isabel@hhylaw.com, stacey@hhylaw.com<BR>
+Ms. Adele P. Kimmel, Managing Attorney: akimmel@publicjustice.net<BR>
+<BR><BR>
+
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca9_4.txt
+++ b/tests/examples/pacer/nda/ca9_4.txt
@@ -52,12 +52,11 @@ COURT DELETED INCORRECT ENTRY. Entered in error (already listed on docket).Notic
 Entered appearance of Amicus Curiae USA. [12511871] (SML)<BR>
 <BR>
 <STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
-Claudia Acosta Collings, Assistant Attorney General: Claudia.Collings@azag.gov, sara.franz@azag.gov, thomas.maleta@azag.gov, defensetuc@azag.gov<BR>
-Mollie Berkowitz: mberkowitz@publicjustice.net<BR>
-Mr. John Clune: clune@hbcboulder.com, gault@hbcboulder.com<BR>
-Jim Davy: jimdavy@allriselaw.org, archive@recap.email<BR>
-Ms. Isabel M. Humphrey, Attorney: isabel@hhylaw.com, stacey@hhylaw.com<BR>
-Ms. Adele P. Kimmel, Managing Attorney: akimmel@publicjustice.net<BR>
+Recipient User Test 1: testing1@gexample.com, testing1_1@gexample.com<BR>
+Recipient User Test 2: testing2@gexample.com, testing2_1@gexample.com<BR>
+Recipient User Test 3: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4: testing4@gexample.com, testing4_1@gexample.com, testing4_1@gexample.com<BR>
+Recipient User Test 5: testing5@gexample.com, testing5_1@gexample.com, testing5_1@gexample.com<BR>
 <BR><BR>
 
 </BODY></HTML>

--- a/tests/examples/pacer/nda/cafc_1.json
+++ b/tests/examples/pacer/nda/cafc_1.json
@@ -1,6 +1,7 @@
 {
   "court_id":"cafc",
   "case_name":"Corephotonics, Ltd. v. Apple Inc.",
+  "contains_attachments": false,
   "docket_number":"22-1455",
   "date_filed":"2022-08-22",
   "appellate":true,

--- a/tests/examples/pacer/nda/cafc_1.json
+++ b/tests/examples/pacer/nda/cafc_1.json
@@ -1,0 +1,54 @@
+{
+  "court_id":"cafc",
+  "case_name":"Corephotonics, Ltd. v. Apple Inc.",
+  "docket_number":"22-1455",
+  "date_filed":"2022-08-22",
+  "appellate":true,
+  "docket_entries":[
+     {
+        "date_filed":"2022-08-22",
+        "description":"TEXT ONLY ORDER granting motion to extend time to file brief [18] filed by Appellee Apple Inc. The response brief is due 10/28/2022. Service as of this date by the Clerk of Court. This order has been issued without an attached document and is official and binding. [867470] [EKD]",
+        "document_url":null,
+        "document_number":null,
+        "pacer_doc_id":null,
+        "pacer_case_id":"18362",
+        "pacer_seq_no":null,
+        "pacer_magic_num":null
+     }
+  ],
+  "email_recipients":[
+   {
+      "name":"Recipient User Test 1, -:",
+      "email_addresses":[
+         "testing1@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 2, -:",
+      "email_addresses":[
+         "testing2@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 3, -:",
+      "email_addresses":[
+         "testing3@gexample.com",
+         "testing3_1@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 4, -:",
+      "email_addresses":[
+         "testing4@gexample.com",
+         "testing4_1@gexample.com",
+         "testing4_2@gexample.com"
+      ]
+   },
+   {
+      "name":"Recipient User Test 5, Deputy Clerk:",
+      "email_addresses":[
+         "Testing5@gexample.com"
+      ]
+   }
+]
+}

--- a/tests/examples/pacer/nda/cafc_1.txt
+++ b/tests/examples/pacer/nda/cafc_1.txt
@@ -1,0 +1,60 @@
+Return-Path: <FilingNotice@cafc.uscourts.gov>
+Received: from icmecf201.gtwy.uscourts.gov (icmecf201.gtwy.uscourts.gov [63.241.40.204])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id p586ct3e4n0nbn85hm1uqfu4ld5f9fm5jrmnsg01
+ for nrubin@recap.email;
+ Mon, 22 Aug 2022 13:14:01 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of cafc.uscourts.gov designates 63.241.40.204 as permitted sender) client-ip=63.241.40.204; envelope-from=FilingNotice@cafc.uscourts.gov; helo=icmecf201.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of cafc.uscourts.gov designates 63.241.40.204 as permitted sender) client-ip=63.241.40.204; envelope-from=FilingNotice@cafc.uscourts.gov; helo=icmecf201.gtwy.uscourts.gov;
+ dmarc=none header.from=cafc.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFIbTEwNUhzTjMydG9HN1JLZm5HdmJ3bmx3U2luNWhiY1E2TUNqZnBFcHQ2V1RUNG5qMVJZS0wvZGkrdWcxOTZ5czNzQk1QczJkK2RTR0hVc2ZkSzVKRzJjalVmWitsS2ltb0lZbE9DRm9vci8vdVh0T2JFNkRwU0x4MXdUWCsyZGZDOXJETDFXVHhMYm50MnBubllRb2RsVTJQaG00OCtUcWl1Y0d1clllRjVFd2NhNWtlMHV1Zk11RlhaU1hyUHhERVUrbHBmMjdjRkV5c0JvSHFPRDdheEhpeTIxSllEOGFHM0RYTjJwNmgyTTNZVE91cit2Z1AvZ0tmd2hhSDlJK3YwTzlMNE0vRUE1TDFmaTB0Wk1YL00rL0FCUWhSdzJWbXJ2dHlnYnhKZmU4WmNUNndQbDFwQUE0NDBuNXNyUXM9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=P5Qqk7CGGw1FO57L3S0DHFUHobvV0Azh3AAPKle+QJ8JNbrC/SjmbT13kwQiIBso1zgRPeGMgzAcu36uhd5AlElGsJjvIPP2tMfpsTJcT6sH6Tiqp2SnWNUaYJOGrOOehgl7hW5li19/UQTLPNDfzqroBQ2LLdVi/SHc2ID46lU=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1661174042; v=1; bh=02111tzKE/+Tg+62Z3m6rqSxsw2QnSYNC9HOVInN2l4=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.11
+Received: from cafcdb.cafc.gtwy.dcn ([156.119.190.11])
+  by icmecf201.gtwy.uscourts.gov with ESMTP; 22 Aug 2022 09:13:59 -0400
+Received: from cafcdb.cafc.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by cafcdb.cafc.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 27MDDiJF087335
+	for <nrubin@recap.email>; Mon, 22 Aug 2022 09:13:44 -0400
+Date: Mon, 22 Aug 2022 09:13:44 -0400 (EDT)
+From: FilingNotice@cafc.uscourts.gov
+To: nrubin@recap.email
+Message-ID: <1250237005.196.1661174024805@cafcdb.cafc.gtwy.dcn>
+Subject: 22-1455-MA Corephotonics, Ltd. v. Apple Inc. "Clerk Order Filed"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-1455-MA Corephotonics, Ltd. v. Apple Inc. "Clerk Order Filed"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#D4ED91" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Federal Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was entered on 08/22/2022 at 9:13:39 AM Eastern Daylight Time and filed on 08/22/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Corephotonics, Ltd. v. Apple Inc.<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.cafc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=18362">22-1455</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+**TEXT ONLY** ORDER granting motion to extend time to file brief [18] filed by Appellee Apple Inc. The response brief is due 10/28/2022. Service as of this date by the Clerk of Court.  This order has been issued without an attached document and is official and binding. [867470] [EKD]<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Recipient User Test 1, -: testing1@gexample.com<BR>
+Recipient User Test 2, -: testing2@gexample.com<BR>
+Recipient User Test 3, -: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4, -: testing4@gexample.com, testing4_1@gexample.com, testing4_2@gexample.com<BR>
+Recipient User Test 5, Deputy Clerk: Testing5@gexample.com<BR>
+<BR><BR>
+
+</BODY></HTML>

--- a/tests/examples/pacer/nda/cafc_1.txt
+++ b/tests/examples/pacer/nda/cafc_1.txt
@@ -32,7 +32,7 @@ Content-Transfer-Encoding: 7bit
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-1455-MA Corephotonics, Ltd. v. Apple Inc. "Clerk Order Filed"</TITLE>
 </HEAD>
-<BODY BGCOLOR="#D4ED91" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<BODY BGCOLOR="#D4ED91" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
 <P><STRONG>
 ***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
 <P><CENTER><STRONG>United States Court of Appeals for the Federal Circuit</STRONG></CENTER>

--- a/tests/examples/pacer/nda/cafc_2.json
+++ b/tests/examples/pacer/nda/cafc_2.json
@@ -1,6 +1,7 @@
 {
   "court_id":"cafc",
   "case_name":"Corephotonics, Ltd. v. Apple Inc.",
+  "contains_attachments": false,
   "docket_number":"22-1455",
   "date_filed":"2022-08-19",
   "appellate":true,

--- a/tests/examples/pacer/nda/cafc_2.json
+++ b/tests/examples/pacer/nda/cafc_2.json
@@ -1,21 +1,21 @@
 {
-  "case_name": "New York State Telecommunicati v. James",
-  "court_id": "ca2",
-  "date_filed": "2022-07-27",
-  "docket_entries": [
-    {
-      "date_filed": "2022-07-27",
-      "description": "LETTER, on behalf of Appellant Letitia A. James, <EDIT by Clerk's Office> RECEIVED. Service date 07/27/2022 by CM/ECF.[3355063] [21-1975]",
-      "document_number": null,
-      "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208942267?uid=37cacbbc313ab362",
-      "pacer_case_id": "55129",
-      "pacer_doc_id": "00208942267",
-      "pacer_magic_num": "37cacbbc313ab362",
-      "pacer_seq_no": null
-    }
+  "court_id":"cafc",
+  "case_name":"Corephotonics, Ltd. v. Apple Inc.",
+  "docket_number":"22-1455",
+  "date_filed":"2022-08-19",
+  "appellate":true,
+  "docket_entries":[
+     {
+        "date_filed":"2022-08-19",
+        "description":"MOTION of Appellee Apple Inc. to extend the time to 10/28/2022 to file brief. Service: 08/19/2022 by email. [867380] [22-1455] [Erin Leach]",
+        "document_url":"https://ecf.cafc.uscourts.gov/docs1/01301993624?uid=4c6ae1ed93856cd0",
+        "document_number": null,
+        "pacer_doc_id":"01301993624",
+        "pacer_case_id":"18362",
+        "pacer_seq_no":null,
+        "pacer_magic_num":"4c6ae1ed93856cd0"
+     }
   ],
-  "docket_number": "21-1975",
-  "appellate": true,
   "email_recipients": [
     {
        "name":"Recipient User Test 1, -:",

--- a/tests/examples/pacer/nda/cafc_2.txt
+++ b/tests/examples/pacer/nda/cafc_2.txt
@@ -1,0 +1,68 @@
+Return-Path: <FilingNotice@cafc.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id qbc2fahsm3tfk1m66gpn9sq8f2cie7vs9tjfbio1
+ for nrubin@recap.email;
+ Fri, 19 Aug 2022 17:31:10 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of cafc.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=FilingNotice@cafc.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of cafc.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=FilingNotice@cafc.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=cafc.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHMlZZQ00zOE4waW11aFV0Q0lOZC9YbGZzbzczQit0cUlTdjk4Q3NiQnp5VDFnb0xwU1YzMmpZdTB1cG5ha1FCOGFwQ2MwT01KUHR1ZVRFMnNpa1R6ZENVWGJiWFp4THdsK2ZDSkJyZjJYSWsyQkxYN3FVRXZqQy95QkI3R1F1bzR3Wmo5d0pOZ1JVcXBSUW8xNUJQRzZ2NGZZa2NVcVJEMzZ3MGFtRnBtZEhBTHRLTzVGM0ZuRGRyMlVNTDdhWm9Xd1pzOVk3QzNhcXNnT0M3M0xIblpxdUVBT2l0UjlJQVdjVXBrYXI4WXFMRFRMWGFPQjZEV2xJZTJzMXJRdDgxTEFHUW1iOXN3ekVUUjhqV21RYjNvYUx1U0taQUhmVHNTbFZocWFVWDRMR1dJM1dQcjEwc1cwc3VPYmFPdGZiSlU9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=enjP9Pf+r1piqMnujGIoJyNsik+rsjvN2uC9rLzbWUVIiuEAG0Caj8ruGuJeN+ou3y7JDTviCazkphPetR0xpSm8WuxZ8rGnY05yALLxQgQpf73VxRtMTneMJDndQdExnYFTf8viQbCoznP3kENwSsc1RNc3m0DWunt/rUulwHk=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1660930270; v=1; bh=TK8sgOlwczP1BWhAoXSdrIH71xz14MIXgco3+MGKDdc=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.11
+Received: from cafcdb.cafc.gtwy.dcn ([156.119.190.11])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 19 Aug 2022 13:31:09 -0400
+Received: from cafcdb.cafc.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by cafcdb.cafc.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 27JHV3nF084944
+	for <nrubin@recap.email>; Fri, 19 Aug 2022 13:31:03 -0400
+Date: Fri, 19 Aug 2022 13:31:03 -0400 (EDT)
+From: FilingNotice@cafc.uscourts.gov
+To: nrubin@recap.email
+Message-ID: <669567887.774.1660930263840@cafcdb.cafc.gtwy.dcn>
+Subject: 22-1455-ED Corephotonics, Ltd. v. Apple Inc. "Motion EXTEND TIME TO
+ FILE BRIEF"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-1455-ED Corephotonics, Ltd. v. Apple Inc. "Motion EXTEND TIME TO FILE BRIEF"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#D4ED91" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>United States Court of Appeals for the Federal Circuit</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was entered on 08/19/2022 at 1:31:02 PM Eastern Daylight Time and filed on 08/19/2022
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Corephotonics, Ltd. v. Apple Inc.<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.cafc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=18362">22-1455</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.cafc.uscourts.gov/docs1/01301993624?uid=4c6ae1ed93856cd0">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+MOTION of Appellee Apple Inc. to extend the time to 10/28/2022 to file brief. Service: 08/19/2022 by email. [867380] [22-1455] [Erin Leach]<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+Recipient User Test 1, -: testing1@gexample.com<BR>
+Recipient User Test 2, -: testing2@gexample.com<BR>
+Recipient User Test 3, -: testing3@gexample.com, testing3_1@gexample.com<BR>
+Recipient User Test 4, -: testing4@gexample.com, testing4_1@gexample.com, testing4_2@gexample.com<BR>
+Recipient User Test 5, Deputy Clerk: Testing5@gexample.com<BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Motion<BR>
+<STRONG>Original Filename: </STRONG>22-1455 Response Brief Extension Motion.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1222887174 [Date=08/19/2022] [FileNumber=867380-0] [15f2c7a23c6b7793e2292f3101b2e84c1abd86d89298dec56024591e1cb3b321874ff9c5d7c332cffc014ea3fbc489c21e18051b2e8a0cc50737347889a76a5f]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/cafc_2.txt
+++ b/tests/examples/pacer/nda/cafc_2.txt
@@ -33,7 +33,7 @@ Content-Transfer-Encoding: 7bit
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>22-1455-ED Corephotonics, Ltd. v. Apple Inc. "Motion EXTEND TIME TO FILE BRIEF"</TITLE>
 </HEAD>
-<BODY BGCOLOR="#D4ED91" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<BODY BGCOLOR="#D4ED91" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
 <P><STRONG>
 ***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
 <P><CENTER><STRONG>United States Court of Appeals for the Federal Circuit</STRONG></CENTER>

--- a/tests/examples/pacer/nef/ared_1.json
+++ b/tests/examples/pacer/nef/ared_1.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-00065",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/ared_1.json
+++ b/tests/examples/pacer/nef/ared_1.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-00065",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/ared_2.json
+++ b/tests/examples/pacer/nef/ared_2.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:21-cv-00428",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/ared_2.json
+++ b/tests/examples/pacer/nef/ared_2.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:21-cv-00428",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/ared_3.json
+++ b/tests/examples/pacer/nef/ared_3.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:21-cv-00075",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/ared_3.json
+++ b/tests/examples/pacer/nef/ared_3.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:21-cv-00075",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/arwd.json
+++ b/tests/examples/pacer/nef/arwd.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "2:21-cv-02016",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/arwd.json
+++ b/tests/examples/pacer/nef/arwd.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "2:21-cv-02016",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/cacd.json
+++ b/tests/examples/pacer/nef/cacd.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "5:20-cv-00768",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/cacd.json
+++ b/tests/examples/pacer/nef/cacd.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "5:20-cv-00768",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/cand.json
+++ b/tests/examples/pacer/nef/cand.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-05640",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/cand.json
+++ b/tests/examples/pacer/nef/cand.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-05640",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/ned.json
+++ b/tests/examples/pacer/nef/ned.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "8:20-cv-00510",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/ned.json
+++ b/tests/examples/pacer/nef/ned.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "8:20-cv-00510",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/almd_1.json
+++ b/tests/examples/pacer/nef/s3/almd_1.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "3:21-cv-00437",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/almd_1.json
+++ b/tests/examples/pacer/nef/s3/almd_1.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "3:21-cv-00437",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/almd_2.json
+++ b/tests/examples/pacer/nef/s3/almd_2.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "3:21-cv-00437",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/almd_2.json
+++ b/tests/examples/pacer/nef/s3/almd_2.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "3:21-cv-00437",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/almd_3_plain.json
+++ b/tests/examples/pacer/nef/s3/almd_3_plain.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "1:17-cr-00201",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/almd_3_plain.json
+++ b/tests/examples/pacer/nef/s3/almd_3_plain.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "1:17-cr-00201",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/almd_4_plain.json
+++ b/tests/examples/pacer/nef/s3/almd_4_plain.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "1:17-cr-00201",
+  "appellate": false,
   "email_recipients": [
     {
        "email_addresses":[

--- a/tests/examples/pacer/nef/s3/alsd_1.json
+++ b/tests/examples/pacer/nef/s3/alsd_1.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "1:21-cv-00057",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/alsd_1.json
+++ b/tests/examples/pacer/nef/s3/alsd_1.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "1:21-cv-00057",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/alsd_2.json
+++ b/tests/examples/pacer/nef/s3/alsd_2.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "1:21-cv-00057",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/alsd_2.json
+++ b/tests/examples/pacer/nef/s3/alsd_2.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "1:21-cv-00057",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/alsd_3.json
+++ b/tests/examples/pacer/nef/s3/alsd_3.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "1:20-cv-00572",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/alsd_3.json
+++ b/tests/examples/pacer/nef/s3/alsd_3.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "1:20-cv-00572",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_1.json
+++ b/tests/examples/pacer/nef/s3/ared_1.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "2:20-cv-00082",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_1.json
+++ b/tests/examples/pacer/nef/s3/ared_1.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "2:20-cv-00082",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_2.json
+++ b/tests/examples/pacer/nef/s3/ared_2.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-01091",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_2.json
+++ b/tests/examples/pacer/nef/s3/ared_2.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-01091",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_3.json
+++ b/tests/examples/pacer/nef/s3/ared_3.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:21-cv-00428",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_3.json
+++ b/tests/examples/pacer/nef/s3/ared_3.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:21-cv-00428",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_4.json
+++ b/tests/examples/pacer/nef/s3/ared_4.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-01296",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_4.json
+++ b/tests/examples/pacer/nef/s3/ared_4.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-01296",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_5.json
+++ b/tests/examples/pacer/nef/s3/ared_5.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-01091",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_5.json
+++ b/tests/examples/pacer/nef/s3/ared_5.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-01091",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_6.json
+++ b/tests/examples/pacer/nef/s3/ared_6.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-01296",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_6.json
+++ b/tests/examples/pacer/nef/s3/ared_6.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:20-cv-01296",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_7.json
+++ b/tests/examples/pacer/nef/s3/ared_7.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "5:18-cv-00222",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ared_7.json
+++ b/tests/examples/pacer/nef/s3/ared_7.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "5:18-cv-00222",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/arwd_1.json
+++ b/tests/examples/pacer/nef/s3/arwd_1.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "2:21-cv-02107",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/arwd_1.json
+++ b/tests/examples/pacer/nef/s3/arwd_1.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "2:21-cv-02107",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/arwd_2.json
+++ b/tests/examples/pacer/nef/s3/arwd_2.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "2:21-cv-02107",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/arwd_2.json
+++ b/tests/examples/pacer/nef/s3/arwd_2.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "2:21-cv-02107",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/arwd_3.json
+++ b/tests/examples/pacer/nef/s3/arwd_3.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "5:21-cv-05075",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/arwd_3.json
+++ b/tests/examples/pacer/nef/s3/arwd_3.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "5:21-cv-05075",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/arwd_4.json
+++ b/tests/examples/pacer/nef/s3/arwd_4.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "2:21-cv-02107",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/arwd_4.json
+++ b/tests/examples/pacer/nef/s3/arwd_4.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "2:21-cv-02107",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/arwd_5.json
+++ b/tests/examples/pacer/nef/s3/arwd_5.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "1:21-cv-01008",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/arwd_5.json
+++ b/tests/examples/pacer/nef/s3/arwd_5.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "1:21-cv-01008",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ded_1.json
+++ b/tests/examples/pacer/nef/s3/ded_1.json
@@ -3,6 +3,7 @@
   "case_name":"CBV, Inc. v. ChanBond, LLC",
   "contains_attachments": true,
   "docket_number":"1:21-cv-01456",
+  "appellate": false,
   "date_filed":"2022-08-03",
   "docket_entries":[
      {

--- a/tests/examples/pacer/nef/s3/ded_2.json
+++ b/tests/examples/pacer/nef/s3/ded_2.json
@@ -3,6 +3,7 @@
    "case_name":"CBV, Inc. v. ChanBond, LLC",
    "contains_attachments":true,
    "docket_number":"1:21-cv-01456",
+   "appellate": false,
    "date_filed":"2022-08-05",
    "docket_entries":[
       {

--- a/tests/examples/pacer/nef/s3/gand_1.json
+++ b/tests/examples/pacer/nef/s3/gand_1.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "1:20-cv-02973",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/gand_1.json
+++ b/tests/examples/pacer/nef/s3/gand_1.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "1:20-cv-02973",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ilnd_1.json
+++ b/tests/examples/pacer/nef/s3/ilnd_1.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "1:21-cv-02975",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/ilnd_1.json
+++ b/tests/examples/pacer/nef/s3/ilnd_1.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "1:21-cv-02975",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/laed_1.json
+++ b/tests/examples/pacer/nef/s3/laed_1.json
@@ -3,6 +3,7 @@
   "case_name":"Lou v. Lopinto",
   "contains_attachments": true,
   "docket_number":"2:21-cv-00080",
+  "appellate": false,
   "date_filed":"2022-08-10",
   "docket_entries":[
      {

--- a/tests/examples/pacer/nef/s3/laed_2.json
+++ b/tests/examples/pacer/nef/s3/laed_2.json
@@ -3,6 +3,7 @@
    "case_name":"Grant v. Gusman",
    "contains_attachments":true,
    "docket_number":"2:17-cv-02797",
+   "appellate": false,
    "date_filed":"2022-08-11",
    "docket_entries":[
       {

--- a/tests/examples/pacer/nef/s3/nyed_1.json
+++ b/tests/examples/pacer/nef/s3/nyed_1.json
@@ -3,6 +3,7 @@
    "case_name":"Cunningham v. The City of New York",
    "contains_attachments":true,
    "docket_number":"1:22-cv-00588",
+   "appellate": false,
    "date_filed":"2022-08-01",
    "docket_entries":[
       {

--- a/tests/examples/pacer/nef/s3/nyed_2.json
+++ b/tests/examples/pacer/nef/s3/nyed_2.json
@@ -3,6 +3,7 @@
    "case_name":"Acosta v. City of New York",
    "contains_attachments":true,
    "docket_number":"1:22-cv-00576",
+   "appellate": false,
    "date_filed":"2022-08-05",
    "docket_entries":[
       {

--- a/tests/examples/pacer/nef/s3/nysd_1.json
+++ b/tests/examples/pacer/nef/s3/nysd_1.json
@@ -3,6 +3,7 @@
    "case_name":"IN RE: NEW YORK CITY POLICING DURING SUMMER 2020 DEMONSTRATIONS",
    "contains_attachments":true,
    "docket_number":"1:20-cv-08924",
+   "appellate": false,
    "date_filed":"2022-08-04",
    "docket_entries":[
       {

--- a/tests/examples/pacer/nef/s3/nysd_2.json
+++ b/tests/examples/pacer/nef/s3/nysd_2.json
@@ -3,6 +3,7 @@
    "case_name":"IN RE: NEW YORK CITY POLICING DURING SUMMER 2020 DEMONSTRATIONS",
    "contains_attachments":true,
    "docket_number":"1:20-cv-08924",
+   "appellate": false,
    "date_filed":"2022-08-08",
    "docket_entries":[
       {

--- a/tests/examples/pacer/nef/s3/ohnd_1.json
+++ b/tests/examples/pacer/nef/s3/ohnd_1.json
@@ -3,6 +3,7 @@
    "case_name":"In Re: Sonic Corp. Customer Data Security Breach",
    "contains_attachments":true,
    "docket_number":"1:17-md-02807",
+   "appellate": false,
    "date_filed":"2022-08-08",
    "docket_entries":[
       {

--- a/tests/examples/pacer/nef/s3/ohsd_2.json
+++ b/tests/examples/pacer/nef/s3/ohsd_2.json
@@ -3,6 +3,7 @@
    "case_name":"Roe v. University Of Cincinnati",
    "contains_attachments":true,
    "docket_number":"1:22-cv-00376",
+   "appellate": false,
    "date_filed":"2022-08-08",
    "docket_entries":[
       {

--- a/tests/examples/pacer/nef/s3/oknd_1.json
+++ b/tests/examples/pacer/nef/s3/oknd_1.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:18-cv-00499",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/oknd_1.json
+++ b/tests/examples/pacer/nef/s3/oknd_1.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:18-cv-00499",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txnd_1.json
+++ b/tests/examples/pacer/nef/s3/txnd_1.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "4:21-cv-00953",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txnd_1.json
+++ b/tests/examples/pacer/nef/s3/txnd_1.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "4:21-cv-00953",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txsd_1.json
+++ b/tests/examples/pacer/nef/s3/txsd_1.json
@@ -3,6 +3,7 @@
    "case_name":"United States of America, ex rel v. Merida Health Care Group",
    "contains_attachments":true,
    "docket_number":"2:15-cv-00208",
+   "appellate": false,
    "date_filed":"2022-08-10",
    "docket_entries":[
       {

--- a/tests/examples/pacer/nef/s3/txwd_1.json
+++ b/tests/examples/pacer/nef/s3/txwd_1.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "5:17-cv-01246",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_1.json
+++ b/tests/examples/pacer/nef/s3/txwd_1.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "5:17-cv-01246",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_2.json
+++ b/tests/examples/pacer/nef/s3/txwd_2.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "5:20-cv-01403",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_2.json
+++ b/tests/examples/pacer/nef/s3/txwd_2.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "5:20-cv-01403",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_3.json
+++ b/tests/examples/pacer/nef/s3/txwd_3.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "5:21-cv-00634",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_3.json
+++ b/tests/examples/pacer/nef/s3/txwd_3.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "5:21-cv-00634",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_4.json
+++ b/tests/examples/pacer/nef/s3/txwd_4.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "5:21-cv-00306",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_4.json
+++ b/tests/examples/pacer/nef/s3/txwd_4.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "5:21-cv-00306",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_5.json
+++ b/tests/examples/pacer/nef/s3/txwd_5.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "7:20-cv-00083",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_5.json
+++ b/tests/examples/pacer/nef/s3/txwd_5.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "7:20-cv-00083",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_6.json
+++ b/tests/examples/pacer/nef/s3/txwd_6.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "1:20-cv-01202",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/s3/txwd_6.json
+++ b/tests/examples/pacer/nef/s3/txwd_6.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "1:20-cv-01202",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/txed.json
+++ b/tests/examples/pacer/nef/txed.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "9:21-cv-00029",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/txed.json
+++ b/tests/examples/pacer/nef/txed.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "9:21-cv-00029",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/txnd.json
+++ b/tests/examples/pacer/nef/txnd.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "3:21-cv-00071",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/txnd.json
+++ b/tests/examples/pacer/nef/txnd.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "3:21-cv-00071",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/txwd.json
+++ b/tests/examples/pacer/nef/txwd.json
@@ -16,7 +16,7 @@
     }
   ],
   "docket_number": "7:19-cv-00150",
-  "email_notice_type": "NEF",
+  "appellate": false,
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/examples/pacer/nef/txwd.json
+++ b/tests/examples/pacer/nef/txwd.json
@@ -16,6 +16,7 @@
     }
   ],
   "docket_number": "7:19-cv-00150",
+  "email_notice_type": "NEF",
   "email_recipients": [
     {
       "email_addresses": [

--- a/tests/local/test_PacerNotificationEmailTest.py
+++ b/tests/local/test_PacerNotificationEmailTest.py
@@ -8,6 +8,9 @@ TESTS_ROOT_EXAMPLES_PACER_NEF = os.path.join(TESTS_ROOT_EXAMPLES_PACER, "nef")
 TESTS_ROOT_EXAMPLES_PACER_NEF_S3 = os.path.join(
     TESTS_ROOT_EXAMPLES_PACER, "nef/s3"
 )
+TESTS_ROOT_EXAMPLES_PACER_NDA_S3 = os.path.join(
+    TESTS_ROOT_EXAMPLES_PACER, "nda"
+)
 
 
 class PacerNotificationEmailTest(PacerParseTestCase):
@@ -27,4 +30,14 @@ class S3PacerNotificationEmailTest(PacerParseTestCase):
     def test_notification_emails_s3(self):
         self.parse_files(
             TESTS_ROOT_EXAMPLES_PACER_NEF_S3, "*.txt", S3NotificationEmail
+        )
+
+
+class S3PacerNdaNotificationEmailTest(PacerParseTestCase):
+    def setUp(self):
+        self.maxDiff = 200000
+
+    def test_notification_emails_s3(self):
+        self.parse_files(
+            TESTS_ROOT_EXAMPLES_PACER_NDA_S3, "*.txt", S3NotificationEmail
         )

--- a/tests/network/test_PacerFreeOpinionsTest.py
+++ b/tests/network/test_PacerFreeOpinionsTest.py
@@ -194,6 +194,7 @@ class PacerFreeOpinionsTest(unittest.TestCase):
         )
 
 
+@mock.patch("juriscraper.pacer.reports.logger")
 class PacerMagicLinkTest(unittest.TestCase):
     """Test related to PACER magic link free download"""
 
@@ -206,9 +207,12 @@ class PacerMagicLinkTest(unittest.TestCase):
 
         self.reports = {}
         court_id = "nysd"
+        court_id_nda = "ca3"
         self.reports[court_id] = FreeOpinionReport(court_id, pacer_session)
+        self.reports[court_id_nda] = FreeOpinionReport(
+            court_id_nda, pacer_session
+        )
 
-    @mock.patch("juriscraper.pacer.reports.logger")
     def test_download_simple_pdf_magic_link_fails(self, mock_logger):
         """Can we download a PACER document with an invalid or expired
         magic link? land on a login page and returns an error.
@@ -220,6 +224,27 @@ class PacerMagicLinkTest(unittest.TestCase):
         pacer_magic_num = "46253052"
         r, msg = report.download_pdf(
             pacer_case_id, pacer_doc_id, pacer_magic_num
+        )
+        mock_logger.warning.assert_called_with(
+            "Document not available via magic link in case: "
+            f"caseid: {pacer_case_id}, magic_num: {pacer_magic_num}, "
+            f"URL: {url}"
+        )
+        # No PDF should be returned
+        self.assertEqual(r, None)
+
+    def test_download_nda_pdf_magic_link(self, mock_logger):
+        """Can we download a NDA PACER document with an invalid or expired
+        magic link? land on a login page and returns an error.
+        """
+        report = self.reports["ca3"]
+        url = "https://ecf.ca3.uscourts.gov/docs1/003014193380"
+        pacer_case_id = "21-1832"
+        pacer_doc_id = "003014193380"
+        pacer_magic_num = "3594681a19879633"
+        email_notice_type = "NDA"
+        r, msg = report.download_pdf(
+            pacer_case_id, pacer_doc_id, pacer_magic_num, email_notice_type
         )
         mock_logger.warning.assert_called_with(
             "Document not available via magic link in case: "

--- a/tests/network/test_PacerFreeOpinionsTest.py
+++ b/tests/network/test_PacerFreeOpinionsTest.py
@@ -242,9 +242,9 @@ class PacerMagicLinkTest(unittest.TestCase):
         pacer_case_id = "21-1832"
         pacer_doc_id = "003014193380"
         pacer_magic_num = "3594681a19879633"
-        email_notice_type = "NDA"
+        appellate = True
         r, msg = report.download_pdf(
-            pacer_case_id, pacer_doc_id, pacer_magic_num, email_notice_type
+            pacer_case_id, pacer_doc_id, pacer_magic_num, appellate
         )
         mock_logger.warning.assert_called_with(
             "Document not available via magic link in case: "


### PR DESCRIPTION
Support to parse and download free documents for NDAs was added.

It was necessary to add a new field to support download documents for NDAs `email_notice_type` due to download link structures are different.

Here is some example data for an NDA:
```
{
  "case_name": "New York State Telecommunicati v. James",
  "court_id": "ca2",
  "date_filed": "2022-03-23",
  "docket_entries": [
    {
      "date_filed": "2022-03-23",
      "description": "REPLY BRIEF, on behalf of Appellant Letitia A. James, FILED. Service date 03/23/2022 by CM/ECF. [3283515] [21-1975]",
      "document_number": "00208754210",
      "document_url": "https://ecf.ca2.uscourts.gov/docs1/00208754210?uid=59a7f7615f78153b",
      "pacer_case_id": "21-1975",
      "pacer_doc_id": "00208754210",
      "pacer_magic_num": "59a7f7615f78153b",
      "pacer_seq_no": null
    }
  ],
  "docket_number": "21-1975",
  "email_notice_type": "NDA",
  "email_recipients": [
    {
      "email_addresses": [
        "recipient@recap.email"
      ],
      "name": "Recap email recipient, -:"
    }
  ]
}
``` 
Added tests using examples from the emails we've received from different courts but they aren't too many, so as long as we receive more NDA's it might be necessary to adjust the parser to consider all possible cases. 

Let me know what do you think and if it's ok I can do a version bump and update the CL PR.
