### PR TITLE
Check that input date string is not empty in docket_report.py

### DIFF
--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -962,7 +962,7 @@ class DocketReport(BaseDocketReport, BaseReport):
                 del cells[1]
 
             date_filed_str = force_unicode(cells[0].text_content())
-            if not date_filed_str:
+            if not date_filed_str.strip():
                 # Some older dockets have missing dates. Press on.
                 continue
             de["date_filed"] = convert_date_string(date_filed_str)


### PR DESCRIPTION
With input data court_id='cacd' and pacer_case_id='806502' received unhandled exception `ParserError("String does not contain a date: %s", timestr)` here: `juriscraper/lib/string_utils.py, line 510` in convert_date_string method.

This exception occurs when date_filed_str (docket_report.py, line 964) contains only white spaces. There is no check for such cases inside the convert_date_string method. 


P.S.
License agreement is on the way. It takes some time for me to print/sign/scan it.

