### PR TITLE
Version bump v2.5.13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,18 @@ Releases are also tagged in git, if that's helpful.
 
 ## Current
 
+**2.5.13 - 2022-08-24**
+
+Features:
+
+ - N/A
+
+Changes:
+
+ - Added support to get attached documents from NEFs.
+
+## Past
+
 **2.5.12 - 2022-08-12**
 
 Features:
@@ -25,9 +37,6 @@ Features:
 Changes:
 
  - Added support to parse NDAs and download their free documents.
- - Added support to get attached documents from NEFs.
-
-## Past
 
 **2.5.11 - 2022-07-29**
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import unittest
 from setuptools import find_packages, setup
 from setuptools.command.install import install
 
-VERSION = "2.5.12"
+VERSION = "2.5.13"
 AUTHOR = "Free Law Project"
 EMAIL = "info@free.law"
 HERE = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Seems that the last version 2.5.12 didn't get the updates for NEFs attachments. 

Maybe because the release changes are until the date I added the commit tag?