### PR TITLE
More exceptions to avoid asking for login again into PACER

### DIFF
--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -61,11 +61,23 @@ def check_if_logged_in_page(text):
     # A download confirmation page doesn't contain a logout link but we're
     # logged into.
     is_a_download_confirmation_page = "Download Confirmation" in text
+    # When looking for a download confirmation page sometimes an appellate
+    # attachment page is returned instead, see:
+    # https://ecf.ca8.uscourts.gov/n/beam/servlet/TransportRoom?servlet=ShowDoc&pacer=i&dls_id=00802251695
+    appellate_attachment_page = "Documents are attached to this filing" in text
+    # Sometimes the document is completely unavailable and an error message is
+    # shown, see:
+    # https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=ShowDoc/009033568259
+    appellate_document_error = (
+        "The requested document cannot be displayed" in text
+    )
     if any(
         [
             found_district_logout_link,
             found_appellate_logout_link,
             is_a_download_confirmation_page,
+            appellate_attachment_page,
+            appellate_document_error,
         ]
     ):
         # A normal HTML page we're logged into.

--- a/tests/network/test_PacerFreeOpinionsTest.py
+++ b/tests/network/test_PacerFreeOpinionsTest.py
@@ -263,6 +263,7 @@ class PacerDownloadConfirmationPageTest(unittest.TestCase):
         self.session.login()
         self.report = DownloadConfirmationPage("ca8", self.session)
         self.pacer_doc_id = "00812590792"
+        self.no_confirmation_page_pacer_doc_id = "00802251695"
 
     @SKIP_IF_NO_PACER_LOGIN
     def test_get_document_number(self):
@@ -275,3 +276,11 @@ class PacerDownloadConfirmationPageTest(unittest.TestCase):
         self.assertEqual(data_report["cost"], "0.30")
         self.assertEqual(data_report["billable_pages"], "3")
         self.assertEqual(data_report["document_description"], "PDF Document")
+
+    @SKIP_IF_NO_PACER_LOGIN
+    def test_no_confirmation_page(self):
+        """If the download confirmation page is not available an empty
+        dictionary is returned"""
+        self.report.query(self.no_confirmation_page_pacer_doc_id)
+        data_report = self.report.data
+        self.assertEqual(data_report, {})


### PR DESCRIPTION
Working on the `DownloadConfirmationPage` Courtlistener integration I found a couple more cases when a `PacerLoginException` error is raised due to the download confirmation page is not available.

The exceptions added are:

When looking for a download confirmation page sometimes an appellate attachment page is returned instead, see:
https://ecf.ca8.uscourts.gov/n/beam/servlet/TransportRoom?servlet=ShowDoc&pacer=i&dls_id=00802251695

Sometimes the document is completely unavailable and an error message is shown, see:
https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=ShowDoc/009033568259

So in these cases, no `PacerLoginException` will be raised and we will just return an empty dict for the `DownloadConfirmationPage` report (Cases where we won't be able to get the document number either from the PDF or DownloadConfirmationPage).



