### PR TITLE
Skip attachment page for appellate documents

### DIFF
--- a/juriscraper/pacer/download_confirmation_page.py
+++ b/juriscraper/pacer/download_confirmation_page.py
@@ -30,7 +30,7 @@ class DownloadConfirmationPage(BaseReport):
         ), "session attribute of DownloadConfirmationPage cannot be None."
 
         # Make the NDA document URL
-        url = make_docs1_url(self.court_id, pacer_doc_id)
+        url = make_docs1_url(self.court_id, pacer_doc_id, True)
 
         logger.info("Querying the confirmation page endpoint at URL: %s", url)
         self.response = self.session.get(url)

--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -194,7 +194,7 @@ class BaseReport:
             # Magic link parameters
             # We don't need the de_seq_num parameter to fetch the free document
             if appellate:
-                url = make_docs1_url(self.court_id, pacer_doc_id)
+                url = make_docs1_url(self.court_id, pacer_doc_id, True)
                 # For appellate documents the magic_number is the uid param
                 params = {
                     "uid": pacer_magic_num,

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -186,12 +186,17 @@ def make_doc1_url(court_id, pacer_doc_id, skip_attachment_page):
     return f"https://ecf.{court_id}.uscourts.gov/doc1/{pacer_doc_id}"
 
 
-def make_docs1_url(court_id: str, pacer_doc_id: str) -> str:
+def make_docs1_url(
+    court_id: str, pacer_doc_id: str, skip_attachment_page
+) -> str:
     """Make a docs1 URL for NDAs free look downloads.
 
     :param court_id: The court ID.
     :param pacer_doc_id: The PACER document ID.
     """
+    if skip_attachment_page and pacer_doc_id[3] == "0":
+        # If the fourth digit is a 0, replace it with a 1
+        pacer_doc_id = f"{pacer_doc_id[:3]}1{pacer_doc_id[4:]}"
     return f"https://ecf.{court_id}.uscourts.gov/docs1/{pacer_doc_id}"
 
 

--- a/tests/network/test_PacerFreeOpinionsTest.py
+++ b/tests/network/test_PacerFreeOpinionsTest.py
@@ -262,8 +262,10 @@ class PacerDownloadConfirmationPageTest(unittest.TestCase):
         self.session = get_pacer_session()
         self.session.login()
         self.report = DownloadConfirmationPage("ca8", self.session)
+        self.report_att = DownloadConfirmationPage("ca5", self.session)
         self.pacer_doc_id = "00812590792"
         self.no_confirmation_page_pacer_doc_id = "00802251695"
+        self.pacer_doc_id_att = "00506470276"
 
     @SKIP_IF_NO_PACER_LOGIN
     def test_get_document_number(self):
@@ -275,6 +277,18 @@ class PacerDownloadConfirmationPageTest(unittest.TestCase):
         self.assertEqual(data_report["docket_number"], "14-3066")
         self.assertEqual(data_report["cost"], "0.30")
         self.assertEqual(data_report["billable_pages"], "3")
+        self.assertEqual(data_report["document_description"], "PDF Document")
+
+    @SKIP_IF_NO_PACER_LOGIN
+    def test_get_document_number_skipping_attachment_page(self):
+        """Can we get the PACER document number from a download confirmation
+        page skipping the attachment page?"""
+        self.report_att.query(self.pacer_doc_id_att)
+        data_report = self.report_att.data
+        self.assertEqual(data_report["document_number"], "00516470276")
+        self.assertEqual(data_report["docket_number"], "22-30311")
+        self.assertEqual(data_report["cost"], "1.50")
+        self.assertEqual(data_report["billable_pages"], "15")
         self.assertEqual(data_report["document_description"], "PDF Document")
 
     @SKIP_IF_NO_PACER_LOGIN


### PR DESCRIPTION
Seems that we need to skip the attachment page for appellate documents with attachments so that with this fix we can:

- Skip the appellate attachment page when querying the download confirmation page
- Skip the appellate attachment page when downloading the free document

In a next stage, we should also parse the attachment page for appellate courts since they have a different format than non-appellate.