### PR TITLE
564 chardet performance binary content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,18 @@ Releases are also tagged in git, if that's helpful.
 
 ## Current
 
+**2.5.19 - 2022-09-29**
+
+Features:
+
+ - N/A
+
+Changes:
+
+ - Fix performance when downloading large PDFs (see #564)
+
+## Past
+
 **2.5.18 - 2022-09-29**
 
 Features:
@@ -27,8 +39,6 @@ Changes:
  - Skip appellate attachment page when querying the download confirmation page
  - Skip appellate attachment page when downloading the free document
  - Fix getting filed date on email notifications
-
-## Past
 
 **2.5.17 - 2022-09-28**
 

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -14,26 +14,25 @@ logger = make_default_logger()
 requests.packages.urllib3.disable_warnings(exceptions.InsecureRequestWarning)
 
 
-def check_if_logged_in_page(text):
+def check_if_logged_in_page(content: bytes) -> bool:
     """Is this a valid HTML page from PACER?
 
-    Check if the html in 'text' is from a valid PACER page or valid PACER XML
-    document, or if it's from a page telling you to log in or informing you
+    Check if the data in 'content' is from a valid PACER page or valid PACER
+    XML document, or if it's from a page telling you to log in or informing you
     that you're not logged in.
-    :param text: The HTML or XML of the page to test
+    :param content: The data to test, of type bytes. This uses bytes to avoid
+    converting data to text using an unknown encoding. (see #564)
     :return boolean: True if logged in, False if not.
     """
-    if isinstance(text, bytes):
-        text = text.decode("utf-8")
 
     valid_case_number_query = (
-        "<case number=" in text
-        or "<request number=" in text
-        or 'id="caseid"' in text
-        or "Cost: " in text
+        b"<case number=" in content
+        or b"<request number=" in content
+        or b'id="caseid"' in content
+        or b"Cost: " in content
     )
-    no_results_case_number_query = re.search("<message.*Cannot find", text)
-    sealed_case_query = re.search("<message.*Case Under Seal", text)
+    no_results_case_number_query = re.search(b"<message.*Cannot find", content)
+    sealed_case_query = re.search(b"<message.*Case Under Seal", content)
     if any(
         [
             valid_case_number_query,
@@ -41,7 +40,7 @@ def check_if_logged_in_page(text):
             sealed_case_query,
         ]
     ):
-        not_logged_in = re.search("text.*Not logged in", text)
+        not_logged_in = re.search(b"text.*Not logged in", content)
         if not_logged_in:
             # An unauthenticated PossibleCaseNumberApi XML result. Simply
             # continue onwards. The complete result looks like:
@@ -55,21 +54,23 @@ def check_if_logged_in_page(text):
 
     # Detect if we are logged in. If so, no need to do so. If not, we login
     # again below.
-    found_district_logout_link = "/cgi-bin/login.pl?logout" in text
-    found_appellate_logout_link = "InvalidUserLogin.jsp" in text
+    found_district_logout_link = b"/cgi-bin/login.pl?logout" in content
+    found_appellate_logout_link = b"InvalidUserLogin.jsp" in content
 
     # A download confirmation page doesn't contain a logout link but we're
     # logged into.
-    is_a_download_confirmation_page = "Download Confirmation" in text
+    is_a_download_confirmation_page = b"Download Confirmation" in content
     # When looking for a download confirmation page sometimes an appellate
     # attachment page is returned instead, see:
     # https://ecf.ca8.uscourts.gov/n/beam/servlet/TransportRoom?servlet=ShowDoc&pacer=i&dls_id=00802251695
-    appellate_attachment_page = "Documents are attached to this filing" in text
+    appellate_attachment_page = (
+        b"Documents are attached to this filing" in content
+    )
     # Sometimes the document is completely unavailable and an error message is
     # shown, see:
     # https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=ShowDoc/009033568259
     appellate_document_error = (
-        "The requested document cannot be displayed" in text
+        b"The requested document cannot be displayed" in content
     )
     if any(
         [
@@ -134,7 +135,7 @@ class PacerSession(requests.Session):
 
         r = super().get(url, **kwargs)
 
-        if "This user has no access privileges defined." in r.text:
+        if b"This user has no access privileges defined." in r.content:
             # This is a strange error that we began seeing in CM/ECF 6.3.1 at
             # ILND. You can currently reproduce it by logging in on the central
             # login page, selecting "Court Links" as your destination, and then
@@ -370,7 +371,7 @@ class PacerSession(requests.Session):
         if is_text(r):
             return False
 
-        logged_in = check_if_logged_in_page(r.text)
+        logged_in = check_if_logged_in_page(r.content)
         if logged_in:
             return False
 

--- a/tests/local/test_PacerNeedLoginTest.py
+++ b/tests/local/test_PacerNeedLoginTest.py
@@ -31,9 +31,9 @@ class PacerNeedLoginTest(unittest.TestCase):
             json_path = os.path.join(dirname, f"{filename_sans_ext}.json")
 
             with open(path, "rb") as f:
-                text = f.read()
+                content = f.read()
 
-            result = check_if_logged_in_page(text)
+            result = check_if_logged_in_page(content)
 
             if not os.path.exists(json_path):
                 with open(json_path, "w") as f:

--- a/tests/network/test_PacerFreeOpinionsTest.py
+++ b/tests/network/test_PacerFreeOpinionsTest.py
@@ -238,7 +238,7 @@ class PacerMagicLinkTest(unittest.TestCase):
         magic link? land on a login page and returns an error.
         """
         report = self.reports["ca3"]
-        url = "https://ecf.ca3.uscourts.gov/docs1/003014193380"
+        url = "https://ecf.ca3.uscourts.gov/docs1/003114193380"
         pacer_case_id = "21-1832"
         pacer_doc_id = "003014193380"
         pacer_magic_num = "3594681a19879633"


### PR DESCRIPTION
It turns out that r.text makes calls to chardet each time it is called. That's
not great because chardet can be slow and use a lot of memory, particularly
when checking PDFs.

Instead of doing that or checking if things are PDFs all the time, simply use
the binary content instead of the text.

Fixes: https://github.com/freelawproject/juriscraper/issues/564
Relates to: https://github.com/psf/requests/issues/6250