### PR TITLE
520 Fixes redirected pdfs download

### DIFF
--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -304,7 +304,8 @@ class BaseReport:
             redirect_re = re.compile(rb'window\.\s*?location\s*=\s*"(.*)"\s*;')
             m = redirect_re.search(r.content)
             if m is not None:
-                r = self.session.get(urljoin(url, str(m.group(1))))
+                redirect_url = m.group(1).decode("utf-8")
+                r = self.session.get(urljoin(url, redirect_url))
                 r.raise_for_status()
 
         # The request above sometimes generates an HTML page with an iframe

--- a/tests/network/test_PacerFreeOpinionsTest.py
+++ b/tests/network/test_PacerFreeOpinionsTest.py
@@ -119,6 +119,13 @@ class PacerFreeOpinionsTest(unittest.TestCase):
         self.assertEqual(r.headers["Content-Type"], "application/pdf")
 
     @SKIP_IF_NO_PACER_LOGIN
+    def test_download_redirected_pdf(self):
+        """Can we download a PDF document returned after a redirection?"""
+        report = self.reports["azd"]
+        r, msg = report.download_pdf("1311031", "025125636132")
+        self.assertEqual(r.headers["Content-Type"], "application/pdf")
+
+    @SKIP_IF_NO_PACER_LOGIN
     def test_download_iframed_pdf(self):
         """Can we download a PDF document returned in IFrame?"""
         report = self.reports["vib"]


### PR DESCRIPTION
Seems that PDFs downloads returned within a `window.location` were failing.

The problem was that the URL was being malformed:
https://ecf.azd.uscourts.gov b'/cgi-bin/show_temp.pl?file=23976857-0--126044.pdf&type=application/pdf'

Since the regex works within bytes so we needed to decode the URL instead of just casting to `str`