### PR TITLE
Avoid parsing a download confirmation page when the PDF is returned directly

### DIFF
--- a/juriscraper/pacer/download_confirmation_page.py
+++ b/juriscraper/pacer/download_confirmation_page.py
@@ -4,7 +4,7 @@ from typing import Optional
 from ..lib.log_tools import make_default_logger
 from ..lib.string_utils import clean_string, convert_date_string, force_unicode
 from .reports import BaseReport
-from .utils import make_docs1_url
+from .utils import is_pdf, make_docs1_url
 
 logger = make_default_logger()
 
@@ -34,6 +34,11 @@ class DownloadConfirmationPage(BaseReport):
 
         logger.info("Querying the confirmation page endpoint at URL: %s", url)
         self.response = self.session.get(url)
+        if is_pdf(self.response):
+            # Sometimes the PDF document is returned without showing the
+            # download confirmation page, not a valid page to parse.
+            self.is_valid = False
+            return
         self.parse()
 
     @property

--- a/tests/network/test_PacerFreeOpinionsTest.py
+++ b/tests/network/test_PacerFreeOpinionsTest.py
@@ -270,9 +270,11 @@ class PacerDownloadConfirmationPageTest(unittest.TestCase):
         self.session.login()
         self.report = DownloadConfirmationPage("ca8", self.session)
         self.report_att = DownloadConfirmationPage("ca5", self.session)
+        self.report_pdf = DownloadConfirmationPage("ca11", self.session)
         self.pacer_doc_id = "00812590792"
         self.no_confirmation_page_pacer_doc_id = "00802251695"
         self.pacer_doc_id_att = "00506470276"
+        self.pacer_doc_id_pdf = "011012534985"
 
     @SKIP_IF_NO_PACER_LOGIN
     def test_get_document_number(self):
@@ -304,4 +306,12 @@ class PacerDownloadConfirmationPageTest(unittest.TestCase):
         dictionary is returned"""
         self.report.query(self.no_confirmation_page_pacer_doc_id)
         data_report = self.report.data
+        self.assertEqual(data_report, {})
+
+    @SKIP_IF_NO_PACER_LOGIN
+    def test_no_confirmation_page_pdf_returned(self):
+        """If the download confirmation page is not available when the PDF is
+        returned directly, no valid page to parse."""
+        self.report_pdf.query(self.pacer_doc_id_pdf)
+        data_report = self.report_pdf.data
         self.assertEqual(data_report, {})


### PR DESCRIPTION
This PR is related to the weird error we received in https://github.com/freelawproject/juriscraper/issues/582

This was an NDA, when adding a docket entry for an NDA we get the document number either from the download confirmation page or from the PDF, the main problem here is that the document is returned directly and no Download confirmation is displayed (seems to be a free document). So when trying to parse the download confirmation page over the PDF binary the error `ValueError: Invalid tag name 'mU0007EU0FFFD...` is raised.

To solve this problem I added a condition to check that the data returned when querying the Download confirmation page is not a PDF, so if the document is free and no confirmation page is shown, we consider it a no valid page so no data is returned from Juriscraper.

In cases like this when is not possible to get the document number from the PDF or the confirmation page, the docket entry is added without a number.

In addition while checking this error in detail I found some inconsistencies so I did a deep investigation, here are some findings:

- When this docket entry was added seems that the PDF didn't have a document number, so we fell back on the download confirmation page to get the document number (and the error described above was raised).

- If you check the document today: https://ecf.ca11.uscourts.gov/docs1/011112534985 the document has a number (84-1).

   So two strange things happened here: 
  1.- Numbers in PDFs for this case were added recently, you can confirm this by looking to the most recent document we could download for this case (12/02/22): 
  https://www.courtlistener.com/docket/64886106/011012573155/marjorie-taylor-greene-v-secretary-of-state-for-the-state-of-georgia/
  The PDF doesn't have a document number. 
  But if you [buy](https://ecf.ca11.uscourts.gov/docs1/011112573155) it the same document in PACER now has a number `86-1`: 
  ![Screen Shot 2022-12-19 at 18 31 15](https://user-images.githubusercontent.com/486004/208553983-db481425-efaa-4758-9ff0-441ed0956ac3.png)

  2.- The court changed the way of numbering entries in this case (maybe also in other cases), going from using `pacer_doc_id` as a document number to using numbers.

  These changes seem that happened recently. 

  I checked the docket in PACER and I could confirm that now the case uses numbers, actually, I triggered a docket upload via RECAP extension, and the docket entries that use numbers were added.
  ![Screen Shot 2022-12-19 at 18 53 22](https://user-images.githubusercontent.com/486004/208556172-9db1fd72-4aed-44bf-810b-4f0fb9edcdf1.png)

  https://www.courtlistener.com/docket/64886106/marjorie-taylor-greene-v-secretary-of-state-for-the-state-of-georgia/

  You can see now there are duplicated docket entries since before many docket entries were unnumbered and the ones that have `pacer_doc_id` as a number were added via recap.email (getting the number through the confirmation page when it was available)

  I could confirm this docket didn't have document numbers before looking for a docket upload in pacer HTML files.
  ![Screen Shot 2022-12-19 at 18 49 01](https://user-images.githubusercontent.com/486004/208555869-cd9b92ee-ac12-4999-8721-15bdeedfe51b.png)

In a brief:
- Sometimes we'll not be able to get the document number from the PDF and the download confirmation page is not available due to the PDF being "free", this problem is solved in this PR.

- A court can change the way how it numbers docket entries at any moment for a case or multiple cases, updating the full docket and also PDFs.

- When that happens we can get duplicated docket entries since we rely on the document number to add entries,  I think the only way to avoid this issue might be to use the related RD `pacer_doc_id` to check if a docket entry already exists or does not.

Let me know what you think about these issues.
