### PR TITLE
607 Fix remove bad HTML escaped chars

### DIFF
--- a/juriscraper/lib/html_utils.py
+++ b/juriscraper/lib/html_utils.py
@@ -229,6 +229,10 @@ def clean_html(text: str) -> str:
     if isinstance(text, str):
         text = re.sub(r"^\s*<\?xml\s+.*?\?>", "", text)
 
+        # Remove bad escaped HTML chars &#01 or &#1 to &#08 or &#8 since are not
+        # valid XML bytes 0x1 to 0x8
+        text = re.sub(r"&#0[1-8]\b|&#[1-8]\b", "", text)
+
     # Fix invalid bytes in XML (http://stackoverflow.com/questions/8733233/)
     # Note that this won't work completely on narrow builds of Python, which
     # existed prior to Py3. Thus, we check if it's a narrow build, and adjust

--- a/tests/examples/pacer/case_queries/case_query_error.html
+++ b/tests/examples/pacer/case_queries/case_query_error.html
@@ -1,0 +1,72 @@
+<html><head><link rel="shortcut icon"  href="/favicon.ico"/><title>CM/ECF - NCWB</title>
+<script type="text/javascript">document.cookie = "PRTYPE=web; path=/;"</script> <script>var default_base_path = "/"; </script> <link rel="stylesheet" type="text/css" href="/css/default.css"><script type="text/javascript" src="/lib/core.js"></script><script type="text/javascript" src="/lib/autocomplete.js"></script><script type="text/javascript" src="/lib/DisableAJTALinks.js"></script><script type="text/javascript">if (top!=self) {top.location.replace(location.href);}</script><script>var default_base_path = "/"; </script><script type="text/javascript" src="/cgi-bin/menu.pl?id=-1"></script></head><body BGCOLOR=#fffff0 TEXT=#000000 >
+				<div class="noprint">
+				<div id="topmenu" class="yuimenubar"><div class="bd">
+				<img id="cmecfLogo" class="cmecfLogo" src="/graphics/logo-cmecf-sm.png" alt="CM/ECF" title="" onClick="CMECF.MainMenu.showCourtInformation(); return false" />
+				<ul class="first-of-type">
+
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href='/cgi-bin/iquery.pl'><u>Q</u>uery</a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href='/cgi-bin/DisplayMenu.pl?Reports&id=-1'><u>R</u>eports <div class='spritedownarrow'></div></a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href='/cgi-bin/DisplayMenu.pl?Utilities&id=-1'><u>U</u>tilities <div class='spritedownarrow'></div></a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" onClick="CMECF.MainMenu.showHelpPage(''); return false">Help</a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href='/cgi-bin/login.pl?logout'>Log Out</a></li><li class='yuimenubaritem' id='placeholderForAlertsIcon'></li>
+				</ul></div>
+				<hr class="hrmenuseparator"></div></div>
+
+			<script type="text/javascript">
+callCreateMenu=function(){
+				var fn = "CMECF.MainMenu.createMenu";
+				if(typeof CMECF.MainMenu.createMenu == 'function') {
+					CMECF.MainMenu.createMenu();
+				}
+                        }
+if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout( function(){ callCreateMenu(); }, 1);}else{CMECF.util.Event.addListener(window, "load",  callCreateMenu());}</script> <div id="cmecfMainContent"><input type="hidden" id="cmecfMainContentScroll" value="0"><CENTER>
+<B><FONT SIZE=+1>20-03006</FONT></B>
+<B></B>Culp v. FSC Franchise Co., LLC d/b/a Beef O&#039;Brady&#03
+<BR>
+<B>Case type:</B> ap
+<B>Related bankruptcy:</B> 19-30334
+<b>Judge:</b> J. Craig Whitley
+<BR>
+<B>Date filed:</B> 01/24/2020
+<B>Date of last filing:</B> 03/06/2020
+<BR><B>Date terminated:</B> 03/06/2020
+<BR>
+</CENTER><BR>
+<BODY BGCOLOR=#fffff0 TEXT=#000000>
+<div style="margin: 3px 0 1em 3px"><a href="/cgi-bin/mobile_query.pl?search=caseInfo&caseid=204571">Mobile Query</a></div><font size=+1><strong>Query</strong></font><BR>
+
+				<script language="JavaScript">
+					document.cookie = "CASE_NUM=3-20-ap-3006";
+				</script>
+				<TABLE vspace=0 cellspacing=10 hspace=10 cellpadding=0 align=left valign=top>
+		<TR align=left valign=top>
+		<TD ALIGN="top">
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/qryAlias.pl?204571">Alias</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/qryAscCases.pl?204571">Associated Cases</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/qryAttorneys.pl?204571">Attorney</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/qrySummary.pl?204571">Case Summary</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/SchedQry.pl?204571">Deadline/Schedule</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/DktRpt.pl?204571">Docket Report ...</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/FilerQry.pl?204571">Filers</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/HistDocQry.pl?204571">History/Documents</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/qryParties.pl?204571">Party</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/RelTransactQry.pl?204571">Related Transactions</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/StatusQry.pl?204571">Status</A><BR>
+		</TD>
+
+
+		<TD>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/qryViewDocument.pl?204571">View Document</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/SearchClaims.pl?204571">Claims Register</A><BR>
+			&nbsp;&nbsp;&nbsp;<A HREF="/cgi-bin/CredMatrixCase.pl?204571">List of Creditors</A><BR>
+		</td>
+		</tr>
+		</table>
+
+
+<script>
+function clearDesktopCookie(){
+	document.cookie = "uiexperience=dtp;secure;path=/;expires=Thu, 01-Jan-1970 00:00:01 GMT';";
+}
+</script>

--- a/tests/examples/pacer/case_queries/case_query_error.json
+++ b/tests/examples/pacer/case_queries/case_query_error.json
@@ -1,0 +1,12 @@
+{
+  "assigned_to_str": "J. Craig Whitley",
+  "case_name": "Culp v. FSC Franchise Co., LLC d/b/a Beef O'Brady",
+  "case_name_raw": "Culp v. FSC Franchise Co., LLC d/b/a Beef O'Brady",
+  "case_type": "ap",
+  "court_id": "case",
+  "date_filed": "2020-01-24",
+  "date_last_filing": "2020-03-06",
+  "date_terminated": "2020-03-06",
+  "docket_number": null,
+  "related_bankruptcy": "19-30334"
+}


### PR DESCRIPTION
This fixes #607, the problem is due to bad HTML escaped chars in this case `&#03` equivalent to 0x3 which is a no valid XML byte. 

Since the char is escaped can't be removed by the current method that fixes invalid XML bytes in `clean_html`, so then when the escaped char is converted to bytes the parsing fails. 

To solve it I added a regex that removes escaped chars from `&#01` or `&#1` to `&#08` or` &#8` equivalent to `0x1` to `0x8` bytes that are not XML valid.

Let me know what you think!