### PR TITLE
612 Fixes index error when parsing appellate attachment page

### DIFF
--- a/juriscraper/pacer/appellate_attachment_page.py
+++ b/juriscraper/pacer/appellate_attachment_page.py
@@ -140,10 +140,13 @@ class AppellateAttachmentPage(BaseReport):
         :param row: Table row
         :return: Attachment description
         """
-        description_text_nodes = row.xpath(".//td/text()")
-        if not description_text_nodes:
+        row_nodes = row.xpath(".//td")
+        if not row_nodes:
             return ""
-        return force_unicode(description_text_nodes[2].strip())
+        description = row_nodes[-2].xpath("text()")
+        if description:
+            return force_unicode(description[0].strip())
+        return ""
 
     @staticmethod
     def _get_page_count_from_tr(row: html.HtmlElement) -> Optional[int]:
@@ -156,7 +159,7 @@ class AppellateAttachmentPage(BaseReport):
         description_text_nodes = row.xpath(".//td/text()")
         if not description_text_nodes:
             return None
-        return int(description_text_nodes[3].strip())
+        return int(description_text_nodes[-1].strip())
 
     @staticmethod
     def _get_pacer_doc_id(row: html.HtmlElement) -> Optional[str]:

--- a/tests/examples/pacer/appellate_attachment_pages/ca1_46307.html
+++ b/tests/examples/pacer/appellate_attachment_pages/ca1_46307.html
@@ -1,0 +1,137 @@
+<head><title>Document</title><meta http-equiv="X-UA-Compatible" content="IE=edge"></head>
+<body bgcolor="#FFFFDA">
+<table border="0" align="center">
+<tbody><tr><th align="center"><b>2 Documents are attached to this filing</b><br><br></th></tr>
+</tbody></table>
+<table border="1" align="center" cellpadding="5">
+<tbody><tr><td>
+  <table border="0" cellpadding="5">
+ <tbody><tr><th align="center" colspan="3">Document</th> <th align="center">Description</th><th align="center">Pages</th></tr>
+<tr><td align="center"><input class="selDocCl" type="checkbox" name="md" value="7548050" onclick="sumDocSelected(this,1,13481, 7548050)" checked=""></td><td align="center">1</td><td align="center"><a href="https://ecf.ca1.uscourts.gov/docs1/00117548050" target="_self"><img title="Open Document" width="13" height="15" border="2" src="TransportRoom?servlet=document.gif" alt="Open document"></a>&nbsp;</td><td>Main Document</td><td align="center">3</td></tr>
+<tr><td align="center"><input class="selDocCl" type="checkbox" name="md" value="7548051" onclick="sumDocSelected(this,1,8890, 7548051)" checked=""></td><td align="center">2</td><td align="center"><a href="https://ecf.ca1.uscourts.gov/docs1/00117548051" target="_self"><img title="Open Document" width="13" height="15" border="2" src="TransportRoom?servlet=document.gif" alt="Open document"></a>&nbsp;</td><td></td><td align="center">5</td></tr>
+  </tbody></table>
+</td></tr>
+</tbody></table>
+<br>
+<center>
+<b>Selected Pages:
+<input id="totPageCntFld" type="text" size="10" value="2" onfocus="this.blur();">
+&nbsp;&nbsp;Selected Size:
+<input id="totByteSizeFld" type="text" size="10" value="21.85 KB" onfocus="this.blur();">
+ </b>
+
+<br><b>Totals reflect accessible documents only and do not include unauthorized restricted documents.</b>
+ <br><br>
+<div id="opts"><form name="dktEntry" action=""><input value="y" type="checkbox" name="incPdfFooter"><b>Include Page Numbers</b><br>
+<input name="viewSelBtn" value="View Selected" type="button" onclick="ProcessForm(&quot;view&quot;)">
+<input type="hidden" id="totPageHFld" value="2">
+<input type="hidden" id="totBytesHFld" value="22371">
+<input type="hidden" id="dynaTotPageId" name="dynaTotPageFld" value="2">
+<input type="hidden" id="dynaTotBytesId" name="dynaTotBytesFld" value="22371">
+<input type="hidden" id="pageLoadHFld" value="1">
+</form>
+</div><div id="noOpts" style="visibility:hidden"><b>Selected documents cannot be combined due to size. Please remove some selections to be below 250 MB.</b></div><script type="text/javascript">
+<!--
+var winOptions = 'location=no,resizable,toolbar,status,scrollbars';
+var winTarget = '_blank';
+function doDocPostURL(dls) {
+   // This use of a function when a user clicks a document
+   // link was done so params aren't in copied doc hyperlinks.
+   // This allows user to right click & get the URL for copying doc
+   // links, but still gets params back to the server as needed
+   var aWin = window.open('TransportRoom?servlet=ShowDoc&caseId=46307&dls_id='+dls+'&caseId=46307',winTarget,winOptions,false);
+   return false;
+}
+
+window.onload = function() {
+}
+
+window.onpageshow = function(event) {
+   if(performance.navigation.type == 2){
+     location.reload(true);
+   }
+}
+
+var dlsIdArr = [7548050,7548051];
+function getSize(bytes) {
+   if (bytes >= 1048576) {
+     return Math.round(bytes/1048576*100)/100 + ' MB';
+   }
+   return Math.round(bytes/1024*100)/100 + ' KB';
+}
+function tooManyDocs(disable) {
+   if (disable) {
+     hideOpts();
+     if (document.dktEntry.viewSelBtn.disabled == false) {
+       document.dktEntry.viewSelBtn.disabled = true;
+       alert('Too many documents are selected: ' + getSize(totNumByte) + '. Please remove some selections to be below 250 MB.');
+     }
+   } else {
+     showOpts();
+     document.dktEntry.viewSelBtn.disabled = false;
+   }
+}
+
+var totNumPage = 0.0;
+var totNumByte = 0.0;
+var maxSize = 0;
+function sumDocSelected(aField, numPage, numByte, docId) {
+   pageLoadIndexUpdate();
+   if (aField.checked == true) {
+     dlsIdArr.push(docId);     totNumPage = parseInt(totNumPage) + parseInt(numPage);
+     totNumByte = parseInt(totNumByte) + parseInt(numByte);
+   } else {
+     var dlsIndex = dlsIdArr.indexOf(docId);
+     dlsIdArr.splice(dlsIndex, 1);
+     totNumPage = parseInt(totNumPage) - parseInt(numPage);
+     totNumByte = parseInt(totNumByte) - parseInt(numByte);
+   }
+   document.getElementById('totPageCntFld').value = totNumPage;
+   document.getElementById('totByteSizeFld').value = getSize(totNumByte);
+   document.dktEntry.dynaTotPageFld.value = totNumPage;
+   document.dktEntry.dynaTotBytesFld.value = getSize(totNumByte);
+   tooManyDocs(totNumByte > 262144000);
+   return false;
+}
+
+function pageLoadIndexUpdate() {
+   var pageLoadIndex = document.getElementById('pageLoadHFld').value;
+   if (pageLoadIndex == 1) {
+     totNumByte = document.getElementById('totBytesHFld').value;
+     totNumPage = document.getElementById('totPageHFld').value;
+     document.getElementById('pageLoadHFld').value = 2;
+   }
+   return false;
+}
+
+function showOpts() {
+   document.getElementById('opts').style.pointerEvents = 'auto';
+   document.getElementById('opts').style.opacity = '1';
+   document.getElementById('noOpts').style.visibility = 'hidden';
+}
+
+function hideOpts() {
+   document.getElementById('opts').style.pointerEvents = 'none';
+   document.getElementById('opts').style.opacity = '0.4';
+   document.getElementById('noOpts').style.visibility = 'visible';
+}
+
+function ProcessForm(uChoice) {
+   pageLoadIndexUpdate();
+   if (totNumByte == 0) {
+     alert('No entries with accessible documents were selected. Please select the desired documents before proceeding.');
+     return false;
+   }
+   if(uChoice=='view'){
+     var incFoot = '';
+     if (document.dktEntry.incPdfFooter.checked) {
+       incFoot = 'y';
+     }
+     window.location='TransportRoom?servlet=ShowDocMulti&caseId=46307&outputType=doc&d=6315334&outputForm=view&incPdfFooter='+incFoot+'&dls='+dlsIdArr.join();
+   }
+   return false;
+}
+
+//-->
+</script>
+</center></body>

--- a/tests/examples/pacer/appellate_attachment_pages/ca1_46307.json
+++ b/tests/examples/pacer/appellate_attachment_pages/ca1_46307.json
@@ -1,0 +1,19 @@
+{
+  "attachments": [
+    {
+      "attachment_number": 1,
+      "description": "Main Document",
+      "pacer_doc_id": "00107548050",
+      "page_count": 3
+    },
+    {
+      "attachment_number": 2,
+      "description": "",
+      "pacer_doc_id": "00107548051",
+      "page_count": 5
+    }
+  ],
+  "pacer_case_id": "46307",
+  "pacer_doc_id": "00107548050",
+  "pacer_seq_no": "6315334"
+}


### PR DESCRIPTION
This fixes #612.

The error was due to an attachment row with a blank description. Then the list of text elements found in a row contains one less element raising the index error.

To solve it, now to extract the `page_count` I changed the index to the last element `[-1]` since it's always in the last cell.

To extract the `description`,  the `[-2]` element is selected based on all the cells found in a row (not only the ones that contain text) since the description is always before the page count (last element).

There is an error in tests, Bill told me is solved in #614 so once it's merged I'll rebase it so tests pass.

Let me know what you think.
