### PR TITLE
Do and additional GET request when a PACER login page is returned.

### DIFF
--- a/juriscraper/lib/test_utils.py
+++ b/juriscraper/lib/test_utils.py
@@ -85,3 +85,13 @@ def warn_or_crash_slow_parser(duration, warn_duration=1, max_duration=15):
 def warn_generated_compare_file(path_to_compare_file):
     warning = f"WARNING: GENERATED COMPARE FILE: {path_to_compare_file}"
     warnings.warn(warning, CompareFileGeneratedWarning)
+
+
+class MockResponse(Response):
+    """Mock a Request Response"""
+
+    def __init__(self, status_code, content=None, headers=None, request=None):
+        self.status_code = status_code
+        self._content = content
+        self.headers = headers
+        self.request = request

--- a/tests/local/test_PacerNeedLoginTest.py
+++ b/tests/local/test_PacerNeedLoginTest.py
@@ -9,8 +9,10 @@ import time
 import unittest
 from unittest import mock
 
+from requests import Request
+
 from juriscraper.lib.exceptions import PacerLoginException
-from juriscraper.lib.test_utils import warn_or_crash_slow_parser
+from juriscraper.lib.test_utils import MockResponse, warn_or_crash_slow_parser
 from juriscraper.pacer.http import PacerSession, check_if_logged_in_page
 from tests import TESTS_ROOT_EXAMPLES_PACER
 
@@ -57,7 +59,15 @@ class PacerNeedLoginTest(unittest.TestCase):
         )
         self.parse_files(path_root, "*.html")
 
-    @mock.patch("juriscraper.pacer.http.requests.Session.get")
+    @mock.patch(
+        "juriscraper.pacer.http.requests.Session.get",
+        side_effect=lambda *args, **kwargs: MockResponse(
+            200,
+            b"",
+            headers={"content-type": "text/html"},
+            request=Request(method="GET"),
+        ),
+    )
     @mock.patch(
         "juriscraper.pacer.http.check_if_logged_in_page",
         side_effect=lambda x: False,
@@ -75,7 +85,15 @@ class PacerNeedLoginTest(unittest.TestCase):
 
         self.assertEqual(mock_check_if_logged_in.call_count, 2)
 
-    @mock.patch("juriscraper.pacer.http.requests.Session.post")
+    @mock.patch(
+        "juriscraper.pacer.http.requests.Session.post",
+        side_effect=lambda *args, **kwargs: MockResponse(
+            200,
+            b"",
+            headers={"content-type": "text/html"},
+            request=Request(method="POST"),
+        ),
+    )
     @mock.patch(
         "juriscraper.pacer.http.check_if_logged_in_page",
         side_effect=lambda x: False,

--- a/tests/local/test_PacerNeedLoginTest.py
+++ b/tests/local/test_PacerNeedLoginTest.py
@@ -7,9 +7,11 @@ import os
 import sys
 import time
 import unittest
+from unittest import mock
 
+from juriscraper.lib.exceptions import PacerLoginException
 from juriscraper.lib.test_utils import warn_or_crash_slow_parser
-from juriscraper.pacer.http import check_if_logged_in_page
+from juriscraper.pacer.http import PacerSession, check_if_logged_in_page
 from tests import TESTS_ROOT_EXAMPLES_PACER
 
 
@@ -54,3 +56,57 @@ class PacerNeedLoginTest(unittest.TestCase):
             TESTS_ROOT_EXAMPLES_PACER, "authentication_samples"
         )
         self.parse_files(path_root, "*.html")
+
+    @mock.patch("juriscraper.pacer.http.requests.Session.get")
+    @mock.patch(
+        "juriscraper.pacer.http.check_if_logged_in_page",
+        side_effect=lambda x: False,
+    )
+    def test_do_an_additional_get_request(
+        self, mock_get, mock_check_if_logged_in
+    ):
+        """Test if we can do an additional GET request after check_if_logged_in
+        returned False, check_if_logged_in_page should be called 2 times and
+        raise a PacerLoginException afterwards.
+        """
+        session = PacerSession(username="", password="")
+        with self.assertRaises(PacerLoginException):
+            session.get("https://example.com")
+
+        self.assertEqual(mock_check_if_logged_in.call_count, 2)
+
+    @mock.patch("juriscraper.pacer.http.requests.Session.post")
+    @mock.patch(
+        "juriscraper.pacer.http.check_if_logged_in_page",
+        side_effect=lambda x: False,
+    )
+    def test_avoid_an_additional_post_request(
+        self, mock_get, mock_check_if_logged_in
+    ):
+        """Test if we can avoid an additional POST request after
+        check_if_logged_in returned False, check_if_logged_in_page should be
+        called 1 time and raise a PacerLoginException afterwards.
+        """
+        session = PacerSession(username="", password="")
+        with self.assertRaises(PacerLoginException):
+            session.post("https://example.com")
+        self.assertEqual(mock_check_if_logged_in.call_count, 1)
+
+    @mock.patch("juriscraper.pacer.http.requests.Session.get")
+    @mock.patch(
+        "juriscraper.pacer.http.check_if_logged_in_page",
+        side_effect=lambda x: False,
+    )
+    @mock.patch(
+        "juriscraper.pacer.http.is_pdf",
+        side_effect=lambda x: True,
+    )
+    def test_avoid_an_additional_get_request_pdf(
+        self, mock_get, mock_check_if_logged_in, mock_is_pdf
+    ):
+        """Test if we can avoid an additional GET requests if a PDF binary is
+        returned, check_if_logged_in_page shouldn't be called.
+        """
+        session = PacerSession(username="", password="")
+        session.get("https://example.com")
+        self.assertEqual(mock_check_if_logged_in.call_count, 0)

--- a/tests/network/test_PacerFreeOpinionsTest.py
+++ b/tests/network/test_PacerFreeOpinionsTest.py
@@ -294,7 +294,7 @@ class PacerDownloadConfirmationPageTest(unittest.TestCase):
         page skipping the attachment page?"""
         self.report_att.query(self.pacer_doc_id_att)
         data_report = self.report_att.data
-        self.assertEqual(data_report["document_number"], "00516470276")
+        self.assertEqual(data_report["document_number"], "45-1")
         self.assertEqual(data_report["docket_number"], "22-30311")
         self.assertEqual(data_report["cost"], "1.50")
         self.assertEqual(data_report["billable_pages"], "15")


### PR DESCRIPTION
As described in [#2160 ](https://github.com/freelawproject/courtlistener/issues/2160)sometimes a PACER login page is shown after a GET request, even though cookies are still valid. Usually doing additional requests solve the problem and the requested content is returned.

So in this PR, I added some code to do 1 additional GET request after `check_if_logged_in_page` returns `False`. So this would save retries and hopefully fewer PACERLoginExceptions would be raised into Sentry.

This logic only applies to PACER GET requests, since we don't have problems with POST requests according to sentry.

I did some tests in CL using this approach and seems to work, without this logic on a failing `fetch_attachment_page` task, it took on average 4-5 retries or failed to get the attachment page.  
While using this logic it took on average 1-3 retries to get the attachment page.


Let me know what you think.