### PR TITLE
617 Fixes index error if originating_court_information is no available

### DIFF
--- a/tests/examples/pacer/dockets/appellate/cadc_1.html
+++ b/tests/examples/pacer/dockets/appellate/cadc_1.html
@@ -1,0 +1,329 @@
+<head>
+	<title>22-8513 Docket</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<link rel="stylesheet" type="text/css" media="all" href="TransportRoom?servlet=ShowPagePublic&amp;page=PACER.css">
+<style type="text/css" media="print">.noprint{display:none;}</style></head>
+<body data-feedly-extension-follow-feed="1.0.3">
+<div class="noprint">
+<table border="0" cellspacing="0" cellpadding="0" width="100%" bgcolor="#0000af">
+<tbody><tr><td>
+	<!-- THESE ITEMS ARE ON THE LEFT PORTION OF THE MENU -->
+	<table border="0" cellspacing="0" cellpadding="0" align="left" bgcolor="#0000af">
+	<tbody><tr valign="middle" align="left">
+		<td><a href="/n/AttorneyFiling"><img src="TransportRoom?servlet=cmecf_logo.gif" alt="CM/ECF" title="File"></a></td>
+		<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=CaseSearch.jsp">Case Search</a>&nbsp;&nbsp;&nbsp;</td>
+		<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=PACERCalendar.jsp">Calendar</a>&nbsp;&nbsp;&nbsp;</td>
+		<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=PACEROpinion.jsp">Opinions</a>&nbsp;&nbsp;&nbsp;</td>
+		<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=OrderJudgment.jsp">Orders/Judgments</a>&nbsp;&nbsp;&nbsp;</td>
+<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=Briefs.jsp">Briefs</a>&nbsp;&nbsp;&nbsp;</td>
+<td><a style="color: #ffffff; font-weight:bold;" href="javascript:downloadData(&quot;XML&quot;);">XML</a>&nbsp;&nbsp;&nbsp;</td>
+		<td><a style="color: #ffffff; font-weight:bold;" href="javascript:downloadData(&quot;TXT&quot;);">TXT</a>&nbsp;&nbsp;&nbsp;</td>
+</tr>
+	</tbody></table>
+</td><td>
+<!-- THESE ITEMS ARE ON THE RIGHT PORTION OF THE MENU -->
+	<table border="0" cellspacing="0" cellpadding="0" align="right" bgcolor="#0000af">
+	<tbody><tr>
+<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=InvalidUserLogin.jsp&amp;logout=y">Logout</a>&nbsp;&nbsp;&nbsp;</td>
+<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=PacerHelp.jsp#CaseSummary">Help</a>&nbsp;&nbsp;</td>
+	</tr>
+	</tbody></table>
+</td></tr>
+</tbody></table>
+<br>
+</div>
+<script type="text/javascript">
+function downloadData(aType) {
+	document.f1.outputXML_TXT.value = aType;
+	document.f1.submit();
+}
+</script>
+
+<form name="f1" action="TransportRoom?servlet=CaseSummary.jsp" method="post">
+<input type="hidden" name="outputXML_TXT">
+<input type="hidden" name="servlet" value="CaseSummary.jsp">
+<input type="hidden" name="CSRF" value="csrf_2225582963178865690">
+<input type="hidden" name="caseNum" value="22-8513">
+<input type="hidden" name="fullDocketReport" value="Y">
+<input type="hidden" name="incOrigDkt" value="Y">
+<input type="hidden" name="incPrior" value="Y">
+<input type="hidden" name="incAssoc" value="Y">
+<input type="hidden" name="incPanel" value="Y">
+<input type="hidden" name="incPtyAty" value="Y">
+<input type="hidden" name="incCaption" value="long">
+<input type="hidden" name="incDktEntries" value="Y">
+<input type="hidden" name="dateFrom" value="">
+<input type="hidden" name="dateTo" value="">
+<input type="hidden" name="incPdfMulti" value="Y">
+<input type="hidden" name="actionType" value="Run Docket Report"><input name="CSRF" type="hidden" value="csrf_2225582963178865690">
+</form>
+<table width="100%" border="0">
+	<tbody><tr><td align="right"></td></tr>
+	<tr><td align="center"><b>General Docket<br>
+	United States Court of Appeals for District of Columbia Circuit</b></td>
+	</tr>
+</tbody></table><div class="btn-group" id="recap-action-button"><a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-spinner fa-spin recap-btn-spinner-hidden" id="recap-button-spinner"></i> RECAP Actions<span class="caret"></span></a><ul class="dropdown-menu"><h2 class="dropdown-header" id="action-button-dropdown-header">CourtListener</h2><li id="view-docket-button"><a href="https://www.courtlistener.com/recap/gov.uscourts.cadc.39014/" target="_blank">View this docket</a></li><div class="recap-dropdown-divider"></div><li><a href="javascript:void(0);" id="refresh-recap-links" role="button">Refresh RECAP Links</a></li></ul></div>
+<table width="100%" border="1" cellpadding="4">
+<!-- ===================== NEW SECTION - Case Stub ======================== -->
+<tbody><tr><td>
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tbody><tr><td><b>Court of Appeals Docket #: </b>22-8513</td>
+		<td valign="top" align="right" rowspan="2">
+		<b>Docketed:</b> 09/01/2022<br><b>Termed:</b> 10/06/2022</td></tr>
+<tr><td>In re: Sealed Case</td></tr>
+	<tr><td><b>Appeal From:</b>
+	null</td>
+</tr>
+	<tr><td><b>Fee Status:</b>  Fee Not Required</td>
+</tr>
+	</tbody></table>
+</td></tr>
+<!-- ==================== NEW SECTION - Case Type ========================= -->
+<tr><td>
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tbody><tr><td><b>Case Type Information:</b></td></tr>
+	<tr><td><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1)</b> Attorney Discipline</td></tr>
+	<tr><td><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2)</b> </td></tr>
+	<tr><td><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3)</b> </td></tr>
+	<tr><td></td></tr>
+	</tbody></table>
+</td></tr>
+<!-- =================== NEW SECTION - Orig Court ========================= -->
+<tr><td>
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tbody><tr><td colspan="4"><b>Originating Court Information:</b></td></tr>
+<tr><td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None</td></tr>
+	</tbody></table>
+</td></tr>
+<!-- =============== NEW SECTION - Prior and/or Assoc Cases =============== -->
+<tr><td>
+<!-- NEW SUBSECTION - Prior Cases -->
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tbody><tr><td colspan="2"><b>Prior Cases:</b></td></tr>
+<tr><td colspan="9">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None</td></tr>
+</tbody></table>
+<br>
+<!-- NEW SUBSECTION - Assoc Cases -->
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tbody><tr><td colspan="2"><b>Current Cases:</b></td></tr>
+<tr><td colspan="5">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None</td></tr>
+</tbody></table>
+</td></tr>
+<!-- ================= NEW SECTION - Panel Assignment ===================== -->
+<tr><td><b>Panel Assignment:</b>
+
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Not available
+</td></tr>
+</tbody></table>
+
+<!-- ===================NEW SECTION - Party/Aty List ====================== -->
+<br>
+<!-- NEW SHEET -->
+<table width="100%" border="1" cellpadding="0">
+<tbody><tr><td>
+	<table width="100%" border="0" cellpadding="4" cellspacing="0">
+<tbody><tr><td colspan="2"></td></tr>
+	<tr><td valign="top" width="50%">In re:  Sealed Case<br>
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;In&nbsp;re
+
+</td>
+		<td valign="top" width="50%">
+</td></tr>
+</tbody></table>
+</td></tr>
+</tbody></table>
+<!-- ==================== NEW SECTION - Case Caption ================== -->
+	<h1 style="page-break-before: always;"> </h1>
+	<table width="100%" border="1" cellpadding="4">
+	<tbody><tr><td>
+	In re:&nbsp;&nbsp;Sealed Case, <br>
+<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;In re</td></tr>
+	</tbody></table>
+<!-- ================= NEW SECTION - DOCKET ENTRIES =================== -->
+	<h1 style="page-break-before: always;"> </h1>
+<form name="dktEntry" action="TransportRoom" method="GET" target="_blank">
+<table width="100%" border="1" cellpadding="0">
+		<tbody><tr><td>
+		<table border="0" cellpadding="4">
+<!-- NEED 0 -->
+		<tbody><tr><td valign="top">09/01/2022</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="1961710" onclick="sumSelected(this,0,0);">
+
+		&nbsp;&nbsp;
+</td><td width="90%" valign="top">ATTORNEY DISCIPLINE CASE docketed. [22-8513]  [Entered: 09/01/2022 09:53 AM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">09/01/2022</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="1961713" onclick="sumSelected(this,0,0);">
+
+		&nbsp;&nbsp;
+</td><td width="90%" valign="top">COMPLAINT received from Not Listed/Other; Type of Action: other discipinary action [Document: 22-8513 Complaint.pdf] [22-8513]  [Entered: 09/01/2022 09:58 AM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">09/01/2022</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="1961747" onclick="sumSelected(this,0,0);">
+
+		&nbsp;&nbsp;
+</td><td width="90%" valign="top">LETTER [1961747] sent to complainant regarding grievance to the court [22-8513]  [Entered: 09/01/2022 11:35 AM]</td></tr>
+<!-- NEED 3 -->
+		<tr><td valign="top">09/01/2022</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="1961779" onclick="sumSelected(this,0,0);">
+
+		&nbsp;&nbsp;
+</td><td width="90%" valign="top">CLERK'S ORDER [1961779] filed considering case opening document [1961713-2], referring attorney discipline matter to court; The Clerk is directed to send this order to respondent by certified mail, return receipt requested and by 1st class mail. [22-8513]  [Entered: 09/01/2022 12:24 PM]</td></tr>
+<!-- NEED 2 -->
+		<tr><td valign="top">09/01/2022</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="1961791" onclick="sumSelected(this,0,0);">
+
+		&nbsp;&nbsp;
+</td><td width="90%" valign="top">CERTIFIED AND FIRST CLASS MAIL SENT [1961791] with return receipt requested [Receipt No.70210350000186797347]
+ of order [1961779-3]. Certified Mail Receipt due 10/03/2022 from Party 1. [22-8513]  [Entered: 09/01/2022 01:04 PM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">09/09/2022</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="1963473" onclick="sumSelected(this,0,0);">
+
+		&nbsp;&nbsp;
+</td><td width="90%" valign="top">CERTIFIED MAIL RECEIPT [1963473] received from respondent for order [1961791-2] sent to respondent [22-8513]  [Entered: 09/13/2022 02:43 PM]</td></tr>
+<!-- NEED 2 -->
+		<tr><td valign="top">10/06/2022</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="1967834" onclick="sumSelected(this,0,0);">
+
+		&nbsp;&nbsp;
+</td><td width="90%" valign="top">PER CURIAM ORDER [1967834] filed considering case opening document [1961713-2]; dismissing case opening document [1961713-2], No mandate shall issue., Before Judges: Millett, Rao and Childs. [22-8513]  [Entered: 10/06/2022 12:28 PM]</td></tr>
+</tbody></table></td></tr></tbody></table>
+<script type="text/javascript">
+	function ProcessForm() {
+		document.dktEntry.submit();
+		return true;
+	}
+	function tooManyDocs() {
+		if (document.dktEntry.submitbtn.disabled == false) {
+			document.dktEntry.submitbtn.disabled = true;
+			alert("Too many documents are selected: "+getSize(totNumByte)
+			+".\nPlease remove some selections to be below 55 MB.");
+		}
+		document.dktEntry.totPageFld.value=" too many!";
+	}
+	var totNumPage = 0.0;
+	var totNumByte = 0.0;
+	var maxSize = 0;
+	function getSize(bytes) {
+		//using 1024^2 instead of 1000^2
+		if (bytes >= 1048576)
+			return Math.round(bytes/1048576*100)/100 + " MB";
+		return Math.round(bytes/1024*100)/100 + " KB";
+	}
+	function sumSelected(aField, numPage, numByte) {
+		if (aField.checked == true) {
+			totNumPage = totNumPage + numPage;
+			totNumByte = totNumByte + numByte;
+		} else {
+			totNumPage = totNumPage - numPage;
+			totNumByte = totNumByte - numByte;
+		}
+		document.dktEntry.totPageFld.value=totNumPage;
+		document.dktEntry.totByteFld.value=getSize(totNumByte);
+		if (totNumByte > 57671680) {
+			tooManyDocs();
+		} else {
+			document.dktEntry.submitbtn.disabled = false;
+		}
+	}
+	function checkEm(aField, yesNo){
+		if (aField.length == null) {
+			aField.checked = yesNo;
+		} else {
+			for (i = 0; i < aField.length; i++)
+				aField[i].checked = yesNo;
+		}
+		if (yesNo == false) {
+			totNumPage = 0.0;
+			totNumByte = 0.0;
+		} else {
+			totNumPage = 0;
+			totNumByte = 0;
+		}
+		document.dktEntry.totPageFld.value=totNumPage;
+		document.dktEntry.totByteFld.value=getSize(totNumByte);
+		if (totNumByte > 57671680) {
+			tooManyDocs();
+		} else {
+			document.dktEntry.submitbtn.disabled = false;
+		}
+	}
+</script>
+<h1 style="page-break-before: always;"> </h1>
+<b>
+<input type="hidden" name="servlet" value="ShowDocMulti">
+<input type="hidden" name="caseId" value="39014">
+<input type="button" value="Clear All" onclick="checkEm(document.dktEntry.d, false);return false;">
+<br>
+<br><input type="radio" name="outputType" value="docrpt" checked=""> Documents and Docket Summary
+<br><input type="radio" name="outputType" value="doc"> Documents Only
+<br><br><input value="y" type="checkbox" name="incPdfFooter" checked=""> Include Page Numbers
+<br><br>
+Selected Pages: <input name="totPageFld" type="text" size="8" onfocus="this.blur();">
+&nbsp;Selected Size: <input name="totByteFld" type="text" size="8" onfocus="this.blur();"> <br><br><input value="View Selected" name="submitbtn" type="button" onclick="ProcessForm();">
+</b>
+</form>
+<script type="text/javascript">
+	checkEm(document.dktEntry.d, false);
+</script>
+
+<form name="doDocPostURLForm" method="post" target="_self" action="TransportRoom">
+  <input name="servlet" type="hidden" value="ShowDoc">
+  <input name="dls_id" type="hidden" value="">
+  <input name="caseId" type="hidden" value="">
+  <input name="dktType" type="hidden" value="dktPublic">
+</form>
+
+<script type="text/javascript">
+function doDocPostURL(dls, caseIdStr){
+  document.doDocPostURLForm.dls_id.value = dls;
+  document.doDocPostURLForm.caseId.value = caseIdStr;
+  document.doDocPostURLForm.submit();
+  return false;
+}
+</script>
+<br>
+<hr><center><table border="1" bgcolor="WHITE" width="500">
+<tbody><tr><th colspan="4"><font size="+1" color="DARKRED">PACER Service Center</font></th></tr>
+<tr><th colspan="4"><font color="DARKBLUE">Transaction Receipt</font></th></tr>
+<tr></tr>
+<tr></tr>
+<tr><td colspan="4" align="CENTER">
+<font size="-1" color="DARKBLUE">DC Circuit (USCA) - 01/06/2023 10:22:43</font></td></tr>
+<tr><th align="LEFT"><font size="-1" color="DARKBLUE">PACER Login:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">gogopopo</font></td><th align="LEFT">
+<font size="-1" color="DARKBLUE">Client Code:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">&nbsp;</font></td></tr><tr><th align="LEFT">
+<font size="-1" color="DARKBLUE">Description:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">Docket Report (full)</font></td><th align="LEFT">
+<font size="-1" color="DARKBLUE">
+Search Criteria:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">22-8513</font></td></tr><tr><th align="LEFT">
+<font size="-1" color="DARKBLUE">Billable Pages:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">1</font></td><th align="LEFT">
+<font size="-1" color="DARKBLUE">Cost:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">0.10</font></td></tr>
+</tbody></table>
+</center>
+
+<div class="noprint">
+<hr>
+<center>
+<table border="0" cellspacing="0" cellpadding="3" style="width: 95%; text-align: center; margin-left: auto; margin-right: auto;">
+<tbody><tr>
+<td><a href="TransportRoom?servlet=CourtInfo.jsp&amp;menu=yes">Court Information</a>&nbsp;&nbsp;</td>
+<td><a href="http://www.cadc.uscourts.gov/">Court Home</a>&nbsp;&nbsp;</td>
+<td><a href="http://www.pacer.gov/">PACER Service Center</a>&nbsp;&nbsp;</td>
+ <td><a href="https://pacer.login.uscourts.gov/csologin/login.jsf?pscCourtId=1DCCA&amp;appurl=https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom">Change Client</a>&nbsp;&nbsp;</td>
+<td><a href="https://pacer.login.uscourts.gov/csobill-hist/billingmenu.jsf" target="_blank">Billing History</a>&nbsp;&nbsp;</td>
+<td><a href="mailto:pacer@cadc.uscourts.gov?Subject=Appellate_PACER_comment">Contact Us</a>&nbsp;&nbsp;</td>
+</tr>
+</tbody></table>
+</center>
+</div>
+
+
+</body>

--- a/tests/examples/pacer/dockets/appellate/cadc_1.json
+++ b/tests/examples/pacer/dockets/appellate/cadc_1.json
@@ -1,0 +1,64 @@
+{
+  "appeal_from": "",
+  "case_name": "In re: Sealed Case",
+  "case_type_information": "Attorney Discipline",
+  "court_id": "cadc",
+  "date_filed": "2022-09-01",
+  "date_terminated": "2022-10-06",
+  "docket_entries": [
+    {
+      "date_filed": "2022-09-01",
+      "description": "ATTORNEY DISCIPLINE CASE docketed. [22-8513] [Entered: 09/01/2022 09:53 AM]",
+      "document_number": null,
+      "pacer_doc_id": null
+    },
+    {
+      "date_filed": "2022-09-01",
+      "description": "COMPLAINT received from Not Listed/Other; Type of Action: other discipinary action [Document: 22-8513 Complaint.pdf] [22-8513] [Entered: 09/01/2022 09:58 AM]",
+      "document_number": null,
+      "pacer_doc_id": null
+    },
+    {
+      "date_filed": "2022-09-01",
+      "description": "LETTER [1961747] sent to complainant regarding grievance to the court [22-8513] [Entered: 09/01/2022 11:35 AM]",
+      "document_number": null,
+      "pacer_doc_id": null
+    },
+    {
+      "date_filed": "2022-09-01",
+      "description": "CLERK'S ORDER [1961779] filed considering case opening document [1961713-2], referring attorney discipline matter to court; The Clerk is directed to send this order to respondent by certified mail, return receipt requested and by 1st class mail. [22-8513] [Entered: 09/01/2022 12:24 PM]",
+      "document_number": null,
+      "pacer_doc_id": null
+    },
+    {
+      "date_filed": "2022-09-01",
+      "description": "CERTIFIED AND FIRST CLASS MAIL SENT [1961791] with return receipt requested [Receipt No.70210350000186797347] of order [1961779-3]. Certified Mail Receipt due 10/03/2022 from Party 1. [22-8513] [Entered: 09/01/2022 01:04 PM]",
+      "document_number": null,
+      "pacer_doc_id": null
+    },
+    {
+      "date_filed": "2022-09-09",
+      "description": "CERTIFIED MAIL RECEIPT [1963473] received from respondent for order [1961791-2] sent to respondent [22-8513] [Entered: 09/13/2022 02:43 PM]",
+      "document_number": null,
+      "pacer_doc_id": null
+    },
+    {
+      "date_filed": "2022-10-06",
+      "description": "PER CURIAM ORDER [1967834] filed considering case opening document [1961713-2]; dismissing case opening document [1961713-2], No mandate shall issue., Before Judges: Millett, Rao and Childs. [22-8513] [Entered: 10/06/2022 12:28 PM]",
+      "document_number": null,
+      "pacer_doc_id": null
+    }
+  ],
+  "docket_number": "22-8513",
+  "fee_status": "Fee Not Required",
+  "nature_of_suit": "",
+  "originating_court_information": {},
+  "panel": [],
+  "parties": [
+    {
+      "attorneys": [],
+      "name": "In re:  Sealed Case",
+      "type": "In\u00a0re"
+    }
+  ]
+}


### PR DESCRIPTION
This PR Fixes #617.

![Screen Shot 2023-01-11 at 10 46 54](https://user-images.githubusercontent.com/486004/211865937-e63f4e04-b3fb-4103-80a3-baaf1e1d5eb2.png)

- The problem here is the `Originating Court Information` table is available, however, the table only contains two rows one for the title and one with the text "None".

  In order to solve it, we check if the only data we have within the `Originating Court Information` table (besides the title) is "None" if so an empty dict is returned. This approach will allow us to detect some other possible variations for example in case only the first row is "None" but if there are other rows with good data an error will be raised and we could add support for that example.

I detected a couple of small adjust in this example:

- Case Type Information, here point 2) and 3) exist but they are blank. So I added within the parsing conditions if it is an empty string the data is not added, this fixes the addition of unnecessary `,` going from `Attorney Discipline,,` to `Attorney Discipline`.
- In this example, the `Appeal From` has the string "null", so I added a method to detect if is "null" and return an empty string instead of the string "null". However doing some testing in CL, this change will avoid adding additional appellate data to the docket like the `case_type_information` or "fee_status", since there is a condition in CL where the `appeal_from` shouldn't be empty to add additional appellate information. 
So let me know if this change is ok and if we need to tweak this logic in CL, since this docket example seems quite unique.

