### PR TITLE
646 Added support to parse appellate RSS Feeds

### DIFF
--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -45,6 +45,7 @@ class BaseDocketReport:
     )
     docket_number_bankr_regex = re.compile(r"(?:#:\s+)?((\d-)?\d\d-\d*)")
     docket_number_jpml = re.compile(r"(MDL No.\s+\d*)")
+    docket_number_appellate_regex = re.compile(r"(\d\d-\d+)")
 
     def __init__(self, court_id):
         self.court_id = court_id

--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -5,8 +5,8 @@ import re
 import sys
 from html import unescape
 
+import dateparser
 import feedparser
-from dateutil import parser
 from requests import Session
 
 from ..lib.log_tools import make_default_logger
@@ -17,7 +17,6 @@ from .utils import (
     get_pacer_case_id_from_nonce_url,
     get_pacer_doc_id_from_doc1_url,
     get_pacer_seq_no_from_doc1_url,
-    parse_datetime_for_us_timezone,
     set_pacer_doc_id_as_appellate_document_number,
 )
 
@@ -276,7 +275,7 @@ class PacerRssFeed(DocketReport):
         Although there is only one, return it as a list.
         """
         de = {
-            "date_filed": parse_datetime_for_us_timezone(entry.published),
+            "date_filed": dateparser.parse(entry.published),
             "description": "",
             "document_number": self._get_value(
                 self.document_number_regex, entry.summary

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -1,6 +1,6 @@
 import re
-from datetime import datetime
-from typing import Optional
+from datetime import date, datetime
+from typing import Dict, Optional, Union
 
 import requests
 import tldextract
@@ -317,14 +317,36 @@ def parse_datetime_for_us_timezone(datetime_str: str) -> datetime:
         "PST": gettz("America/Los_Angeles"),
         "AKST": gettz("America/Anchorage"),
         "HST": gettz("Pacific/Honolulu"),
+        "CHST": gettz("Pacific/Guam"),
+        "SST": gettz("Pacific/Samoa"),
+        "AST": gettz("America/Puerto_Rico"),
         # US daylight saving time timezones
         "EDT": gettz("America/New_York"),
         "CDT": gettz("America/Chicago"),
         "MDT": gettz("America/Denver"),
         "PDT": gettz("America/Los_Angeles"),
         "AKDT": gettz("America/Anchorage"),
-        "HDT": gettz(
-            "Pacific/Honolulu"
-        ),  # Pacific/Honolulu doesn't observe DST
+        "HDT": gettz("Pacific/Honolulu"),
+        # CHST, SST and AST, dont' observe DST.
     }
     return parser.parse(datetime_str, tzinfos=tzinfos)
+
+
+def set_pacer_doc_id_as_appellate_document_number(
+    de: Dict[str, Union[str, date, datetime]]
+) -> None:
+    """For appellate courts that don't use numbers, if available set the
+    pacer_doc_id as document number.
+
+    :param de: The docket entry dict to set the document number.
+    :return: None, the dict is modified in place.
+    """
+    if not de["document_number"]:
+        if de["pacer_doc_id"]:
+            # If we lack the document number, but have
+            # the pacer doc ID, use it.
+            de["document_number"] = de["pacer_doc_id"]
+        else:
+            # We lack both the document number and the pacer doc ID.
+            # Probably a minute order. No need to set either.
+            pass

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -4,8 +4,6 @@ from typing import Dict, Optional, Union
 
 import requests
 import tldextract
-from dateutil import parser
-from dateutil.tz import gettz
 from lxml import html
 
 from ..lib.exceptions import ParsingException
@@ -299,37 +297,6 @@ def get_pdf_url(court, pacer_case_id, document_number, attachment_number):
             court, pacer_case_id, document_number, attachment_number
         ),
     )
-
-
-def parse_datetime_for_us_timezone(datetime_str: str) -> datetime:
-    """Parse a datetime from a string that contains a US timezone.
-
-    :param datetime_str: The str datetime to parse.
-    :return: A datetime object with UTC timezone offset.
-    """
-
-    # Supported US timezones.
-    tzinfos = {
-        # US standard timezones
-        "EST": gettz("America/New_York"),
-        "CST": gettz("America/Chicago"),
-        "MST": gettz("America/Denver"),
-        "PST": gettz("America/Los_Angeles"),
-        "AKST": gettz("America/Anchorage"),
-        "HST": gettz("Pacific/Honolulu"),
-        "CHST": gettz("Pacific/Guam"),
-        "SST": gettz("Pacific/Samoa"),
-        "AST": gettz("America/Puerto_Rico"),
-        # US daylight saving time timezones
-        "EDT": gettz("America/New_York"),
-        "CDT": gettz("America/Chicago"),
-        "MDT": gettz("America/Denver"),
-        "PDT": gettz("America/Los_Angeles"),
-        "AKDT": gettz("America/Anchorage"),
-        "HDT": gettz("Pacific/Honolulu"),
-        # CHST, SST and AST, dont' observe DST.
-    }
-    return parser.parse(datetime_str, tzinfos=tzinfos)
 
 
 def set_pacer_doc_id_as_appellate_document_number(

--- a/juriscraper/pacer/utils.py
+++ b/juriscraper/pacer/utils.py
@@ -1,8 +1,11 @@
 import re
+from datetime import datetime
 from typing import Optional
 
 import requests
 import tldextract
+from dateutil import parser
+from dateutil.tz import gettz
 from lxml import html
 
 from ..lib.exceptions import ParsingException
@@ -296,3 +299,32 @@ def get_pdf_url(court, pacer_case_id, document_number, attachment_number):
             court, pacer_case_id, document_number, attachment_number
         ),
     )
+
+
+def parse_datetime_for_us_timezone(datetime_str: str) -> datetime:
+    """Parse a datetime from a string that contains a US timezone.
+
+    :param datetime_str: The str datetime to parse.
+    :return: A datetime object with UTC timezone offset.
+    """
+
+    # Supported US timezones.
+    tzinfos = {
+        # US standard timezones
+        "EST": gettz("America/New_York"),
+        "CST": gettz("America/Chicago"),
+        "MST": gettz("America/Denver"),
+        "PST": gettz("America/Los_Angeles"),
+        "AKST": gettz("America/Anchorage"),
+        "HST": gettz("Pacific/Honolulu"),
+        # US daylight saving time timezones
+        "EDT": gettz("America/New_York"),
+        "CDT": gettz("America/Chicago"),
+        "MDT": gettz("America/Denver"),
+        "PDT": gettz("America/Los_Angeles"),
+        "AKDT": gettz("America/Anchorage"),
+        "HDT": gettz(
+            "Pacific/Honolulu"
+        ),  # Pacific/Honolulu doesn't observe DST
+    }
+    return parser.parse(datetime_str, tzinfos=tzinfos)

--- a/tests/examples/pacer/rss_feeds/ca10.json
+++ b/tests/examples/pacer/rss_feeds/ca10.json
@@ -1,0 +1,188 @@
+[
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Kahn",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca10",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T09:05:16-07:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "010010807970",
+        "short_description": "Case termination for opinion"
+      }
+    ],
+    "docket_number": "19-8054",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Singh v. Garland",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca10",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T08:50:47-07:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "010010807953",
+        "short_description": "Case termination for order and judgment"
+      }
+    ],
+    "docket_number": "21-9589",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Acosta v. Wilson",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca10",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T08:28:28-07:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "010010807929",
+        "short_description": "Case termination for order and judgment"
+      }
+    ],
+    "docket_number": "22-1120",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Pacheco",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca10",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T08:11:51-07:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "010010807922",
+        "short_description": "Case termination for order and judgment"
+      }
+    ],
+    "docket_number": "22-1298",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Noseep",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca10",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T13:02:53-07:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "010010807580",
+        "short_description": "Case termination without a panel"
+      }
+    ],
+    "docket_number": "22-8039",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Board of Education for the Gallup-McKinley County v. EDUC",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca10",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T11:41:49-07:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "010010807448",
+        "short_description": "Case termination without a panel"
+      }
+    ],
+    "docket_number": "21-9568",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  }
+]

--- a/tests/examples/pacer/rss_feeds/ca10.json
+++ b/tests/examples/pacer/rss_feeds/ca10.json
@@ -14,7 +14,7 @@
       {
         "date_filed": "2023-02-03T09:05:16-07:00",
         "description": "",
-        "document_number": null,
+        "document_number": "010010807970",
         "pacer_doc_id": "010010807970",
         "short_description": "Case termination for opinion"
       }
@@ -45,7 +45,7 @@
       {
         "date_filed": "2023-02-03T08:50:47-07:00",
         "description": "",
-        "document_number": null,
+        "document_number": "010010807953",
         "pacer_doc_id": "010010807953",
         "short_description": "Case termination for order and judgment"
       }
@@ -76,7 +76,7 @@
       {
         "date_filed": "2023-02-03T08:28:28-07:00",
         "description": "",
-        "document_number": null,
+        "document_number": "010010807929",
         "pacer_doc_id": "010010807929",
         "short_description": "Case termination for order and judgment"
       }
@@ -107,7 +107,7 @@
       {
         "date_filed": "2023-02-03T08:11:51-07:00",
         "description": "",
-        "document_number": null,
+        "document_number": "010010807922",
         "pacer_doc_id": "010010807922",
         "short_description": "Case termination for order and judgment"
       }
@@ -138,7 +138,7 @@
       {
         "date_filed": "2023-02-02T13:02:53-07:00",
         "description": "",
-        "document_number": null,
+        "document_number": "010010807580",
         "pacer_doc_id": "010010807580",
         "short_description": "Case termination without a panel"
       }
@@ -169,7 +169,7 @@
       {
         "date_filed": "2023-02-02T11:41:49-07:00",
         "description": "",
-        "document_number": null,
+        "document_number": "010010807448",
         "pacer_doc_id": "010010807448",
         "short_description": "Case termination without a panel"
       }

--- a/tests/examples/pacer/rss_feeds/ca10.xml
+++ b/tests/examples/pacer/rss_feeds/ca10.xml
@@ -1,0 +1,60 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+
+<rss version="2.0" xmlns:blogChannel="http://backend.userland.com/blogChannelModule">
+
+<channel>
+	<title>Tenth Circuit Court of Appeals - Recent Entries</title>
+	<link>https://ecf.ca10.uscourts.gov</link>
+	<description>Docket entries of type: opinions</description>
+	<lastBuildDate>Fri, 03 Feb 2023 10:58:42 MST</lastBuildDate>
+<item>
+	<title>19-8054 United States v. Kahn</title>
+	<link>https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=19-8054</link>
+	<description>[Case termination for opinion] (&lt;a href='https://ecf.ca10.uscourts.gov/docs1/010010807970'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=19-8054&amp;partId=10974397</guid>
+	<pubDate>Fri, 03 Feb 2023 09:05:16 MST</pubDate>
+
+</item>
+<item>
+	<title>21-9589 Singh v. Garland</title>
+	<link>https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-9589</link>
+	<description>[Case termination for order and judgment] (&lt;a href='https://ecf.ca10.uscourts.gov/docs1/010010807953'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-9589&amp;partId=10974386</guid>
+	<pubDate>Fri, 03 Feb 2023 08:50:47 MST</pubDate>
+
+</item>
+<item>
+	<title>22-1120 Acosta v. Wilson, et al</title>
+	<link>https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1120</link>
+	<description>[Case termination for order and judgment] (&lt;a href='https://ecf.ca10.uscourts.gov/docs1/010010807929'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1120&amp;partId=10974365</guid>
+	<pubDate>Fri, 03 Feb 2023 08:28:28 MST</pubDate>
+
+</item>
+<item>
+	<title>22-1298 United States v. Pacheco</title>
+	<link>https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1298</link>
+	<description>[Case termination for order and judgment] (&lt;a href='https://ecf.ca10.uscourts.gov/docs1/010010807922'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1298&amp;partId=10974359</guid>
+	<pubDate>Fri, 03 Feb 2023 08:11:51 MST</pubDate>
+
+</item>
+<item>
+	<title>22-8039 United States v. Noseep</title>
+	<link>https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-8039</link>
+	<description>[Case termination without a panel] (&lt;a href='https://ecf.ca10.uscourts.gov/docs1/010010807580'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-8039&amp;partId=10974163</guid>
+	<pubDate>Thu, 02 Feb 2023 13:02:53 MST</pubDate>
+
+</item>
+<item>
+	<title>21-9568 Board of Education for the Gallup-McKinley County, et al v. EDUC</title>
+	<link>https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-9568</link>
+	<description>[Case termination without a panel] (&lt;a href='https://ecf.ca10.uscourts.gov/docs1/010010807448'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca10.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-9568&amp;partId=10974101</guid>
+	<pubDate>Thu, 02 Feb 2023 11:41:49 MST</pubDate>
+
+</item>
+
+</channel>
+</rss>

--- a/tests/examples/pacer/rss_feeds/ca11.json
+++ b/tests/examples/pacer/rss_feeds/ca11.json
@@ -1,0 +1,312 @@
+[
+  {
+    "assigned_to_str": "",
+    "case_name": "Joseph Nichols, Jr. v. Secretary, Florida Department of Corrections",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca11",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:58:25-05:00",
+        "description": "",
+        "document_number": "23",
+        "pacer_doc_id": "011012658791",
+        "short_description": "Opinion Issued"
+      }
+    ],
+    "docket_number": "21-14262",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Paul Jackson v. Midnight Express Power Boats, Inc.",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca11",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:35:19-05:00",
+        "description": "",
+        "document_number": "31",
+        "pacer_doc_id": "011012658730",
+        "short_description": "Opinion Issued"
+      }
+    ],
+    "docket_number": "22-11012",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Francisco Fajardo-Rebollar v. U.S. Attorney General",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca11",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:02:47-05:00",
+        "description": "",
+        "document_number": "30",
+        "pacer_doc_id": "011012658562",
+        "short_description": "Opinion Issued"
+      }
+    ],
+    "docket_number": "21-10390",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Yves Santais v. U.S. Attorney General",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca11",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T09:31:21-05:00",
+        "description": "",
+        "document_number": "22",
+        "pacer_doc_id": "011012658438",
+        "short_description": "Opinion Issued"
+      }
+    ],
+    "docket_number": "22-10567",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Brenda Thomas v. Clayton County Board of Commissioners",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca11",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T08:43:21-05:00",
+        "description": "",
+        "document_number": "22",
+        "pacer_doc_id": "011012658304",
+        "short_description": "Opinion Issued"
+      }
+    ],
+    "docket_number": "22-10762",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Craig German",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca11",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T15:24:38-05:00",
+        "description": "",
+        "document_number": "28",
+        "pacer_doc_id": "011012657673",
+        "short_description": "Opinion Issued"
+      }
+    ],
+    "docket_number": "22-11811",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Andrae Crook",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca11",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T14:55:44-05:00",
+        "description": "",
+        "document_number": "28",
+        "pacer_doc_id": "011012657555",
+        "short_description": "Opinion Issued"
+      }
+    ],
+    "docket_number": "22-10942",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Jeffrey Spivack",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca11",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T14:39:53-05:00",
+        "description": "",
+        "document_number": "47",
+        "pacer_doc_id": "011012657489",
+        "short_description": "Opinion Issued"
+      }
+    ],
+    "docket_number": "21-12788",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Marvas Aurelien",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca11",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T14:27:00-05:00",
+        "description": "",
+        "document_number": "45",
+        "pacer_doc_id": "011012657406",
+        "short_description": "Opinion Issued"
+      }
+    ],
+    "docket_number": "21-12995",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Robert Vazzo v. City of Tampa, Florida",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca11",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T12:52:25-05:00",
+        "description": "",
+        "document_number": "77",
+        "pacer_doc_id": "011012657099",
+        "short_description": "Opinion Issued"
+      }
+    ],
+    "docket_number": "19-14387",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  }
+]

--- a/tests/examples/pacer/rss_feeds/ca11.xml
+++ b/tests/examples/pacer/rss_feeds/ca11.xml
@@ -1,0 +1,92 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+
+<rss version="2.0" xmlns:blogChannel="http://backend.userland.com/blogChannelModule">
+
+<channel>
+	<title>United States Court of Appeals for the Eleventh Circuit - Recent Entries</title>
+	<link>https://ecf.ca11.uscourts.gov</link>
+	<description>Docket entries of type: opinions</description>
+	<lastBuildDate>Fri, 03 Feb 2023 12:31:34 EST</lastBuildDate>
+<item>
+	<title>21-14262 Joseph Nichols, Jr. v. Secretary, Florida Department of Corrections, et al</title>
+	<link>https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-14262</link>
+	<description>[Opinion Issued] (&lt;a href='https://ecf.ca11.uscourts.gov/docs1/011012658791'>23&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-14262&amp;partId=9861632</guid>
+	<pubDate>Fri, 03 Feb 2023 10:58:25 EST</pubDate>
+
+</item>
+<item>
+	<title>22-11012 Paul Jackson v. Midnight Express Power Boats, Inc.</title>
+	<link>https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-11012</link>
+	<description>[Opinion Issued] (&lt;a href='https://ecf.ca11.uscourts.gov/docs1/011012658730'>31&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-11012&amp;partId=9861608</guid>
+	<pubDate>Fri, 03 Feb 2023 10:35:19 EST</pubDate>
+
+</item>
+<item>
+	<title>21-10390 Francisco Fajardo-Rebollar v. U.S. Attorney General</title>
+	<link>https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-10390</link>
+	<description>[Opinion Issued] (&lt;a href='https://ecf.ca11.uscourts.gov/docs1/011012658562'>30&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-10390&amp;partId=9861523</guid>
+	<pubDate>Fri, 03 Feb 2023 10:02:47 EST</pubDate>
+
+</item>
+<item>
+	<title>22-10567 Yves Santais v. U.S. Attorney General</title>
+	<link>https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-10567</link>
+	<description>[Opinion Issued] (&lt;a href='https://ecf.ca11.uscourts.gov/docs1/011012658438'>22&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-10567&amp;partId=9861450</guid>
+	<pubDate>Fri, 03 Feb 2023 09:31:21 EST</pubDate>
+
+</item>
+<item>
+	<title>22-10762 Brenda Thomas v. Clayton County Board of Commissioners, et al</title>
+	<link>https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-10762</link>
+	<description>[Opinion Issued] (&lt;a href='https://ecf.ca11.uscourts.gov/docs1/011012658304'>22&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-10762&amp;partId=9861376</guid>
+	<pubDate>Fri, 03 Feb 2023 08:43:21 EST</pubDate>
+
+</item>
+<item>
+	<title>22-11811 USA v. Craig German</title>
+	<link>https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-11811</link>
+	<description>[Opinion Issued] (&lt;a href='https://ecf.ca11.uscourts.gov/docs1/011012657673'>28&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-11811&amp;partId=9861055</guid>
+	<pubDate>Thu, 02 Feb 2023 15:24:38 EST</pubDate>
+
+</item>
+<item>
+	<title>22-10942 USA v. Andrae Crook</title>
+	<link>https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-10942</link>
+	<description>[Opinion Issued] (&lt;a href='https://ecf.ca11.uscourts.gov/docs1/011012657555'>28&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-10942&amp;partId=9860982</guid>
+	<pubDate>Thu, 02 Feb 2023 14:55:44 EST</pubDate>
+
+</item>
+<item>
+	<title>21-12788 USA v. Jeffrey Spivack</title>
+	<link>https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-12788</link>
+	<description>[Opinion Issued] (&lt;a href='https://ecf.ca11.uscourts.gov/docs1/011012657489'>47&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-12788&amp;partId=9860947</guid>
+	<pubDate>Thu, 02 Feb 2023 14:39:53 EST</pubDate>
+
+</item>
+<item>
+	<title>21-12995 USA v. Marvas Aurelien</title>
+	<link>https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-12995</link>
+	<description>[Opinion Issued] (&lt;a href='https://ecf.ca11.uscourts.gov/docs1/011012657406'>45&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-12995&amp;partId=9860911</guid>
+	<pubDate>Thu, 02 Feb 2023 14:27:00 EST</pubDate>
+
+</item>
+<item>
+	<title>19-14387 Robert Vazzo, et al v. City of Tampa, Florida</title>
+	<link>https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=19-14387</link>
+	<description>[Opinion Issued] (&lt;a href='https://ecf.ca11.uscourts.gov/docs1/011012657099'>77&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca11.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=19-14387&amp;partId=9860761</guid>
+	<pubDate>Thu, 02 Feb 2023 12:52:25 EST</pubDate>
+
+</item>
+
+</channel>
+</rss>

--- a/tests/examples/pacer/rss_feeds/ca2_1.json
+++ b/tests/examples/pacer/rss_feeds/ca2_1.json
@@ -1,0 +1,126 @@
+[
+  {
+    "assigned_to_str": "",
+    "case_name": "Haller v. U.S. Department of Health and Human Services",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca2",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:52:07-05:00",
+        "description": "",
+        "document_number": "27",
+        "pacer_doc_id": "00209229396",
+        "short_description": "So-Ordered Scheduling Notification FILED"
+      }
+    ],
+    "docket_number": "22-3054",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "In re: Maura Lynch",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca2",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:43:01-05:00",
+        "description": "",
+        "document_number": "48",
+        "pacer_doc_id": "00209229372",
+        "short_description": "So-Ordered Scheduling Notification FILED"
+      }
+    ],
+    "docket_number": "22-1495",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Fredricks v. Debra",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca2",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:39:11-05:00",
+        "description": "",
+        "document_number": "38",
+        "pacer_doc_id": "00209229354",
+        "short_description": "Motion Order FILED"
+      }
+    ],
+    "docket_number": "22-1406",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Rodriguez v. United States",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca2",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:18:02-05:00",
+        "description": "",
+        "document_number": "46",
+        "pacer_doc_id": "00209229291",
+        "short_description": "Strike Order FILED"
+      }
+    ],
+    "docket_number": "22-1684",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  }
+]

--- a/tests/examples/pacer/rss_feeds/ca2_1.xml
+++ b/tests/examples/pacer/rss_feeds/ca2_1.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+
+<rss version="2.0" xmlns:blogChannel="http://backend.userland.com/blogChannelModule">
+
+<channel>
+	<title>Court of Appeals, 2nd Circuit - Recent Entries</title>
+	<link>https://ecf.ca2.uscourts.gov</link>
+	<description>Docket entries of type: orders, opinions</description>
+	<lastBuildDate>Fri, 03 Feb 2023 12:33:06 EST</lastBuildDate>
+<item>
+	<title>22-3054 Haller v. U.S. Department of Health and Human Services</title>
+	<link>https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-3054</link>
+	<description>[So-Ordered Scheduling Notification FILED] (&lt;a href='https://ecf.ca2.uscourts.gov/docs1/00209229396'>27&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-3054&amp;partId=3463600</guid>
+	<pubDate>Fri, 03 Feb 2023 11:52:07 EST</pubDate>
+
+</item>
+<item>
+	<title>22-1495 In re: Maura Lynch</title>
+	<link>https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1495</link>
+	<description>[So-Ordered Scheduling Notification FILED] (&lt;a href='https://ecf.ca2.uscourts.gov/docs1/00209229372'>48&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1495&amp;partId=3463593</guid>
+	<pubDate>Fri, 03 Feb 2023 11:43:01 EST</pubDate>
+
+</item>
+<item>
+	<title>22-1406 Fredricks v. Debra</title>
+	<link>https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1406</link>
+	<description>[Motion Order FILED] (&lt;a href='https://ecf.ca2.uscourts.gov/docs1/00209229354'>38&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1406&amp;partId=3463589</guid>
+	<pubDate>Fri, 03 Feb 2023 11:39:11 EST</pubDate>
+
+</item>
+<item>
+	<title>22-1684 Rodriguez v. United States of America</title>
+	<link>https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1684</link>
+	<description>[Strike Order FILED] (&lt;a href='https://ecf.ca2.uscourts.gov/docs1/00209229291'>46&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca2.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1684&amp;partId=3463562</guid>
+	<pubDate>Fri, 03 Feb 2023 11:18:02 EST</pubDate>
+
+</item>
+</channel>
+</rss>

--- a/tests/examples/pacer/rss_feeds/ca4_1.json
+++ b/tests/examples/pacer/rss_feeds/ca4_1.json
@@ -1,0 +1,622 @@
+[
+  {
+    "assigned_to_str": "",
+    "case_name": "Alden Harden v. Jamel Jackson",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T12:20:16-05:00",
+        "description": "",
+        "document_number": "95",
+        "pacer_doc_id": "00409219058",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "11-8",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Charlie Hardin v. D. Everett",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T12:08:02-05:00",
+        "description": "",
+        "document_number": "3",
+        "pacer_doc_id": "00409219066",
+        "short_description": "Informal briefing order filed"
+      }
+    ],
+    "docket_number": "23-6105",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Leonard Harris v. Albert Presto",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:47:19-05:00",
+        "description": "",
+        "document_number": "4",
+        "pacer_doc_id": "00409218974",
+        "short_description": "Informal briefing order filed"
+      }
+    ],
+    "docket_number": "23-1124",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Donte Baker v. Warden FCI Williamsburg",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:42:20-05:00",
+        "description": "",
+        "document_number": "3",
+        "pacer_doc_id": "00409218950",
+        "short_description": "Informal briefing order filed"
+      }
+    ],
+    "docket_number": "23-6106",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. James Squire",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:28:09-05:00",
+        "description": "",
+        "document_number": "2",
+        "pacer_doc_id": "00409218908",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "23-4060",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Jeffrey Cohen v. United States",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:24:33-05:00",
+        "description": "",
+        "document_number": "14",
+        "pacer_doc_id": "00409218911",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "22-7158",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Marvin Minor",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:18:10-05:00",
+        "description": "",
+        "document_number": "18",
+        "pacer_doc_id": "00409218872",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "22-4492",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Leonard Harris v. Albert Presto",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:16:31-05:00",
+        "description": "",
+        "document_number": "3",
+        "pacer_doc_id": "00409218867",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "23-1124",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Robert Barnes",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:08:54-05:00",
+        "description": "",
+        "document_number": "59",
+        "pacer_doc_id": "00409218846",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "20-4482",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Siobhan James v. RPS Holdings, LLC",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:06:59-05:00",
+        "description": "",
+        "document_number": "28",
+        "pacer_doc_id": "00409218841",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "22-1027",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Ana Martinez Hernandez v. Merrick Garland",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:02:58-05:00",
+        "description": "",
+        "document_number": "21",
+        "pacer_doc_id": "00409218836",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "22-2033",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. James Noyes",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:54:04-05:00",
+        "description": "",
+        "document_number": "11",
+        "pacer_doc_id": "00409218811",
+        "short_description": "Briefing order filed"
+      }
+    ],
+    "docket_number": "23-4014",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Ricky Abner",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:52:06-05:00",
+        "description": "",
+        "document_number": "8",
+        "pacer_doc_id": "00409218804",
+        "short_description": "Briefing order filed"
+      }
+    ],
+    "docket_number": "23-4018",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Blazine Monaco v. WV Parkways Authority",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:46:03-05:00",
+        "description": "",
+        "document_number": "60",
+        "pacer_doc_id": "00409218776",
+        "short_description": "Court order filed"
+      }
+    ],
+    "docket_number": "21-1230",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. James Noyes",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:45:03-05:00",
+        "description": "",
+        "document_number": "10",
+        "pacer_doc_id": "00409218801",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "23-4014",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Jamaile Huey",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:35:01-05:00",
+        "description": "",
+        "document_number": "22",
+        "pacer_doc_id": "00409218765",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "21-4374",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Tildren Hunter",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:28:19-05:00",
+        "description": "",
+        "document_number": "35",
+        "pacer_doc_id": "00409218735",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "22-4300",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Elizabeth Langston v. Commissioner of Social Security Administration",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:16:07-05:00",
+        "description": "",
+        "document_number": "22",
+        "pacer_doc_id": "00409218690",
+        "short_description": "Judgment order filed"
+      }
+    ],
+    "docket_number": "22-1257",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Abdulkadir Nur v. Unknown CBP Officers",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:15:32-05:00",
+        "description": "",
+        "document_number": "17",
+        "pacer_doc_id": "00409218691",
+        "short_description": "Order filed"
+      }
+    ],
+    "docket_number": "23-1057",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Elizabeth Langston v. Commissioner of Social Security Administration",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca4",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:14:03-05:00",
+        "description": "",
+        "document_number": "21",
+        "pacer_doc_id": "00409218678",
+        "short_description": "Unpublished per curiam opinion filed"
+      }
+    ],
+    "docket_number": "22-1257",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  }
+]

--- a/tests/examples/pacer/rss_feeds/ca4_1.xml
+++ b/tests/examples/pacer/rss_feeds/ca4_1.xml
@@ -1,0 +1,171 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+
+<rss version="2.0" xmlns:blogChannel="http://backend.userland.com/blogChannelModule">
+
+<channel>
+	<title>United States Court of Appeals for the Fourth Circuit - Recent Entries</title>
+	<link>https://ecf.ca4.uscourts.gov</link>
+	<description>Docket entries of type: orders, opinions, judgments</description>
+	<lastBuildDate>Fri, 03 Feb 2023 12:35:03 EST</lastBuildDate>
+<item>
+	<title>11-8 Alden Harden v. Jamel Jackson</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=11-8</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409219058'>95&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=11-8&amp;partId=1001310265</guid>
+	<pubDate>Fri, 03 Feb 2023 12:20:16 EST</pubDate>
+
+</item>
+<item>
+	<title>23-6105 Charlie Hardin v. D. Everett</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-6105</link>
+	<description>[Informal briefing order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409219066'>3&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-6105&amp;partId=1001310251</guid>
+	<pubDate>Fri, 03 Feb 2023 12:08:02 EST</pubDate>
+
+</item>
+<item>
+	<title>23-1124 Leonard Harris v. Albert Presto</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-1124</link>
+	<description>[Informal briefing order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218974'>4&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-1124&amp;partId=1001310225</guid>
+	<pubDate>Fri, 03 Feb 2023 11:47:19 EST</pubDate>
+
+</item>
+<item>
+	<title>23-6106 Donte Baker v. Warden FCI Williamsburg</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-6106</link>
+	<description>[Informal briefing order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218950'>3&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-6106&amp;partId=1001310215</guid>
+	<pubDate>Fri, 03 Feb 2023 11:42:20 EST</pubDate>
+
+</item>
+<item>
+	<title>23-4060 US v. James Squire</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-4060</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218908'>2&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-4060&amp;partId=1001310195</guid>
+	<pubDate>Fri, 03 Feb 2023 11:28:09 EST</pubDate>
+
+</item>
+<item>
+	<title>22-7158 Jeffrey Cohen v. US</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-7158</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218911'>14&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-7158&amp;partId=1001310190</guid>
+	<pubDate>Fri, 03 Feb 2023 11:24:33 EST</pubDate>
+
+</item>
+<item>
+	<title>22-4492 US v. Marvin Minor</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-4492</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218872'>18&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-4492&amp;partId=1001310182</guid>
+	<pubDate>Fri, 03 Feb 2023 11:18:10 EST</pubDate>
+
+</item>
+<item>
+	<title>23-1124 Leonard Harris v. Albert Presto</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-1124</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218867'>3&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-1124&amp;partId=1001310177</guid>
+	<pubDate>Fri, 03 Feb 2023 11:16:31 EST</pubDate>
+
+</item>
+<item>
+	<title>20-4482 US v. Robert Barnes</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=20-4482</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218846'>59&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=20-4482&amp;partId=1001310163</guid>
+	<pubDate>Fri, 03 Feb 2023 11:08:54 EST</pubDate>
+
+</item>
+<item>
+	<title>22-1027 Siobhan James v. RPS Holdings, LLC</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1027</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218841'>28&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1027&amp;partId=1001310159</guid>
+	<pubDate>Fri, 03 Feb 2023 11:06:59 EST</pubDate>
+
+</item>
+<item>
+	<title>22-2033 Ana Martinez Hernandez v. Merrick Garland</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-2033</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218836'>21&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-2033&amp;partId=1001310153</guid>
+	<pubDate>Fri, 03 Feb 2023 11:02:58 EST</pubDate>
+
+</item>
+<item>
+	<title>23-4014 US v. James Noyes</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-4014</link>
+	<description>[Briefing order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218811'>11&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-4014&amp;partId=1001310143</guid>
+	<pubDate>Fri, 03 Feb 2023 10:54:04 EST</pubDate>
+
+</item>
+<item>
+	<title>23-4018 US v. Ricky Abner</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-4018</link>
+	<description>[Briefing order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218804'>8&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-4018&amp;partId=1001310138</guid>
+	<pubDate>Fri, 03 Feb 2023 10:52:06 EST</pubDate>
+
+</item>
+<item>
+	<title>21-1230 Blazine Monaco v. WV Parkways Authority</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-1230</link>
+	<description>[Court order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218776'>60&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-1230&amp;partId=1001310129</guid>
+	<pubDate>Fri, 03 Feb 2023 10:46:03 EST</pubDate>
+
+</item>
+<item>
+	<title>23-4014 US v. James Noyes</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-4014</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218801'>10&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-4014&amp;partId=1001310127</guid>
+	<pubDate>Fri, 03 Feb 2023 10:45:03 EST</pubDate>
+
+</item>
+<item>
+	<title>21-4374 US v. Jamaile Huey</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-4374</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218765'>22&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-4374&amp;partId=1001310119</guid>
+	<pubDate>Fri, 03 Feb 2023 10:35:01 EST</pubDate>
+
+</item>
+<item>
+	<title>22-4300 US v. Tildren Hunter</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-4300</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218735'>35&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-4300&amp;partId=1001310109</guid>
+	<pubDate>Fri, 03 Feb 2023 10:28:19 EST</pubDate>
+
+</item>
+<item>
+	<title>22-1257 Elizabeth Langston v. Commissioner of Social Security Administration</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1257</link>
+	<description>[Judgment order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218690'>22&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1257&amp;partId=1001310088</guid>
+	<pubDate>Fri, 03 Feb 2023 10:16:07 EST</pubDate>
+
+</item>
+<item>
+	<title>23-1057 Abdulkadir Nur v. Unknown CBP Officers</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-1057</link>
+	<description>[Order filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218691'>17&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-1057&amp;partId=1001310085</guid>
+	<pubDate>Fri, 03 Feb 2023 10:15:32 EST</pubDate>
+
+</item>
+<item>
+	<title>22-1257 Elizabeth Langston v. Commissioner of Social Security Administration</title>
+	<link>https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1257</link>
+	<description>[Unpublished per curiam opinion filed] (&lt;a href='https://ecf.ca4.uscourts.gov/docs1/00409218678'>21&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca4.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1257&amp;partId=1001310082</guid>
+	<pubDate>Fri, 03 Feb 2023 10:14:03 EST</pubDate>
+
+</item>
+</channel>
+</rss>

--- a/tests/examples/pacer/rss_feeds/ca6.json
+++ b/tests/examples/pacer/rss_feeds/ca6.json
@@ -1,0 +1,282 @@
+[
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Shantel Caldwell",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca6",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T12:07:00-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "",
+        "pacer_seq_no": null,
+        "short_description": "ruling"
+      }
+    ],
+    "docket_number": "23-1104",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Jeffrey Kaiser",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca6",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:44:34-05:00",
+        "description": "",
+        "document_number": "40",
+        "pacer_doc_id": "006014913158",
+        "short_description": "judge order filed"
+      }
+    ],
+    "docket_number": "21-1611",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Calvin Starks",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca6",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:32:55-05:00",
+        "description": "",
+        "document_number": "42",
+        "pacer_doc_id": "006014913147",
+        "short_description": "ruling letter sent"
+      }
+    ],
+    "docket_number": "21-5984",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Darek Lathan v. Matthew Simko",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca6",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:16:41-05:00",
+        "description": "",
+        "document_number": "13",
+        "pacer_doc_id": "006014913121",
+        "short_description": "clerk order filed"
+      }
+    ],
+    "docket_number": "22-3439",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Juan Arroyo",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca6",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:06:04-05:00",
+        "description": "",
+        "document_number": "33",
+        "pacer_doc_id": "006014913098",
+        "short_description": "unpublished opinion and judgment filed"
+      }
+    ],
+    "docket_number": "21-1845",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Calvin Caver",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca6",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T10:39:37-05:00",
+        "description": "",
+        "document_number": "24",
+        "pacer_doc_id": "006014913087",
+        "short_description": "ruling letter sent"
+      }
+    ],
+    "docket_number": "21-3753",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Adarius Ferguson",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca6",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T14:05:19-05:00",
+        "description": "",
+        "document_number": "21",
+        "pacer_doc_id": "006014912254",
+        "short_description": "clerk order filed"
+      }
+    ],
+    "docket_number": "22-2151",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Cory McNeal",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca6",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T13:49:12-05:00",
+        "description": "",
+        "document_number": "23",
+        "pacer_doc_id": "006014912187",
+        "short_description": "ruling letter sent"
+      }
+    ],
+    "docket_number": "22-5847",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. William Reid",
+    "cause": "",
+    "chapter": "",
+    "court_id": "ca6",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T13:37:46-05:00",
+        "description": "",
+        "document_number": "14",
+        "pacer_doc_id": "006014912156",
+        "short_description": "ruling letter sent"
+      }
+    ],
+    "docket_number": "22-5928",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  }
+]

--- a/tests/examples/pacer/rss_feeds/ca6.xml
+++ b/tests/examples/pacer/rss_feeds/ca6.xml
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+
+<rss version="2.0" xmlns:blogChannel="http://backend.userland.com/blogChannelModule">
+
+<channel>
+	<title>United States Court of Appeals for the Sixth Circuit - Recent Entries</title>
+	<link>https://ecf.ca6.uscourts.gov</link>
+	<description>Docket entries of type: orders,opinions,judgments</description>
+	<lastBuildDate>Fri, 03 Feb 2023 12:42:52 EST</lastBuildDate>
+<item>
+	<title>23-1104 USA v. Shantel Caldwell</title>
+	<link>https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-1104</link>
+	<description>[ruling]</description>
+	<guid isPermaLink="true">https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-1104&amp;partId=6940522</guid>
+	<pubDate>Fri, 03 Feb 2023 12:07:00 EST</pubDate>
+
+</item>
+<item>
+	<title>21-1611 USA v. Jeffrey Kaiser</title>
+	<link>https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-1611</link>
+	<description>[judge order filed] (&lt;a href='https://ecf.ca6.uscourts.gov/docs1/006014913158'>40&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-1611&amp;partId=6940494</guid>
+	<pubDate>Fri, 03 Feb 2023 11:44:34 EST</pubDate>
+
+</item>
+<item>
+	<title>21-5984 USA v. Calvin Starks</title>
+	<link>https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-5984</link>
+	<description>[ruling letter sent] (&lt;a href='https://ecf.ca6.uscourts.gov/docs1/006014913147'>42&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-5984&amp;partId=6940484</guid>
+	<pubDate>Fri, 03 Feb 2023 11:32:55 EST</pubDate>
+
+</item>
+<item>
+	<title>22-3439 Darek Lathan v. Matthew Simko, et al</title>
+	<link>https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-3439</link>
+	<description>[clerk order filed] (&lt;a href='https://ecf.ca6.uscourts.gov/docs1/006014913121'>13&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-3439&amp;partId=6940470</guid>
+	<pubDate>Fri, 03 Feb 2023 11:16:41 EST</pubDate>
+
+</item>
+<item>
+	<title>21-1845 USA v. Juan Arroyo</title>
+	<link>https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-1845</link>
+	<description>[unpublished opinion and judgment filed] (&lt;a href='https://ecf.ca6.uscourts.gov/docs1/006014913098'>33&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-1845&amp;partId=6940458</guid>
+	<pubDate>Fri, 03 Feb 2023 11:06:04 EST</pubDate>
+
+</item>
+<item>
+	<title>21-3753 USA v. Calvin Caver</title>
+	<link>https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-3753</link>
+	<description>[ruling letter sent] (&lt;a href='https://ecf.ca6.uscourts.gov/docs1/006014913087'>24&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=21-3753&amp;partId=6940433</guid>
+	<pubDate>Fri, 03 Feb 2023 10:39:37 EST</pubDate>
+
+</item>
+<item>
+	<title>22-2151 USA v. Adarius Ferguson</title>
+	<link>https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-2151</link>
+	<description>[clerk order filed] (&lt;a href='https://ecf.ca6.uscourts.gov/docs1/006014912254'>21&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-2151&amp;partId=6939939</guid>
+	<pubDate>Thu, 02 Feb 2023 14:05:19 EST</pubDate>
+
+</item>
+<item>
+	<title>22-5847 USA v. Cory McNeal</title>
+	<link>https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-5847</link>
+	<description>[ruling letter sent] (&lt;a href='https://ecf.ca6.uscourts.gov/docs1/006014912187'>23&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-5847&amp;partId=6939919</guid>
+	<pubDate>Thu, 02 Feb 2023 13:49:12 EST</pubDate>
+
+</item>
+<item>
+	<title>22-5928 USA v. William Reid</title>
+	<link>https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-5928</link>
+	<description>[ruling letter sent] (&lt;a href='https://ecf.ca6.uscourts.gov/docs1/006014912156'>14&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.ca6.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-5928&amp;partId=6939909</guid>
+	<pubDate>Thu, 02 Feb 2023 13:37:46 EST</pubDate>
+
+</item>
+
+</channel>
+</rss>

--- a/tests/examples/pacer/rss_feeds/cadc.json
+++ b/tests/examples/pacer/rss_feeds/cadc.json
@@ -1,0 +1,405 @@
+[
+  {
+    "assigned_to_str": "",
+    "case_name": "Food & Water Watch v. FERC",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:57:38-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208491112",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "22-1214",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Food & Water Watch v. FERC",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:57:38-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208491112",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "22-1315",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Randy Koontz",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:52:44-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208491107",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "23-3014",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Stephen Ollar v. DC",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:49:57-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208491101",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "22-7131",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Tyson Brody v. DOJ",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:40:07-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208491091",
+        "short_description": "Judgment Filed (Merits Panel)"
+      }
+    ],
+    "docket_number": "22-5043",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Wye Oak Technology, Inc. v. Republic of Iraq",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:33:16-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208491086",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "23-7009",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Wye Oak Technology, Inc. v. Republic of Iraq",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T11:33:16-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208491086",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "23-7013",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States v. Dynamic Visions Inc",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T15:39:27-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208490899",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "22-7061",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Insider Inc. v. GSA",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T15:36:06-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208490895",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "22-5330",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "United States Sugar Corporation v. EPA",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T13:41:49-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208490836",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "22-1271",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "American Forest & Paper Association v. EPA",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T13:41:49-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208490836",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "22-1302",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "California Communities Against Toxics v. EPA",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T13:41:49-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208490836",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "22-1303",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Matthew Couch v. Verizon Communications Inc.",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cadc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-02T13:21:39-05:00",
+        "description": "",
+        "document_number": null,
+        "pacer_doc_id": "01208490819",
+        "short_description": "Order Filed (CLERK)"
+      }
+    ],
+    "docket_number": "22-7114",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  }
+]

--- a/tests/examples/pacer/rss_feeds/cadc.json
+++ b/tests/examples/pacer/rss_feeds/cadc.json
@@ -14,7 +14,7 @@
       {
         "date_filed": "2023-02-03T11:57:38-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208491112",
         "pacer_doc_id": "01208491112",
         "short_description": "Order Filed (CLERK)"
       }
@@ -45,7 +45,7 @@
       {
         "date_filed": "2023-02-03T11:57:38-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208491112",
         "pacer_doc_id": "01208491112",
         "short_description": "Order Filed (CLERK)"
       }
@@ -76,7 +76,7 @@
       {
         "date_filed": "2023-02-03T11:52:44-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208491107",
         "pacer_doc_id": "01208491107",
         "short_description": "Order Filed (CLERK)"
       }
@@ -107,7 +107,7 @@
       {
         "date_filed": "2023-02-03T11:49:57-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208491101",
         "pacer_doc_id": "01208491101",
         "short_description": "Order Filed (CLERK)"
       }
@@ -138,7 +138,7 @@
       {
         "date_filed": "2023-02-03T11:40:07-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208491091",
         "pacer_doc_id": "01208491091",
         "short_description": "Judgment Filed (Merits Panel)"
       }
@@ -169,7 +169,7 @@
       {
         "date_filed": "2023-02-03T11:33:16-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208491086",
         "pacer_doc_id": "01208491086",
         "short_description": "Order Filed (CLERK)"
       }
@@ -200,7 +200,7 @@
       {
         "date_filed": "2023-02-03T11:33:16-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208491086",
         "pacer_doc_id": "01208491086",
         "short_description": "Order Filed (CLERK)"
       }
@@ -231,7 +231,7 @@
       {
         "date_filed": "2023-02-02T15:39:27-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208490899",
         "pacer_doc_id": "01208490899",
         "short_description": "Order Filed (CLERK)"
       }
@@ -262,7 +262,7 @@
       {
         "date_filed": "2023-02-02T15:36:06-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208490895",
         "pacer_doc_id": "01208490895",
         "short_description": "Order Filed (CLERK)"
       }
@@ -293,7 +293,7 @@
       {
         "date_filed": "2023-02-02T13:41:49-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208490836",
         "pacer_doc_id": "01208490836",
         "short_description": "Order Filed (CLERK)"
       }
@@ -324,7 +324,7 @@
       {
         "date_filed": "2023-02-02T13:41:49-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208490836",
         "pacer_doc_id": "01208490836",
         "short_description": "Order Filed (CLERK)"
       }
@@ -355,7 +355,7 @@
       {
         "date_filed": "2023-02-02T13:41:49-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208490836",
         "pacer_doc_id": "01208490836",
         "short_description": "Order Filed (CLERK)"
       }
@@ -386,7 +386,7 @@
       {
         "date_filed": "2023-02-02T13:21:39-05:00",
         "description": "",
-        "document_number": null,
+        "document_number": "01208490819",
         "pacer_doc_id": "01208490819",
         "short_description": "Order Filed (CLERK)"
       }

--- a/tests/examples/pacer/rss_feeds/cadc.xml
+++ b/tests/examples/pacer/rss_feeds/cadc.xml
@@ -1,0 +1,116 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+
+<rss version="2.0" xmlns:blogChannel="http://backend.userland.com/blogChannelModule">
+
+<channel>
+	<title>United States Court of Appeals for District of Columbia Circuit - Recent Entries</title>
+	<link>https://ecf.cadc.uscourts.gov</link>
+	<description>Docket entries of type: orders,opinions,judgments</description>
+	<lastBuildDate>Fri, 03 Feb 2023 13:01:59 EST</lastBuildDate>
+<item>
+	<title>22-1214 Food &amp;amp; Water Watch v. FERC</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1214</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208491112'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1214&amp;partId=1984499</guid>
+	<pubDate>Fri, 03 Feb 2023 11:57:38 EST</pubDate>
+
+</item>
+<item>
+	<title>22-1315 Food &amp;amp; Water Watch v. FERC</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1315</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208491112'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1315&amp;partId=1984499</guid>
+	<pubDate>Fri, 03 Feb 2023 11:57:38 EST</pubDate>
+
+</item>
+<item>
+	<title>23-3014 USA v. Randy Koontz</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-3014</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208491107'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-3014&amp;partId=1984496</guid>
+	<pubDate>Fri, 03 Feb 2023 11:52:44 EST</pubDate>
+
+</item>
+<item>
+	<title>22-7131 Stephen Ollar, et al v. DC, et al</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-7131</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208491101'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-7131&amp;partId=1984494</guid>
+	<pubDate>Fri, 03 Feb 2023 11:49:57 EST</pubDate>
+
+</item>
+<item>
+	<title>22-5043 Tyson Brody v. DOJ</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-5043</link>
+	<description>[Judgment Filed (Merits Panel)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208491091'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-5043&amp;partId=1984488</guid>
+	<pubDate>Fri, 03 Feb 2023 11:40:07 EST</pubDate>
+
+</item>
+<item>
+	<title>23-7009 Wye Oak Technology, Inc. v. Republic of Iraq, et al</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-7009</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208491086'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-7009&amp;partId=1984485</guid>
+	<pubDate>Fri, 03 Feb 2023 11:33:16 EST</pubDate>
+
+</item>
+<item>
+	<title>23-7013 Wye Oak Technology, Inc. v. Republic of Iraq, et al</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-7013</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208491086'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=23-7013&amp;partId=1984485</guid>
+	<pubDate>Fri, 03 Feb 2023 11:33:16 EST</pubDate>
+
+</item>
+<item>
+	<title>22-7061 USA v. Dynamic Visions Inc, et al</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-7061</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208490899'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-7061&amp;partId=1984389</guid>
+	<pubDate>Thu, 02 Feb 2023 15:39:27 EST</pubDate>
+
+</item>
+<item>
+	<title>22-5330 Insider Inc. v. GSA</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-5330</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208490895'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-5330&amp;partId=1984388</guid>
+	<pubDate>Thu, 02 Feb 2023 15:36:06 EST</pubDate>
+
+</item>
+<item>
+	<title>22-1271 United States Sugar Corporation v. EPA</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1271</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208490836'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1271&amp;partId=1984347</guid>
+	<pubDate>Thu, 02 Feb 2023 13:41:49 EST</pubDate>
+
+</item>
+<item>
+	<title>22-1302 American Forest &amp;amp; Paper Association, et al v. EPA</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1302</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208490836'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1302&amp;partId=1984347</guid>
+	<pubDate>Thu, 02 Feb 2023 13:41:49 EST</pubDate>
+
+</item>
+<item>
+	<title>22-1303 California Communities Against Toxics, et al v. EPA, et al</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1303</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208490836'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-1303&amp;partId=1984347</guid>
+	<pubDate>Thu, 02 Feb 2023 13:41:49 EST</pubDate>
+
+</item>
+<item>
+	<title>22-7114 Matthew Couch v. Verizon Communications Inc., et al</title>
+	<link>https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-7114</link>
+	<description>[Order Filed (CLERK)] (&lt;a href='https://ecf.cadc.uscourts.gov/docs1/01208490819'>Document&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cadc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-7114&amp;partId=1984340</guid>
+	<pubDate>Thu, 02 Feb 2023 13:21:39 EST</pubDate>
+
+</item>
+
+</channel>
+</rss>

--- a/tests/examples/pacer/rss_feeds/cafc.json
+++ b/tests/examples/pacer/rss_feeds/cafc.json
@@ -1,0 +1,64 @@
+[
+  {
+    "assigned_to_str": "",
+    "case_name": "Transtex Inc. v. Vidal",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cafc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T09:56:28-05:00",
+        "description": "",
+        "document_number": "102",
+        "pacer_doc_id": "01302074965",
+        "short_description": "Judgment"
+      }
+    ],
+    "docket_number": "20-1140",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  },
+  {
+    "assigned_to_str": "",
+    "case_name": "Transtex Inc. v. Vidal",
+    "cause": "",
+    "chapter": "",
+    "court_id": "cafc",
+    "date_converted": null,
+    "date_discharged": null,
+    "date_filed": null,
+    "date_terminated": null,
+    "demand": "",
+    "docket_entries": [
+      {
+        "date_filed": "2023-02-03T09:55:10-05:00",
+        "description": "",
+        "document_number": "101",
+        "pacer_doc_id": "01302074960",
+        "short_description": "Opinion"
+      }
+    ],
+    "docket_number": "20-1140",
+    "jurisdiction": "",
+    "jury_demand": "",
+    "nature_of_suit": "",
+    "office": "",
+    "pacer_case_id": null,
+    "parties": null,
+    "referred_to_str": "",
+    "trustee_str": "",
+    "type": ""
+  }
+]

--- a/tests/examples/pacer/rss_feeds/cafc.xml
+++ b/tests/examples/pacer/rss_feeds/cafc.xml
@@ -1,0 +1,28 @@
+<?xml version='1.0' encoding='ISO-8859-1'?>
+
+<rss version="2.0" xmlns:blogChannel="http://backend.userland.com/blogChannelModule">
+
+<channel>
+	<title>United States Court of Appeals for the Federal Circuit - Recent Entries</title>
+	<link>https://ecf.cafc.uscourts.gov</link>
+	<description>Docket entries of type: orders,opinions,judgments</description>
+	<lastBuildDate>Fri, 03 Feb 2023 12:43:10 EST</lastBuildDate>
+<item>
+	<title>20-1140 Transtex Inc. v. Vidal</title>
+	<link>https://ecf.cafc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=20-1140</link>
+	<description>[Judgment] (&lt;a href='https://ecf.cafc.uscourts.gov/docs1/01302074965'>102&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cafc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=20-1140&amp;partId=901719</guid>
+	<pubDate>Fri, 03 Feb 2023 09:56:28 EST</pubDate>
+
+</item>
+<item>
+	<title>20-1140 Transtex Inc. v. Vidal</title>
+	<link>https://ecf.cafc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=20-1140</link>
+	<description>[Opinion] (&lt;a href='https://ecf.cafc.uscourts.gov/docs1/01302074960'>101&lt;/a>)</description>
+	<guid isPermaLink="true">https://ecf.cafc.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=20-1140&amp;partId=901717</guid>
+	<pubDate>Fri, 03 Feb 2023 09:55:10 EST</pubDate>
+
+</item>
+
+</channel>
+</rss>

--- a/tests/local/test_PacerUtilTest.py
+++ b/tests/local/test_PacerUtilTest.py
@@ -4,6 +4,8 @@
 import unittest
 from datetime import date, timedelta
 
+from dateparser import parse
+
 from juriscraper.lib.utils import clean_court_object
 from juriscraper.pacer.utils import (
     get_court_id_from_url,
@@ -13,7 +15,6 @@ from juriscraper.pacer.utils import (
     get_pacer_magic_num_from_doc1_url,
     get_pacer_seq_no_from_doc1_url,
     make_doc1_url,
-    parse_datetime_for_us_timezone,
     reverse_goDLS_function,
 )
 
@@ -203,10 +204,7 @@ class PacerUtilTest(unittest.TestCase):
             ("2023-02-01 10:00:00 AKST", -9),
             ("2022-08-01 10:00:00 AKDT", -8),
             ("2023-02-01 10:00:00 HST", -10),
-            (
-                "2022-08-01 10:00:00 HDT",
-                -10,
-            ),  # Pacific/Honolulu doesn't observe DST
+            ("2022-08-01 10:00:00 HDT", -9.5),
             ("2023-02-01 10:00:00 EST", -5),
             ("2022-08-01 10:00:00 EDT", -4),
             ("2023-02-01 10:00:00 CST", -6),
@@ -219,6 +217,5 @@ class PacerUtilTest(unittest.TestCase):
         ]
 
         for datetime_str, offset in datetime_tests:
-            dt = parse_datetime_for_us_timezone(datetime_str)
-
+            dt = parse(datetime_str)
             self.assertEqual(dt.utcoffset(), timedelta(hours=offset))

--- a/tests/local/test_PacerUtilTest.py
+++ b/tests/local/test_PacerUtilTest.py
@@ -213,6 +213,9 @@ class PacerUtilTest(unittest.TestCase):
             ("2022-08-01 10:00:00 CDT", -5),
             ("2023-02-01 10:00:00 MST", -7),
             ("2022-08-01 10:00:00 MDT", -6),
+            ("2023-02-01 10:00:00 CHST", 10),
+            ("2023-02-01 10:00:00 SST", -11),
+            ("2023-02-01 10:00:00 AST", -4),
         ]
 
         for datetime_str, offset in datetime_tests:


### PR DESCRIPTION
This PR adds support to query and parse appellate RSS Feeds.

Not too many differences between district and bankruptcy courts, the only ones are:
- No `pacer_case_id` in appellate RSS feeds.
- As in other sources, no `document_number` in appellate courts that don't have numbers yet.
- Appellate RSS Feeds use local timezones for the `date_filed`, this is a difference from district/bankruptcy courts that uses GMT, so added support to parse properly date-times for all the US timezones.