### PR TITLE
Improve performance of parsing RSS feeds

### DIFF
--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -5,7 +5,6 @@ import re
 import sys
 from html import unescape
 
-import dateparser
 import feedparser
 from requests import Session
 
@@ -17,6 +16,7 @@ from .utils import (
     get_pacer_case_id_from_nonce_url,
     get_pacer_doc_id_from_doc1_url,
     get_pacer_seq_no_from_doc1_url,
+    parse_datetime_for_us_timezone,
     set_pacer_doc_id_as_appellate_document_number,
 )
 
@@ -275,7 +275,7 @@ class PacerRssFeed(DocketReport):
         Although there is only one, return it as a list.
         """
         de = {
-            "date_filed": dateparser.parse(entry.published),
+            "date_filed": parse_datetime_for_us_timezone(entry.published),
             "description": "",
             "document_number": self._get_value(
                 self.document_number_regex, entry.summary

--- a/tests/local/test_PacerUtilTest.py
+++ b/tests/local/test_PacerUtilTest.py
@@ -4,8 +4,6 @@
 import unittest
 from datetime import date, timedelta
 
-from dateparser import parse
-
 from juriscraper.lib.utils import clean_court_object
 from juriscraper.pacer.utils import (
     get_court_id_from_url,
@@ -15,6 +13,7 @@ from juriscraper.pacer.utils import (
     get_pacer_magic_num_from_doc1_url,
     get_pacer_seq_no_from_doc1_url,
     make_doc1_url,
+    parse_datetime_for_us_timezone,
     reverse_goDLS_function,
 )
 
@@ -204,7 +203,7 @@ class PacerUtilTest(unittest.TestCase):
             ("2023-02-01 10:00:00 AKST", -9),
             ("2022-08-01 10:00:00 AKDT", -8),
             ("2023-02-01 10:00:00 HST", -10),
-            ("2022-08-01 10:00:00 HDT", -9.5),
+            ("2022-08-01 10:00:00 HDT", -10),
             ("2023-02-01 10:00:00 EST", -5),
             ("2022-08-01 10:00:00 EDT", -4),
             ("2023-02-01 10:00:00 CST", -6),
@@ -214,8 +213,14 @@ class PacerUtilTest(unittest.TestCase):
             ("2023-02-01 10:00:00 CHST", 10),
             ("2023-02-01 10:00:00 SST", -11),
             ("2023-02-01 10:00:00 AST", -4),
+            ("2023-02-01 10:00:00 GMT", 0),
+            ("2023-02-01 10:00:00 AZ", None),
         ]
 
         for datetime_str, offset in datetime_tests:
-            dt = parse(datetime_str)
-            self.assertEqual(dt.utcoffset(), timedelta(hours=offset))
+            if offset is None:
+                with self.assertRaises(NotImplementedError):
+                    dt = parse_datetime_for_us_timezone(datetime_str)
+            else:
+                dt = parse_datetime_for_us_timezone(datetime_str)
+                self.assertEqual(dt.utcoffset(), timedelta(hours=offset))


### PR DESCRIPTION
As described in [#2091](https://github.com/freelawproject/courtlistener/issues/2091) reviewing the performance of parsing RSS feeds we got the following results when parsing an 800KB RSS file that contains approx. 810 entries:

* Actual parsing time: `0.30570292472839355` seconds
* Generate data dict: `2.520118236541748` seconds

The process that took the most time when generating the data dictionary was using `dateparser` for parsing the feed `datetime`.

Comparing this to using `dateutil.parser` and passing a dictionary of `tzinfos`, it only takes `0.6627788543701172` seconds to generate the dictionary for the same RSS file.

This significant difference can save many days when parsing millions of files. Therefore, I believe that it is worth using `dateutil` instead of `dateparser` for this performance improvement.

I also made some improvements to the `parse_datetime_for_us_timezone` function by using US timezones files (e.g., `US/Eastern`) when possible instead of choosing an arbitrary city like "America/New_York".

I checked and found that courts like `azb` use `GMT` instead of `US/Arizona`. In case a court uses a special abbreviation that we don't support, I set it to raise an error so that we can recognize the timezone and add support for it instead of returning a `datetime` without a `UTC` offset.

- Regarding your comments in issue [#2091](https://github.com/freelawproject/courtlistener/issues/2091), I did some tests to parse an RSS file one item at a time in order to evaluate the performance. These are the results:

```
from xml.etree import ElementTree

def _parse_text(self, path):
        """ """
        start_time = time.time()
        context = ElementTree.iterparse(path, events=('start', 'end'))
        for event, element in context:
            # Process only 'item' elements
            if event == 'end' and element.tag == 'item':
                entry = feedparser.parse(ElementTree.tostring(element))["entries"][0]
                self.feed_entries.append(entry)
        end_time = time.time()
        print("Parse elapsed time: ",  end_time-start_time)
```

Using `ElementTree` in order to iterate over the RSS file one item at a time and parse it with `feedparser` the total time of parsing all the items in the RSS files was:
`Parse elapsed time:  0.5050609111785889` seconds

Also tested a version using regex:
```
from xml.etree import ElementTree

def _parse_text(self, path):
        """ """
        start_time = time.time()
         with open(path, 'rb') as f:
            rss_str = f.read().decode("utf-8")
        regex = r'<item>.*?</item>'
        matches = re.findall(regex, rss_str, re.DOTALL)
        for match in matches:
            entry = feedparser.parse(match)["entries"][0]
            self.feed_entries.append(entry)
        end_time = time.time()
        print("Parse elapsed time: ",  end_time-start_time)
```
The total time of parsing all the items in the RSS files was:
`Parse elapsed time:   0.4698631763458252` seconds


While original approach:

```
def _parse_text(self, text):
        """ """
        start_time = time.time()
        self.feed = feedparser.parse(text)
        end_time = time.time()
        print("Parse elapsed time: ",  end_time-start_time)
```

It's faster than parsing one element at a time:
`Parse elapsed time:   0.30281901359558105` seconds

So that according to these tests, there is no performance improvement in parsing one item at a time, let me know if that's the approach you meant.