### PR TITLE
Added null pacer_seq_no to appellate RSS feed entries

### DIFF
--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -295,6 +295,7 @@ class PacerRssFeed(DocketReport):
             de["pacer_seq_no"] = get_pacer_seq_no_from_doc1_url(doc1_url)
         elif docs1_url:
             de["pacer_doc_id"] = get_pacer_doc_id_from_doc1_url(docs1_url)
+            de["pacer_seq_no"] = None
         else:
             # Some courts, in particular, NYED do not provide doc1 links and
             # instead provide show_case_doc links. Some docket entries don't

--- a/tests/examples/pacer/rss_feeds/ca10.json
+++ b/tests/examples/pacer/rss_feeds/ca10.json
@@ -16,6 +16,7 @@
         "description": "",
         "document_number": "010010807970",
         "pacer_doc_id": "010010807970",
+        "pacer_seq_no": null,
         "short_description": "Case termination for opinion"
       }
     ],
@@ -47,6 +48,7 @@
         "description": "",
         "document_number": "010010807953",
         "pacer_doc_id": "010010807953",
+        "pacer_seq_no": null,
         "short_description": "Case termination for order and judgment"
       }
     ],
@@ -78,6 +80,7 @@
         "description": "",
         "document_number": "010010807929",
         "pacer_doc_id": "010010807929",
+        "pacer_seq_no": null,
         "short_description": "Case termination for order and judgment"
       }
     ],
@@ -109,6 +112,7 @@
         "description": "",
         "document_number": "010010807922",
         "pacer_doc_id": "010010807922",
+        "pacer_seq_no": null,
         "short_description": "Case termination for order and judgment"
       }
     ],
@@ -140,6 +144,7 @@
         "description": "",
         "document_number": "010010807580",
         "pacer_doc_id": "010010807580",
+        "pacer_seq_no": null,
         "short_description": "Case termination without a panel"
       }
     ],
@@ -171,6 +176,7 @@
         "description": "",
         "document_number": "010010807448",
         "pacer_doc_id": "010010807448",
+        "pacer_seq_no": null,
         "short_description": "Case termination without a panel"
       }
     ],

--- a/tests/examples/pacer/rss_feeds/ca11.json
+++ b/tests/examples/pacer/rss_feeds/ca11.json
@@ -16,6 +16,7 @@
         "description": "",
         "document_number": "23",
         "pacer_doc_id": "011012658791",
+        "pacer_seq_no": null,
         "short_description": "Opinion Issued"
       }
     ],
@@ -47,6 +48,7 @@
         "description": "",
         "document_number": "31",
         "pacer_doc_id": "011012658730",
+        "pacer_seq_no": null,
         "short_description": "Opinion Issued"
       }
     ],
@@ -78,6 +80,7 @@
         "description": "",
         "document_number": "30",
         "pacer_doc_id": "011012658562",
+        "pacer_seq_no": null,
         "short_description": "Opinion Issued"
       }
     ],
@@ -109,6 +112,7 @@
         "description": "",
         "document_number": "22",
         "pacer_doc_id": "011012658438",
+        "pacer_seq_no": null,
         "short_description": "Opinion Issued"
       }
     ],
@@ -140,6 +144,7 @@
         "description": "",
         "document_number": "22",
         "pacer_doc_id": "011012658304",
+        "pacer_seq_no": null,
         "short_description": "Opinion Issued"
       }
     ],
@@ -171,6 +176,7 @@
         "description": "",
         "document_number": "28",
         "pacer_doc_id": "011012657673",
+        "pacer_seq_no": null,
         "short_description": "Opinion Issued"
       }
     ],
@@ -202,6 +208,7 @@
         "description": "",
         "document_number": "28",
         "pacer_doc_id": "011012657555",
+        "pacer_seq_no": null,
         "short_description": "Opinion Issued"
       }
     ],
@@ -233,6 +240,7 @@
         "description": "",
         "document_number": "47",
         "pacer_doc_id": "011012657489",
+        "pacer_seq_no": null,
         "short_description": "Opinion Issued"
       }
     ],
@@ -264,6 +272,7 @@
         "description": "",
         "document_number": "45",
         "pacer_doc_id": "011012657406",
+        "pacer_seq_no": null,
         "short_description": "Opinion Issued"
       }
     ],
@@ -295,6 +304,7 @@
         "description": "",
         "document_number": "77",
         "pacer_doc_id": "011012657099",
+        "pacer_seq_no": null,
         "short_description": "Opinion Issued"
       }
     ],

--- a/tests/examples/pacer/rss_feeds/ca2_1.json
+++ b/tests/examples/pacer/rss_feeds/ca2_1.json
@@ -16,6 +16,7 @@
         "description": "",
         "document_number": "27",
         "pacer_doc_id": "00209229396",
+        "pacer_seq_no": null,
         "short_description": "So-Ordered Scheduling Notification FILED"
       }
     ],
@@ -47,6 +48,7 @@
         "description": "",
         "document_number": "48",
         "pacer_doc_id": "00209229372",
+        "pacer_seq_no": null,
         "short_description": "So-Ordered Scheduling Notification FILED"
       }
     ],
@@ -78,6 +80,7 @@
         "description": "",
         "document_number": "38",
         "pacer_doc_id": "00209229354",
+        "pacer_seq_no": null,
         "short_description": "Motion Order FILED"
       }
     ],
@@ -109,6 +112,7 @@
         "description": "",
         "document_number": "46",
         "pacer_doc_id": "00209229291",
+        "pacer_seq_no": null,
         "short_description": "Strike Order FILED"
       }
     ],

--- a/tests/examples/pacer/rss_feeds/ca4_1.json
+++ b/tests/examples/pacer/rss_feeds/ca4_1.json
@@ -16,6 +16,7 @@
         "description": "",
         "document_number": "95",
         "pacer_doc_id": "00409219058",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -47,6 +48,7 @@
         "description": "",
         "document_number": "3",
         "pacer_doc_id": "00409219066",
+        "pacer_seq_no": null,
         "short_description": "Informal briefing order filed"
       }
     ],
@@ -78,6 +80,7 @@
         "description": "",
         "document_number": "4",
         "pacer_doc_id": "00409218974",
+        "pacer_seq_no": null,
         "short_description": "Informal briefing order filed"
       }
     ],
@@ -109,6 +112,7 @@
         "description": "",
         "document_number": "3",
         "pacer_doc_id": "00409218950",
+        "pacer_seq_no": null,
         "short_description": "Informal briefing order filed"
       }
     ],
@@ -140,6 +144,7 @@
         "description": "",
         "document_number": "2",
         "pacer_doc_id": "00409218908",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -171,6 +176,7 @@
         "description": "",
         "document_number": "14",
         "pacer_doc_id": "00409218911",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -202,6 +208,7 @@
         "description": "",
         "document_number": "18",
         "pacer_doc_id": "00409218872",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -233,6 +240,7 @@
         "description": "",
         "document_number": "3",
         "pacer_doc_id": "00409218867",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -264,6 +272,7 @@
         "description": "",
         "document_number": "59",
         "pacer_doc_id": "00409218846",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -295,6 +304,7 @@
         "description": "",
         "document_number": "28",
         "pacer_doc_id": "00409218841",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -326,6 +336,7 @@
         "description": "",
         "document_number": "21",
         "pacer_doc_id": "00409218836",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -357,6 +368,7 @@
         "description": "",
         "document_number": "11",
         "pacer_doc_id": "00409218811",
+        "pacer_seq_no": null,
         "short_description": "Briefing order filed"
       }
     ],
@@ -388,6 +400,7 @@
         "description": "",
         "document_number": "8",
         "pacer_doc_id": "00409218804",
+        "pacer_seq_no": null,
         "short_description": "Briefing order filed"
       }
     ],
@@ -419,6 +432,7 @@
         "description": "",
         "document_number": "60",
         "pacer_doc_id": "00409218776",
+        "pacer_seq_no": null,
         "short_description": "Court order filed"
       }
     ],
@@ -450,6 +464,7 @@
         "description": "",
         "document_number": "10",
         "pacer_doc_id": "00409218801",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -481,6 +496,7 @@
         "description": "",
         "document_number": "22",
         "pacer_doc_id": "00409218765",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -512,6 +528,7 @@
         "description": "",
         "document_number": "35",
         "pacer_doc_id": "00409218735",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -543,6 +560,7 @@
         "description": "",
         "document_number": "22",
         "pacer_doc_id": "00409218690",
+        "pacer_seq_no": null,
         "short_description": "Judgment order filed"
       }
     ],
@@ -574,6 +592,7 @@
         "description": "",
         "document_number": "17",
         "pacer_doc_id": "00409218691",
+        "pacer_seq_no": null,
         "short_description": "Order filed"
       }
     ],
@@ -605,6 +624,7 @@
         "description": "",
         "document_number": "21",
         "pacer_doc_id": "00409218678",
+        "pacer_seq_no": null,
         "short_description": "Unpublished per curiam opinion filed"
       }
     ],

--- a/tests/examples/pacer/rss_feeds/ca6.json
+++ b/tests/examples/pacer/rss_feeds/ca6.json
@@ -48,6 +48,7 @@
         "description": "",
         "document_number": "40",
         "pacer_doc_id": "006014913158",
+        "pacer_seq_no": null,
         "short_description": "judge order filed"
       }
     ],
@@ -79,6 +80,7 @@
         "description": "",
         "document_number": "42",
         "pacer_doc_id": "006014913147",
+        "pacer_seq_no": null,
         "short_description": "ruling letter sent"
       }
     ],
@@ -110,6 +112,7 @@
         "description": "",
         "document_number": "13",
         "pacer_doc_id": "006014913121",
+        "pacer_seq_no": null,
         "short_description": "clerk order filed"
       }
     ],
@@ -141,6 +144,7 @@
         "description": "",
         "document_number": "33",
         "pacer_doc_id": "006014913098",
+        "pacer_seq_no": null,
         "short_description": "unpublished opinion and judgment filed"
       }
     ],
@@ -172,6 +176,7 @@
         "description": "",
         "document_number": "24",
         "pacer_doc_id": "006014913087",
+        "pacer_seq_no": null,
         "short_description": "ruling letter sent"
       }
     ],
@@ -203,6 +208,7 @@
         "description": "",
         "document_number": "21",
         "pacer_doc_id": "006014912254",
+        "pacer_seq_no": null,
         "short_description": "clerk order filed"
       }
     ],
@@ -234,6 +240,7 @@
         "description": "",
         "document_number": "23",
         "pacer_doc_id": "006014912187",
+        "pacer_seq_no": null,
         "short_description": "ruling letter sent"
       }
     ],
@@ -265,6 +272,7 @@
         "description": "",
         "document_number": "14",
         "pacer_doc_id": "006014912156",
+        "pacer_seq_no": null,
         "short_description": "ruling letter sent"
       }
     ],

--- a/tests/examples/pacer/rss_feeds/cadc.json
+++ b/tests/examples/pacer/rss_feeds/cadc.json
@@ -16,6 +16,7 @@
         "description": "",
         "document_number": "01208491112",
         "pacer_doc_id": "01208491112",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -47,6 +48,7 @@
         "description": "",
         "document_number": "01208491112",
         "pacer_doc_id": "01208491112",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -78,6 +80,7 @@
         "description": "",
         "document_number": "01208491107",
         "pacer_doc_id": "01208491107",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -109,6 +112,7 @@
         "description": "",
         "document_number": "01208491101",
         "pacer_doc_id": "01208491101",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -140,6 +144,7 @@
         "description": "",
         "document_number": "01208491091",
         "pacer_doc_id": "01208491091",
+        "pacer_seq_no": null,
         "short_description": "Judgment Filed (Merits Panel)"
       }
     ],
@@ -171,6 +176,7 @@
         "description": "",
         "document_number": "01208491086",
         "pacer_doc_id": "01208491086",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -202,6 +208,7 @@
         "description": "",
         "document_number": "01208491086",
         "pacer_doc_id": "01208491086",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -233,6 +240,7 @@
         "description": "",
         "document_number": "01208490899",
         "pacer_doc_id": "01208490899",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -264,6 +272,7 @@
         "description": "",
         "document_number": "01208490895",
         "pacer_doc_id": "01208490895",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -295,6 +304,7 @@
         "description": "",
         "document_number": "01208490836",
         "pacer_doc_id": "01208490836",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -326,6 +336,7 @@
         "description": "",
         "document_number": "01208490836",
         "pacer_doc_id": "01208490836",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -357,6 +368,7 @@
         "description": "",
         "document_number": "01208490836",
         "pacer_doc_id": "01208490836",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],
@@ -388,6 +400,7 @@
         "description": "",
         "document_number": "01208490819",
         "pacer_doc_id": "01208490819",
+        "pacer_seq_no": null,
         "short_description": "Order Filed (CLERK)"
       }
     ],

--- a/tests/examples/pacer/rss_feeds/cafc.json
+++ b/tests/examples/pacer/rss_feeds/cafc.json
@@ -16,6 +16,7 @@
         "description": "",
         "document_number": "102",
         "pacer_doc_id": "01302074965",
+        "pacer_seq_no": null,
         "short_description": "Judgment"
       }
     ],
@@ -47,6 +48,7 @@
         "description": "",
         "document_number": "101",
         "pacer_doc_id": "01302074960",
+        "pacer_seq_no": null,
         "short_description": "Opinion"
       }
     ],


### PR DESCRIPTION
While working on Troller BK and adding docket entries in bulk, I noticed that parsed appellate RSS entries do not contain the `pacer_seq_no`. Although it cannot be retrieved from appellate RSS feeds, I believe it's worth including the key in the JSON even if it is set to null, so that district/bankr feeds and appellate feeds contain the same fields.

I didn't notice this issue before because the `add_docket_entries` function in CL does not require the `pacer_seq_no` key, as it retrieves the value from the dict using `get()`. However, now when adding entries in bulk, I noticed the issue since the adding approach has changed.
