### PR TITLE
Claims activity POST request param wildcard for insb

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,18 @@ Releases are also tagged in git, if that's helpful.
 
 ## Current
 
+**2.5.41 - 2023-04-05**
+
+Features:
+
+- N/A
+
+Changes:
+
+- Fix ClaimsActivity report alternative POST param for insb.
+
+## Past
+
 **2.5.40 - 2023-04-04**
 
 Features:
@@ -25,8 +37,6 @@ Features:
 Changes:
 
 - N/A
-
-## Past
 
 **2.5.39 - 2023-03-09**
 

--- a/juriscraper/pacer/claims_activity.py
+++ b/juriscraper/pacer/claims_activity.py
@@ -417,5 +417,19 @@ class ClaimsActivity(BaseDocketReport, BaseReport):
             self.court_id,
             params,
         )
-        self.response = self.session.post(f"{self.url}?1-L_1_0-1", data=params)
+
+        if self.court_id == "insb":
+            # The POST param wildcard 1-L_1_0-1 doesn't work for insb.
+            # It throws a 500 error. 1-L_945_0-1 doesn't work either.
+            # The only approach that seems to work is using one of the params
+            # generated in cgi-bin/ClaimsActRpt.pl
+            # Unfortunately this might stop working since it seems to expire
+            # or might be linked to the PACER session.
+            post_param = "124892645626785-L_945_0-1"
+        else:
+            post_param = "1-L_1_0-1"
+
+        self.response = self.session.post(
+            f"{self.url}?{post_param}", data=params
+        )
         self.parse()

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import unittest
 from setuptools import find_packages, setup
 from setuptools.command.install import install
 
-VERSION = "2.5.40"
+VERSION = "2.5.41"
 AUTHOR = "Free Law Project"
 EMAIL = "info@free.law"
 HERE = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
Querying a Claims activity report for `insb` using the POST wildcard param `1-L_1_0-1` throws a 500 error.

The valid param for `insb` has the shape `148849513586046-L_945_0-1`, seems there's no wildcard (at least not evident) like `1-L_945_0-1` that works. 

So using a pre-generated param seems to work at least temporarily since it seems to expire or might be linked to the PACER session.

I also checked all the courts in order to find others that don't use `1-L_1_0-1` but seems that `insb` is the only one using a different param.

