### PR TITLE
Sort multi RSS event entries short descriptions alphabetically

### DIFF
--- a/juriscraper/pacer/rss_feeds.py
+++ b/juriscraper/pacer/rss_feeds.py
@@ -99,10 +99,15 @@ def append_or_merge_entry(docket_list, new_docket):
         same_doc_id = entry["pacer_doc_id"] == new_entry["pacer_doc_id"]
         if all([same_dn, same_cn, same_date, same_doc_id]):
             # if docket number, pacer_case_id, date filing, and pacer_doc_id
-            # are same, merge.
-            entry[
-                "short_description"
-            ] += f" AND {new_entry['short_description']}"
+            # are same, order short descriptions alphabetically and merge.
+
+            short_descriptions = [
+                desc.strip()
+                for desc in entry["short_description"].split("AND")
+            ]
+            short_descriptions.append(new_entry["short_description"])
+            short_description = " AND ".join(sorted(short_descriptions))
+            entry["short_description"] = short_description
             break
     else:
         # Loop exited without hitting a break; item is distinct; append.

--- a/tests/examples/pacer/rss_feeds/nyed_1.json
+++ b/tests/examples/pacer/rss_feeds/nyed_1.json
@@ -145,7 +145,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "1:97-cv-07285",
@@ -273,7 +273,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "1:18-cv-02857",
@@ -305,7 +305,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "1:17-cv-07252",
@@ -593,7 +593,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Scheduling Order AND Order"
+        "short_description": "Order AND Scheduling Order"
       }
     ],
     "docket_number": "1:17-cv-05273",
@@ -2417,7 +2417,7 @@
         "document_number": "12",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Stipulation and Order of Remand to SSA AND Order"
+        "short_description": "Order AND Stipulation and Order of Remand to SSA"
       }
     ],
     "docket_number": "2:17-cv-06029",
@@ -2481,7 +2481,7 @@
         "document_number": "13",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Stipulation and Order of Remand to SSA AND Order"
+        "short_description": "Order AND Stipulation and Order of Remand to SSA"
       }
     ],
     "docket_number": "2:17-cv-05513",
@@ -2577,7 +2577,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order on Motion for Extension of Time to File Response/Reply AND Order"
+        "short_description": "Order AND Order on Motion for Extension of Time to File Response/Reply"
       }
     ],
     "docket_number": "1:12-cv-03141",
@@ -2865,7 +2865,7 @@
         "document_number": "86",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order on Motion for Sanctions AND Order on Motion for Extension of Time to Complete Discovery AND ~Util - Set Hearings"
+        "short_description": "Order on Motion for Extension of Time to Complete Discovery AND Order on Motion for Sanctions AND ~Util - Set Hearings"
       }
     ],
     "docket_number": "1:16-cv-00834",
@@ -3025,7 +3025,7 @@
         "document_number": "35",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Status Report Order AND 1 - Terminate Deadlines and Hearings"
+        "short_description": "1 - Terminate Deadlines and Hearings AND Status Report Order"
       }
     ],
     "docket_number": "1:17-cv-06406",
@@ -3089,7 +3089,7 @@
         "document_number": "22",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "2:16-cv-07034",
@@ -3185,7 +3185,7 @@
         "document_number": "15",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "2:17-cv-01454",
@@ -3377,7 +3377,7 @@
         "document_number": "39",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "2:16-cv-02184",
@@ -3409,7 +3409,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "1:16-cv-04502",
@@ -3473,7 +3473,7 @@
         "document_number": "24",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "2:15-cv-02925",
@@ -3569,7 +3569,7 @@
         "document_number": "24",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "2:15-cv-02951",
@@ -3601,7 +3601,7 @@
         "document_number": "14",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "2:18-cv-01041",
@@ -3665,7 +3665,7 @@
         "document_number": "19",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "2:17-cv-03831",
@@ -3761,7 +3761,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "1:15-cv-06228",
@@ -3889,7 +3889,7 @@
         "document_number": "22",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Stipulation and Order AND Order"
+        "short_description": "Order AND Stipulation and Order"
       }
     ],
     "docket_number": "2:17-cv-06601",
@@ -4593,7 +4593,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Scheduling Order AND 1 - Terminate Deadlines and Hearings"
+        "short_description": "1 - Terminate Deadlines and Hearings AND Scheduling Order"
       }
     ],
     "docket_number": "1:17-cv-00547",
@@ -4625,7 +4625,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order on Motion to Adjourn Conference AND 1 - Terminate Deadlines"
+        "short_description": "1 - Terminate Deadlines AND Order on Motion to Adjourn Conference"
       }
     ],
     "docket_number": "1:18-cv-00272",
@@ -4657,7 +4657,7 @@
         "document_number": "79",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order on Motion for Extension of Time to File Response/Reply AND Order"
+        "short_description": "Order AND Order on Motion for Extension of Time to File Response/Reply"
       }
     ],
     "docket_number": "1:17-cv-06729",
@@ -5521,7 +5521,7 @@
         "document_number": "54",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Scheduling Order AND 1 - Terminate Deadlines and Hearings"
+        "short_description": "1 - Terminate Deadlines and Hearings AND Scheduling Order"
       }
     ],
     "docket_number": "2:15-cv-00347",
@@ -5585,7 +5585,7 @@
         "document_number": "22",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order AND Order"
+        "short_description": "Order AND Order AND Order(Other)"
       }
     ],
     "docket_number": "1:00-cv-00858",
@@ -5745,7 +5745,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "~Util - Set Deadlines AND 1 - Terminate Deadlines"
+        "short_description": "1 - Terminate Deadlines AND ~Util - Set Deadlines"
       }
     ],
     "docket_number": "1:17-cv-06414",
@@ -5937,7 +5937,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "1:15-cv-05867",
@@ -6449,7 +6449,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order AND Order"
+        "short_description": "Order AND Order AND Order(Other)"
       }
     ],
     "docket_number": "1:16-cv-03029",
@@ -6577,7 +6577,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order on Motion for Extension of Time to File Response/Reply AND Order"
+        "short_description": "Order AND Order on Motion for Extension of Time to File Response/Reply"
       }
     ],
     "docket_number": "1:16-cv-03029",
@@ -6673,7 +6673,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Status Report Order AND 1 - Terminate Deadlines and Hearings"
+        "short_description": "1 - Terminate Deadlines and Hearings AND Status Report Order"
       }
     ],
     "docket_number": "1:17-cv-05398",
@@ -6737,7 +6737,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Status Report Order AND 1 - Terminate Deadlines"
+        "short_description": "1 - Terminate Deadlines AND Status Report Order"
       }
     ],
     "docket_number": "1:17-cv-04563",
@@ -6833,7 +6833,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Scheduling Order AND 1 - Terminate Deadlines"
+        "short_description": "1 - Terminate Deadlines AND Scheduling Order"
       }
     ],
     "docket_number": "1:15-cv-06119",
@@ -6897,7 +6897,7 @@
         "document_number": "18",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order on Motion for Extension of Time to Complete Discovery AND 1 - Terminate Deadlines"
+        "short_description": "1 - Terminate Deadlines AND Order on Motion for Extension of Time to Complete Discovery"
       }
     ],
     "docket_number": "1:17-cv-04016",
@@ -7153,7 +7153,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order AND Order"
+        "short_description": "Order AND Order AND Order(Other)"
       }
     ],
     "docket_number": "1:15-cv-06228",
@@ -7313,7 +7313,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order on Motion for Extension of Time to Answer AND Order"
+        "short_description": "Order AND Order on Motion for Extension of Time to Answer"
       }
     ],
     "docket_number": "1:17-cv-06198",
@@ -7633,7 +7633,7 @@
         "document_number": "48",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Scheduling Order AND Order"
+        "short_description": "Order AND Scheduling Order"
       }
     ],
     "docket_number": "1:17-cv-04109",
@@ -7825,7 +7825,7 @@
         "document_number": "306",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Stipulation and Order AND Order"
+        "short_description": "Order AND Stipulation and Order"
       }
     ],
     "docket_number": "1:12-cv-05567",
@@ -8049,7 +8049,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order AND Order"
+        "short_description": "Order AND Order AND Order(Other)"
       }
     ],
     "docket_number": "2:17-cv-06214",
@@ -8241,7 +8241,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order on Motion for Extension of Time to File Response/Reply AND Order"
+        "short_description": "Order AND Order on Motion for Extension of Time to File Response/Reply"
       }
     ],
     "docket_number": "1:18-cv-00729",
@@ -8689,7 +8689,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "2:16-cv-05211",
@@ -8721,7 +8721,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "2:17-cv-05225",
@@ -9009,7 +9009,7 @@
         "document_number": "7",
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Stipulation and Order AND Order"
+        "short_description": "Order AND Stipulation and Order"
       }
     ],
     "docket_number": "1:17-cv-06858",
@@ -9073,7 +9073,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order Referring Motion AND Order"
+        "short_description": "Order AND Order Referring Motion"
       }
     ],
     "docket_number": "1:18-cv-01827",
@@ -9489,7 +9489,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "1:18-cv-02435",
@@ -9777,7 +9777,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Scheduling Order AND Order AND Order"
+        "short_description": "Order AND Order AND Scheduling Order"
       }
     ],
     "docket_number": "1:18-cv-00361",
@@ -9905,7 +9905,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order on Motion to Adjourn Conference AND 1 - Terminate Deadlines and Hearings AND ~Util - Set Motion and R&R Deadlines/Hearings AND Order"
+        "short_description": "1 - Terminate Deadlines and Hearings AND Order AND Order on Motion to Adjourn Conference AND ~Util - Set Motion and R&R Deadlines/Hearings"
       }
     ],
     "docket_number": "1:16-cv-01238",
@@ -10609,7 +10609,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order on Motion for Extension of Time to File AND Status Report Order AND 1 - Terminate Deadlines and Hearings"
+        "short_description": "1 - Terminate Deadlines and Hearings AND Order on Motion for Extension of Time to File AND Status Report Order"
       }
     ],
     "docket_number": "1:17-cv-03964",
@@ -10673,7 +10673,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND ~Util - Set Deadlines AND Order"
+        "short_description": "Order AND Order(Other) AND ~Util - Set Deadlines"
       }
     ],
     "docket_number": "1:17-cv-04052",
@@ -10769,7 +10769,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order Acknowledging Receipt of 6(e) Notification Letter AND Order AND Order AND Order"
+        "short_description": "Order AND Order AND Order AND Order Acknowledging Receipt of 6(e) Notification Letter"
       }
     ],
     "docket_number": "1:18-mc-00005",
@@ -11121,7 +11121,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "1:15-cv-05867",
@@ -11377,7 +11377,7 @@
         "document_number": null,
         "pacer_doc_id": "",
         "pacer_seq_no": null,
-        "short_description": "Order(Other) AND Order"
+        "short_description": "Order AND Order(Other)"
       }
     ],
     "docket_number": "1:18-cv-00590",

--- a/tests/examples/pacer/rss_feeds/sdny_1.json
+++ b/tests/examples/pacer/rss_feeds/sdny_1.json
@@ -3121,7 +3121,7 @@
         "document_number": "73",
         "pacer_doc_id": "127022264019",
         "pacer_seq_no": "325",
-        "short_description": "~Util - Add and Terminate Attorneys AND Stipulation and Order"
+        "short_description": "Stipulation and Order AND ~Util - Add and Terminate Attorneys"
       }
     ],
     "docket_number": "7:16-cv-02451",
@@ -3601,7 +3601,7 @@
         "document_number": "29",
         "pacer_doc_id": "127022263966",
         "pacer_seq_no": "89",
-        "short_description": "~Util - Set Deadlines AND Order"
+        "short_description": "Order AND ~Util - Set Deadlines"
       }
     ],
     "docket_number": "7:17-cv-06053",
@@ -4017,7 +4017,7 @@
         "document_number": "62",
         "pacer_doc_id": "127022263926",
         "pacer_seq_no": "248",
-        "short_description": "~Util - Set Deadlines AND Memo Endorsement"
+        "short_description": "Memo Endorsement AND ~Util - Set Deadlines"
       }
     ],
     "docket_number": "7:17-cv-05440",
@@ -4433,7 +4433,7 @@
         "document_number": "23",
         "pacer_doc_id": "127022263887",
         "pacer_seq_no": "67",
-        "short_description": "~Util - Set Hearings AND Order"
+        "short_description": "Order AND ~Util - Set Hearings"
       }
     ],
     "docket_number": "1:18-cv-02786",
@@ -5873,7 +5873,7 @@
         "document_number": "337",
         "pacer_doc_id": "127022263733",
         "pacer_seq_no": "1672",
-        "short_description": "~Util - Set Hearings AND Order"
+        "short_description": "Order AND ~Util - Set Hearings"
       }
     ],
     "docket_number": "1:16-md-02742",
@@ -6321,7 +6321,7 @@
         "document_number": "13",
         "pacer_doc_id": "127022263695",
         "pacer_seq_no": "49",
-        "short_description": "~Util - Add and Terminate Parties AND Notice of Voluntary Dismissal - Signed"
+        "short_description": "Notice of Voluntary Dismissal - Signed AND ~Util - Add and Terminate Parties"
       }
     ],
     "docket_number": "1:18-cv-02441",
@@ -6673,7 +6673,7 @@
         "document_number": "27",
         "pacer_doc_id": "127022263655",
         "pacer_seq_no": "84",
-        "short_description": "~Util - Set Deadlines AND Order"
+        "short_description": "Order AND ~Util - Set Deadlines"
       }
     ],
     "docket_number": "1:17-cv-09841",
@@ -6737,7 +6737,7 @@
         "document_number": "15",
         "pacer_doc_id": "127022263645",
         "pacer_seq_no": "56",
-        "short_description": "~Util - Set Deadlines AND Stipulation and Order"
+        "short_description": "Stipulation and Order AND ~Util - Set Deadlines"
       }
     ],
     "docket_number": "1:17-cv-10085",
@@ -6961,7 +6961,7 @@
         "document_number": "42",
         "pacer_doc_id": "127022263619",
         "pacer_seq_no": "127",
-        "short_description": "Discovery AND Compel"
+        "short_description": "Compel AND Discovery"
       }
     ],
     "docket_number": "1:17-cv-06954",
@@ -7665,7 +7665,7 @@
         "document_number": "240",
         "pacer_doc_id": "127022263533",
         "pacer_seq_no": "1000",
-        "short_description": "~Util - Set Deadlines/Hearings AND Order"
+        "short_description": "Order AND ~Util - Set Deadlines/Hearings"
       }
     ],
     "docket_number": "1:10-cv-09545",
@@ -8273,7 +8273,7 @@
         "document_number": "8",
         "pacer_doc_id": "127022263460",
         "pacer_seq_no": "29",
-        "short_description": "~Util - Set Deadlines/Hearings AND Memo Endorsement"
+        "short_description": "Memo Endorsement AND ~Util - Set Deadlines/Hearings"
       }
     ],
     "docket_number": "1:18-cv-01932",
@@ -8689,7 +8689,7 @@
         "document_number": "63",
         "pacer_doc_id": "127022263420",
         "pacer_seq_no": "230",
-        "short_description": "~Util - Set Motion and R&R Deadlines/Hearings AND Memo Endorsement"
+        "short_description": "Memo Endorsement AND ~Util - Set Motion and R&R Deadlines/Hearings"
       }
     ],
     "docket_number": "1:17-cv-04974",
@@ -9169,7 +9169,7 @@
         "document_number": "12",
         "pacer_doc_id": "127022263376",
         "pacer_seq_no": "47",
-        "short_description": "~Util - Set Deadlines/Hearings AND Order"
+        "short_description": "Order AND ~Util - Set Deadlines/Hearings"
       }
     ],
     "docket_number": "1:17-cv-07005",
@@ -10641,7 +10641,7 @@
         "document_number": "94",
         "pacer_doc_id": "127022263220",
         "pacer_seq_no": "292",
-        "short_description": "~Util - Set Deadlines/Hearings AND Order"
+        "short_description": "Order AND ~Util - Set Deadlines/Hearings"
       }
     ],
     "docket_number": "1:16-cv-03780",
@@ -10769,7 +10769,7 @@
         "document_number": "80",
         "pacer_doc_id": "127022263207",
         "pacer_seq_no": "292",
-        "short_description": "~Util - Set Deadlines AND Stipulation and Order"
+        "short_description": "Stipulation and Order AND ~Util - Set Deadlines"
       }
     ],
     "docket_number": "1:16-cv-00132",
@@ -10801,7 +10801,7 @@
         "document_number": "19",
         "pacer_doc_id": "127022263204",
         "pacer_seq_no": "79",
-        "short_description": "Extension of Time to File Document AND Conference"
+        "short_description": "Conference AND Extension of Time to File Document"
       }
     ],
     "docket_number": "1:15-cv-04455",


### PR DESCRIPTION
According to our plan in https://github.com/freelawproject/bigcases2/issues/87

This PR sorts the short descriptions of multiple RSS events alphabetically. This ensures that if the order of these entries in the RSS file changes the merged entry description will remain the same, so we'll be able to identify it instead of creating a new one in RECAP.

 
