### PR TITLE
Parse short description from recap.email subject

### DIFF
--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -412,8 +412,8 @@ class NotificationEmail(BaseDocketReport, BaseReport):
                 dockets.append(docket)
 
             if len(dockets) > 1:
-                # Re-do the short description for multi-docket NEFs after
-                # obtaining all possible case names.
+                # In multi-docket NEFs, the subject refers to only the short
+                # description of the first item.
                 for docket in dockets:
                     if docket["docket_entries"]:
                         docket["docket_entries"][0][

--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -522,10 +522,14 @@ class NotificationEmail(BaseDocketReport, BaseReport):
         docket_number = self.docket_numbers[0]
         case_name = self.case_names[0]
 
-        if self.court_id == "ctb":
-            # In: 23-20091 Corrected Amendment
-            # Out: Corrected Amendment
+        if self.court_id == "cacb" or self.court_id == "ctb":
+            # In: 6:22-bk-13643-SY Request for courtesy Notice of Electronic Filing (NEF)
+            # Out: Request for courtesy Notice of Electronic Filing (NEF)
             short_description = subject.split(docket_number)[-1]
+
+            # Remove docket number traces "-AAA"
+            regex = r"^-.*?\s"
+            short_description = re.sub(regex, "", short_description)
 
         elif self.court_id == "njb":
             # In: Ch-11 19-27439-MBK Determination of Adjournment Request - Hollister Construc
@@ -556,15 +560,6 @@ class NotificationEmail(BaseDocketReport, BaseReport):
             # In: Ch-7 22-20823-GLT U LOCK INC Reply
             # Out: Reply
             short_description = subject.split(case_name)[-1]
-
-        elif self.court_id == "cacb":
-            # In: 6:22-bk-13643-SY Request for courtesy Notice of Electronic Filing (NEF)
-            # Out: Request for courtesy Notice of Electronic Filing (NEF)
-            short_description = subject.split(docket_number)[-1]
-
-            # Remove docket number traces "-AAA"
-            regex = r"^-.*?\s"
-            short_description = re.sub(regex, "", short_description)
 
         return short_description
 

--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -568,6 +568,8 @@ class NotificationEmail(BaseDocketReport, BaseReport):
         :returns: The short description of the case.
         """
 
+        if not self.subject:
+            return ""
         subject = clean_string(self.subject)
         for case_name in self.case_names:
             # cases_names is a list of strings that can contain one or multiple

--- a/tests/examples/pacer/nda/ca11_1.json
+++ b/tests/examples/pacer/nda/ca11_1.json
@@ -16,7 +16,7 @@
           "pacer_doc_id": "011012414726",
           "pacer_magic_num": "5d3e5e8bb0269ddd",
           "pacer_seq_no": null,
-          "short_description": "Motion filed Take Judicial Notice"
+          "short_description": "Appellant's Motion to Take Judicial Notice"
         }
       ],
       "docket_number": "22-11299"

--- a/tests/examples/pacer/nda/ca11_1.json
+++ b/tests/examples/pacer/nda/ca11_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "78099",
           "pacer_doc_id": "011012414726",
           "pacer_magic_num": "5d3e5e8bb0269ddd",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Motion filed Take Judicial Notice"
         }
       ],
       "docket_number": "22-11299"

--- a/tests/examples/pacer/nda/ca11_2.json
+++ b/tests/examples/pacer/nda/ca11_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "78099",
           "pacer_doc_id": "011012430127",
           "pacer_magic_num": "689705320460ce5c",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Court Order Filed Granted by Court Withdraw as Counsel"
         }
       ],
       "docket_number": "22-11299"

--- a/tests/examples/pacer/nda/ca2_1.json
+++ b/tests/examples/pacer/nda/ca2_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "55129",
           "pacer_doc_id": "00208942267",
           "pacer_magic_num": "37cacbbc313ab362",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Letter RECEIVED"
         }
       ],
       "docket_number": "21-1975"

--- a/tests/examples/pacer/nda/ca2_2.json
+++ b/tests/examples/pacer/nda/ca2_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "55129",
           "pacer_doc_id": "00208883934",
           "pacer_magic_num": "4a800555f691be89",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Letter RECEIVED"
         }
       ],
       "docket_number": "21-1975"

--- a/tests/examples/pacer/nda/ca2_3.json
+++ b/tests/examples/pacer/nda/ca2_3.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "55129",
           "pacer_doc_id": "00208754210",
           "pacer_magic_num": "59a7f7615f78153b",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Appellant/Petitioner Reply Brief FILED"
         }
       ],
       "docket_number": "21-1975"

--- a/tests/examples/pacer/nda/ca2_4.json
+++ b/tests/examples/pacer/nda/ca2_4.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "55129",
           "pacer_doc_id": "00208721516",
           "pacer_magic_num": "b775e9908ad79ce2",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Defective Document FILED"
         }
       ],
       "docket_number": "21-1975"

--- a/tests/examples/pacer/nda/ca2_4.json
+++ b/tests/examples/pacer/nda/ca2_4.json
@@ -16,7 +16,7 @@
           "pacer_doc_id": "00208721516",
           "pacer_magic_num": "b775e9908ad79ce2",
           "pacer_seq_no": null,
-          "short_description": "Defective Document FILED"
+          "short_description": "Defective Document Notice"
         }
       ],
       "docket_number": "21-1975"

--- a/tests/examples/pacer/nda/ca2_5.json
+++ b/tests/examples/pacer/nda/ca2_5.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "56342",
           "pacer_doc_id": "00208962225",
           "pacer_magic_num": "8d96e8f0a9737656",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Appendix FILED"
         }
       ],
       "docket_number": "22-7"

--- a/tests/examples/pacer/nda/ca3_1.json
+++ b/tests/examples/pacer/nda/ca3_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "114792",
           "pacer_doc_id": "003014193380",
           "pacer_magic_num": "3594681a19879633",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Supplemental Brief"
         }
       ],
       "docket_number": "21-1832"

--- a/tests/examples/pacer/nda/ca3_2.json
+++ b/tests/examples/pacer/nda/ca3_2.json
@@ -1,0 +1,26 @@
+{
+  "appellate": true,
+  "contains_attachments": false,
+  "court_id": "ca3",
+  "dockets": [
+    {
+      "case_name": "Port Hamilton Refining and Transportation LLLP v. EPA",
+      "date_filed": "2023-01-27",
+      "docket_entries": [
+        {
+          "date_filed": "2023-01-27",
+          "description": "ECF FILER: Motion filed by Petitioner Port Hamilton Refining and Transportation LLLP to Expedite Case. Certificate of Service dated 01/27/2023. Service made by ECF. [23-1094] (ACS)",
+          "document_number": null,
+          "document_url": "https://ecf.ca3.uscourts.gov/docs1/003014326343?uid=eccc1924d7de560d",
+          "pacer_case_id": "119235",
+          "pacer_doc_id": "003014326343",
+          "pacer_magic_num": "eccc1924d7de560d",
+          "pacer_seq_no": null,
+          "short_description": "Motion for expedited proceeding"
+        }
+      ],
+      "docket_number": "23-1094"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nda/ca3_2.txt
+++ b/tests/examples/pacer/nda/ca3_2.txt
@@ -33,7 +33,7 @@ Content-Transfer-Encoding: 7bit
 <HEAD>
 <META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>23-1094 Port Hamilton Refining and Transportation LLLP v. EPA "Motion(s)"</TITLE>
 </HEAD>
-<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000">
 <P><STRONG>
 ***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
 <P><CENTER><STRONG>Third Circuit Court of Appeals</STRONG></CENTER>

--- a/tests/examples/pacer/nda/ca3_2.txt
+++ b/tests/examples/pacer/nda/ca3_2.txt
@@ -1,0 +1,75 @@
+Return-Path: <CMECF_No_Reply@ca3.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 00d5bago6958be9ks75o8q9ffadi4msbuvf4qso1
+ for recipient@example.com;
+ Sat, 28 Jan 2023 02:01:10 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ca3.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=CMECF_No_Reply@ca3.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ca3.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=CMECF_No_Reply@ca3.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ca3.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFQjFkNTVYUnJZNEpxNjRoUDB5b2xsWjV1SzM5Z3ZXVmFHN0FDT3MzaEZLWWY1UDR1dVJiYVJwR0I0VkZQUlRZZ3JUTWNZdWpOMi9BdjE2VlVGVDg4OGxWcmlCZVl0S0tpZ0x6YldvK2FWUGdUaXVoZDgrRzBsSnFaTUtzUDlEUWNzNG4vbUtBUWozRFp3K1VYK1A0Z25OWEs1aFU3TkozelVLNnB4UkZoOFBrTWNuOUpkNGh6VVVMRGJKc3hXTmFYNHlZNnZla3pyOCtsR0tRV0JpMXd4cnU0aG40aWkwVkVCVitsTUxTeUdIOTk4N2hSWlg1RVJiOVJVL3V2UVlhVFN6VGs3UXYrVTBSdUdKSHRDVUo4SGp1cUFxNzc5OUNOVU9MamFha2U0bGVtYUFTWE9CZG1maXVwaVVLdTRrTXc9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=KI/wYC8spQPtOq1t/Esng68/5tC+qQ5ca32eb6f6aCr+0RdaG982EzkY9+sB70WymCayVQWkumRh0cbSoDQR7aqnfQ+hszqs1N9KU7jSc9g4WMYDIOyvA+2dsnb9CbSXKoF+wdWLQKwKqIbwaXntXjFt+GAs4DO6VooIZoojIRo=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1674871271; v=1; bh=vpHJvNNSHTNDQS1nNROWfJgT1pFrVSEY09w1TZ0421c=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.191.41
+Received: from ca3db.ca3.gtwy.dcn ([156.119.191.41])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 27 Jan 2023 21:01:10 -0500
+Received: from ca3db.ca3.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ca3db.ca3.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 30S20TeO086943
+	for <recipient@example.com>; Fri, 27 Jan 2023 21:00:29 -0500
+Date: Fri, 27 Jan 2023 21:00:29 -0500 (EST)
+From: CMECF_No_Reply@ca3.uscourts.gov
+To: recipient@example.com
+Message-ID: <1710792256.2332.1674871229551@ca3db.ca3.gtwy.dcn>
+Subject: 23-1094 Port Hamilton Refining and Transportation LLLP v. EPA
+ "Motion(s)"
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: 7bit
+
+<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">
+<HTML>
+<HEAD>
+<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=utf-8"><TITLE>23-1094 Port Hamilton Refining and Transportation LLLP v. EPA "Motion(s)"</TITLE>
+</HEAD>
+<BODY BGCOLOR="#FFFFDA" TEXT="#000000" LINK="#0000ff" VLINK="#551a8b" ALINK="#ff0000"> 
+<P><STRONG>
+***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer.  PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing.</STRONG><BR>
+<P><CENTER><STRONG>Third Circuit Court of Appeals</STRONG></CENTER>
+<P><STRONG>Notice of Docket Activity</STRONG><BR>
+<BR>
+The following transaction was filed on 01/27/2023
+<TABLE BORDER=0 CELLSPACING=3>
+<TR><TD><STRONG>Case Name:</STRONG></TD>
+<TD colspan='2'>Port Hamilton Refining and Transportation LLLP v. EPA<BR>
+</TD></TR>
+<TR><TD><STRONG>Case Number:&nbsp;&nbsp;</STRONG></TD>
+<TD><A HREF="https://ecf.ca3.uscourts.gov/n/beam/servlet/TransportRoom?servlet=DocketReportFilter.jsp&caseId=119235">23-1094</A></TD></TR>
+<TR><TD><STRONG>Document(s):</STRONG></TD>
+<TD><A HREF="https://ecf.ca3.uscourts.gov/docs1/003014326343?uid=eccc1924d7de560d">Document(s)</A></TD></TR>
+</TABLE><BR>
+<P><STRONG>Docket Text:</STRONG><BR>
+ECF FILER: Motion filed by Petitioner Port Hamilton Refining and Transportation LLLP to Expedite Case. Certificate of Service dated 01/27/2023. Service made by ECF. [23-1094] (ACS)<BR>
+<BR>
+<STRONG>Notice will be electronically mailed to:</STRONG><BR><BR>
+<BR><BR>
+The following document(s) are associated with this transaction:<BR>
+<STRONG>Document Description: </STRONG>Motion for expedited proceeding<BR>
+<STRONG>Original Filename: </STRONG>Expedited Briefing Motion FINAL.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1107201326 [Date=01/27/2023] [FileNumber=5049293-0] [34a0715e29b6c750aa7bc76ffc9eda882af625dc7257edc5af0fc8033e87646b90bb789d586369a001f06d83bb20e4258fd2b8c69bb8d42e00fc15c6e4bccbed]]<BR>
+<BR><STRONG>Document Description: </STRONG>Declaration of Charles Chambers<BR>
+<STRONG>Original Filename: </STRONG>Charles Chambers Declaration.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1107201326 [Date=01/27/2023] [FileNumber=5049293-1] [9c2129255e88eee317c663b3cfdc1c5bc2db8ea2ff2c24891b8a40265a42242603acc8b9d4d593098ffd2ea6b255c5ae1f4330422320efbb567214530c8e767c]]<BR>
+<BR><STRONG>Document Description: </STRONG>Eduardo del Valle declaration<BR>
+<STRONG>Original Filename: </STRONG>Eduardo del Valle declaration.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1107201326 [Date=01/27/2023] [FileNumber=5049293-2] [2b3c7148dd6a7eec1db71c10a3672c28da93fca5f630da3d0d280834a7fc99291b4eba362910b75865e5d2cbba4ce836e301c320c8b0e4721a919d7feb06111d]]<BR>
+<BR><STRONG>Document Description: </STRONG>Proposed Briefing Schedule<BR>
+<STRONG>Original Filename: </STRONG>Proposed briefing schedule.pdf<BR>
+<STRONG>Electronic Document Stamp:</STRONG><BR>
+[STAMP acecfStamp_ID=1107201326 [Date=01/27/2023] [FileNumber=5049293-3] [cb0c131c0eb692939a28366edd4abbb4c44e9a4d88d0790e4170d476892f996d3b1f974a79c86d0eec365a287bdf7a91efdcc69350090aa3a50a5b0db5d810e6]]<BR>
+<BR>
+</BODY></HTML>

--- a/tests/examples/pacer/nda/ca4_1.json
+++ b/tests/examples/pacer/nda/ca4_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "164306",
           "pacer_doc_id": "00409007652",
           "pacer_magic_num": "ee31b72c3fff6b7f",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Case continued from tentative calendar"
         }
       ],
       "docket_number": "21-1919"

--- a/tests/examples/pacer/nda/ca4_2.json
+++ b/tests/examples/pacer/nda/ca4_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "164306",
           "pacer_doc_id": "00409006913",
           "pacer_magic_num": "55e8d970a5a88b7a",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Notice re:"
         }
       ],
       "docket_number": "21-1919"

--- a/tests/examples/pacer/nda/ca4_2.json
+++ b/tests/examples/pacer/nda/ca4_2.json
@@ -16,7 +16,7 @@
           "pacer_doc_id": "00409006913",
           "pacer_magic_num": "55e8d970a5a88b7a",
           "pacer_seq_no": null,
-          "short_description": "Notice re:"
+          "short_description": "Notice re: Regarding Resolution of Conflict with Proposed Argument dates"
         }
       ],
       "docket_number": "21-1919"

--- a/tests/examples/pacer/nda/ca5_1.json
+++ b/tests/examples/pacer/nda/ca5_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "208667",
           "pacer_doc_id": "00506433781",
           "pacer_magic_num": "12e61e2debdbca3f",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Record Excerpts Filed"
         }
       ],
       "docket_number": "22-30371"

--- a/tests/examples/pacer/nda/ca5_2.json
+++ b/tests/examples/pacer/nda/ca5_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "208282",
           "pacer_doc_id": "00506485029",
           "pacer_magic_num": "c0adda9683f9e753",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Motion Filed on Behalf of Party leave to file document"
         }
       ],
       "docket_number": "22-30311"

--- a/tests/examples/pacer/nda/ca6_1.json
+++ b/tests/examples/pacer/nda/ca6_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "143725",
           "pacer_doc_id": "006014767502",
           "pacer_magic_num": "e957a05e64b3113b",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "motion extend time to file brief"
         }
       ],
       "docket_number": "22-3289"

--- a/tests/examples/pacer/nda/ca6_2.json
+++ b/tests/examples/pacer/nda/ca6_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "144305",
           "pacer_doc_id": "006014769961",
           "pacer_magic_num": "271f3379c94d3ba7",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "ruling letter sent"
         }
       ],
       "docket_number": "22-1458"

--- a/tests/examples/pacer/nda/ca6_2.json
+++ b/tests/examples/pacer/nda/ca6_2.json
@@ -16,7 +16,7 @@
           "pacer_doc_id": "006014769961",
           "pacer_magic_num": "271f3379c94d3ba7",
           "pacer_seq_no": null,
-          "short_description": "ruling letter sent"
+          "short_description": "Reset Briefing Schedule Letter"
         }
       ],
       "docket_number": "22-1458"

--- a/tests/examples/pacer/nda/ca9_1.json
+++ b/tests/examples/pacer/nda/ca9_1.json
@@ -16,7 +16,7 @@
           "pacer_doc_id": "009033568259",
           "pacer_magic_num": "337433b9bebbd7c7",
           "pacer_seq_no": null,
-          "short_description": "Correspondence/Letter to Court"
+          "short_description": "Appellants' Response to Appellee Facebook's July 29, 2022 letter"
         }
       ],
       "docket_number": "21-16499"

--- a/tests/examples/pacer/nda/ca9_1.json
+++ b/tests/examples/pacer/nda/ca9_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "334146",
           "pacer_doc_id": "009033568259",
           "pacer_magic_num": "337433b9bebbd7c7",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Correspondence/Letter to Court"
         }
       ],
       "docket_number": "21-16499"

--- a/tests/examples/pacer/nda/ca9_2.json
+++ b/tests/examples/pacer/nda/ca9_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "320925",
           "pacer_doc_id": "009033566943",
           "pacer_magic_num": "cf70d9ec8f85b22f",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Amicus Brief by Government or with Consent"
         }
       ],
       "docket_number": "20-15568"

--- a/tests/examples/pacer/nda/ca9_3.json
+++ b/tests/examples/pacer/nda/ca9_3.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "334146",
           "pacer_doc_id": "009033568331",
           "pacer_magic_num": "472bdf5935654af5",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "28(j) Letter (Citation of Supplemental Authorities)"
         }
       ],
       "docket_number": "21-16499"

--- a/tests/examples/pacer/nda/ca9_4.json
+++ b/tests/examples/pacer/nda/ca9_4.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "320925",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Deleted Entry"
         }
       ],
       "docket_number": "20-15568"

--- a/tests/examples/pacer/nda/ca9_5.json
+++ b/tests/examples/pacer/nda/ca9_5.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "341370",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Add Attorney"
         }
       ],
       "docket_number": "22-16810"

--- a/tests/examples/pacer/nda/cafc_1.json
+++ b/tests/examples/pacer/nda/cafc_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "18362",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Clerk Order Filed"
         }
       ],
       "docket_number": "22-1455"

--- a/tests/examples/pacer/nda/cafc_2.json
+++ b/tests/examples/pacer/nda/cafc_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "18362",
           "pacer_doc_id": "01301993624",
           "pacer_magic_num": "4c6ae1ed93856cd0",
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Motion EXTEND TIME TO FILE BRIEF"
         }
       ],
       "docket_number": "22-1455"

--- a/tests/examples/pacer/nef/ared_1.json
+++ b/tests/examples/pacer/nef/ared_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "120574",
           "pacer_doc_id": "02705212035",
           "pacer_magic_num": "99963705",
-          "pacer_seq_no": "83"
+          "pacer_seq_no": "83",
+          "short_description": ""
         }
       ],
       "docket_number": "4:20-cv-00065"

--- a/tests/examples/pacer/nef/ared_2.json
+++ b/tests/examples/pacer/nef/ared_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "128089",
           "pacer_doc_id": "02705212135",
           "pacer_magic_num": "45019712",
-          "pacer_seq_no": "10"
+          "pacer_seq_no": "10",
+          "short_description": ""
         }
       ],
       "docket_number": "4:21-cv-00428"

--- a/tests/examples/pacer/nef/ared_3.json
+++ b/tests/examples/pacer/nef/ared_3.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "126540",
           "pacer_doc_id": "02705212553",
           "pacer_magic_num": "69077486",
-          "pacer_seq_no": "134"
+          "pacer_seq_no": "134",
+          "short_description": ""
         }
       ],
       "docket_number": "4:21-cv-00075"

--- a/tests/examples/pacer/nef/arwd.json
+++ b/tests/examples/pacer/nef/arwd.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "62106",
           "pacer_doc_id": "02902287538",
           "pacer_magic_num": "46758052",
-          "pacer_seq_no": "36"
+          "pacer_seq_no": "36",
+          "short_description": ""
         }
       ],
       "docket_number": "2:21-cv-02016"

--- a/tests/examples/pacer/nef/cacd.json
+++ b/tests/examples/pacer/nef/cacd.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "779377",
           "pacer_doc_id": "031035341704",
           "pacer_magic_num": null,
-          "pacer_seq_no": "3644"
+          "pacer_seq_no": "3644",
+          "short_description": ""
         }
       ],
       "docket_number": "5:20-cv-00768"

--- a/tests/examples/pacer/nef/cand.json
+++ b/tests/examples/pacer/nef/cand.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "364265",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": ""
         }
       ],
       "docket_number": "4:20-cv-05640"

--- a/tests/examples/pacer/nef/ned.json
+++ b/tests/examples/pacer/nef/ned.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "89973",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": ""
         }
       ],
       "docket_number": "8:20-cv-00510"

--- a/tests/examples/pacer/nef/s3/almd_1.json
+++ b/tests/examples/pacer/nef/s3/almd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "75736",
           "pacer_doc_id": "01703718205",
           "pacer_magic_num": "77910494",
-          "pacer_seq_no": "30"
+          "pacer_seq_no": "30",
+          "short_description": "Notice (Other)"
         }
       ],
       "docket_number": "3:21-cv-00437"

--- a/tests/examples/pacer/nef/s3/almd_2.json
+++ b/tests/examples/pacer/nef/s3/almd_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "206379",
           "pacer_doc_id": "20904522284",
           "pacer_magic_num": "20105679",
-          "pacer_seq_no": "204"
+          "pacer_seq_no": "204",
+          "short_description": "Notice (Other)"
         }
       ],
       "docket_number": "3:21-cv-00437"

--- a/tests/examples/pacer/nef/s3/almd_3_plain.json
+++ b/tests/examples/pacer/nef/s3/almd_3_plain.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "20190598",
           "pacer_doc_id": "04507059984",
           "pacer_magic_num": "34532",
-          "pacer_seq_no": "2335"
+          "pacer_seq_no": "2335",
+          "short_description": "Status Report"
         }
       ],
       "docket_number": "1:17-cr-00201"

--- a/tests/examples/pacer/nef/s3/almd_4_plain.json
+++ b/tests/examples/pacer/nef/s3/almd_4_plain.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "20190598",
           "pacer_doc_id": "04507059984",
           "pacer_magic_num": "34532",
-          "pacer_seq_no": "2335"
+          "pacer_seq_no": "2335",
+          "short_description": "Status Report"
         }
       ],
       "docket_number": "1:17-cr-00201"

--- a/tests/examples/pacer/nef/s3/alsd_1.json
+++ b/tests/examples/pacer/nef/s3/alsd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "67868",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Document Noted"
         }
       ],
       "docket_number": "1:21-cv-00057"

--- a/tests/examples/pacer/nef/s3/alsd_2.json
+++ b/tests/examples/pacer/nef/s3/alsd_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "67868",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Document Noted"
         }
       ],
       "docket_number": "1:21-cv-00057"

--- a/tests/examples/pacer/nef/s3/alsd_3.json
+++ b/tests/examples/pacer/nef/s3/alsd_3.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "67619",
           "pacer_doc_id": "02103212100",
           "pacer_magic_num": "95052604",
-          "pacer_seq_no": "99"
+          "pacer_seq_no": "99",
+          "short_description": "Notice of Settlement"
         }
       ],
       "docket_number": "1:20-cv-00572"

--- a/tests/examples/pacer/nef/s3/ared_1.json
+++ b/tests/examples/pacer/nef/s3/ared_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "121728",
           "pacer_doc_id": "02705225168",
           "pacer_magic_num": "74127345",
-          "pacer_seq_no": "40"
+          "pacer_seq_no": "40",
+          "short_description": "Response to Statement of Facts"
         }
       ],
       "docket_number": "2:20-cv-00082"

--- a/tests/examples/pacer/nef/s3/ared_2.json
+++ b/tests/examples/pacer/nef/s3/ared_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "123862",
           "pacer_doc_id": "02705225295",
           "pacer_magic_num": "44035396",
-          "pacer_seq_no": "25"
+          "pacer_seq_no": "25",
+          "short_description": "Notice of Appearance"
         }
       ],
       "docket_number": "4:20-cv-01091"

--- a/tests/examples/pacer/nef/s3/ared_3.json
+++ b/tests/examples/pacer/nef/s3/ared_3.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "128089",
           "pacer_doc_id": "02705232355",
           "pacer_magic_num": "77603496",
-          "pacer_seq_no": "15"
+          "pacer_seq_no": "15",
+          "short_description": "Amended Complaint"
         }
       ],
       "docket_number": "4:21-cv-00428"

--- a/tests/examples/pacer/nef/s3/ared_4.json
+++ b/tests/examples/pacer/nef/s3/ared_4.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "125473",
           "pacer_doc_id": "02705232553",
           "pacer_magic_num": "51422299",
-          "pacer_seq_no": "31"
+          "pacer_seq_no": "31",
+          "short_description": "Motion for Recusal"
         }
       ],
       "docket_number": "4:20-cv-01296"

--- a/tests/examples/pacer/nef/s3/ared_5.json
+++ b/tests/examples/pacer/nef/s3/ared_5.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "123862",
           "pacer_doc_id": "02705225301",
           "pacer_magic_num": "22391555",
-          "pacer_seq_no": "28"
+          "pacer_seq_no": "28",
+          "short_description": "Motion for Extension of Time to Complete Discovery"
         }
       ],
       "docket_number": "4:20-cv-01091"

--- a/tests/examples/pacer/nef/s3/ared_6.json
+++ b/tests/examples/pacer/nef/s3/ared_6.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "125473",
           "pacer_doc_id": "02705232704",
           "pacer_magic_num": "39122308",
-          "pacer_seq_no": "38"
+          "pacer_seq_no": "38",
+          "short_description": "Brief in Support"
         }
       ],
       "docket_number": "4:20-cv-01296"

--- a/tests/examples/pacer/nef/s3/ared_7.json
+++ b/tests/examples/pacer/nef/s3/ared_7.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "113274",
           "pacer_doc_id": "02705260440",
           "pacer_magic_num": "29822617",
-          "pacer_seq_no": "173"
+          "pacer_seq_no": "173",
+          "short_description": "Motion for Attorney Fees"
         }
       ],
       "docket_number": "5:18-cv-00222"

--- a/tests/examples/pacer/nef/s3/arwd_1.json
+++ b/tests/examples/pacer/nef/s3/arwd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "63245",
           "pacer_doc_id": "02902295522",
           "pacer_magic_num": "74113823",
-          "pacer_seq_no": "28"
+          "pacer_seq_no": "28",
+          "short_description": "Answer to Complaint (Attorney filed Complaint)"
         }
       ],
       "docket_number": "2:21-cv-02107"

--- a/tests/examples/pacer/nef/s3/arwd_2.json
+++ b/tests/examples/pacer/nef/s3/arwd_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "63245",
           "pacer_doc_id": "02902295525",
           "pacer_magic_num": "7831676",
-          "pacer_seq_no": "30"
+          "pacer_seq_no": "30",
+          "short_description": "Corporate Disclosure Statement - Filed by Attorney"
         }
       ],
       "docket_number": "2:21-cv-02107"

--- a/tests/examples/pacer/nef/s3/arwd_3.json
+++ b/tests/examples/pacer/nef/s3/arwd_3.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "62641",
           "pacer_doc_id": "02902299302",
           "pacer_magic_num": "47155571",
-          "pacer_seq_no": "34"
+          "pacer_seq_no": "34",
+          "short_description": "Final Scheduling Order"
         }
       ],
       "docket_number": "5:21-cv-05075"

--- a/tests/examples/pacer/nef/s3/arwd_4.json
+++ b/tests/examples/pacer/nef/s3/arwd_4.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "63245",
           "pacer_doc_id": "02902295533",
           "pacer_magic_num": "45937239",
-          "pacer_seq_no": "32"
+          "pacer_seq_no": "32",
+          "short_description": "Initial Scheduling Order"
         }
       ],
       "docket_number": "2:21-cv-02107"

--- a/tests/examples/pacer/nef/s3/arwd_5.json
+++ b/tests/examples/pacer/nef/s3/arwd_5.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "62145",
           "pacer_doc_id": "02902313883",
           "pacer_magic_num": "14933770",
-          "pacer_seq_no": "54"
+          "pacer_seq_no": "54",
+          "short_description": "Motion for Extension of Time to File Response/Reply"
         }
       ],
       "docket_number": "1:21-cv-01008"

--- a/tests/examples/pacer/nef/s3/cacb_1.json
+++ b/tests/examples/pacer/nef/s3/cacb_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1952574",
           "pacer_doc_id": "9730105877880",
           "pacer_magic_num": "73586484",
-          "pacer_seq_no": "8"
+          "pacer_seq_no": "8",
+          "short_description": "Statement About Your Social Security Numbers (Official Form 121)"
         }
       ],
       "docket_number": "6:22-bk-13768"

--- a/tests/examples/pacer/nef/s3/cacb_2.json
+++ b/tests/examples/pacer/nef/s3/cacb_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1952574",
           "pacer_doc_id": "9730105879764",
           "pacer_magic_num": "17864844",
-          "pacer_seq_no": "20"
+          "pacer_seq_no": "20",
+          "short_description": "Request for courtesy Notice of Electronic Filing (NEF)"
         }
       ],
       "docket_number": "6:22-bk-13768"

--- a/tests/examples/pacer/nef/s3/cacb_3.json
+++ b/tests/examples/pacer/nef/s3/cacb_3.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1952165",
           "pacer_doc_id": "9730105870952",
           "pacer_magic_num": "25971254",
-          "pacer_seq_no": "39"
+          "pacer_seq_no": "39",
+          "short_description": "Request for courtesy Notice of Electronic Filing (NEF)"
         }
       ],
       "docket_number": "6:22-bk-13643"

--- a/tests/examples/pacer/nef/s3/cacb_6.json
+++ b/tests/examples/pacer/nef/s3/cacb_6.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1949949",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Hearing Rescheduled/Continued (Motion) (BK Case - BNC Option)"
         }
       ],
       "docket_number": "6:22-bk-13036"
@@ -24,8 +25,16 @@
   "email_recipients": [
     {
       "email_addresses": [
-        "testing_a@gexample.com",
-        "testing_a_a@gexample.com"
+        "notice-efile@rodan13.com",
+        "bhestonecf@gmail.com",
+        "benheston@recap.emailNexusBankruptcy@jubileebk.net",
+        "sith@cookseylaw.com",
+        "christinao@mclaw.org",
+        "CACD_ECF@mclaw.org;mcecfnotices@ecf.courtdrive.com",
+        "christinao@mclaw.org",
+        "CACD_ECF@mclaw.org;mcecfnotices@ecf.courtdrive.com",
+        "claims@recoverycorp.com",
+        "ustpregion16.rs.ecf@usdoj.gov"
       ],
       "name": ""
     }

--- a/tests/examples/pacer/nef/s3/cacb_6.json
+++ b/tests/examples/pacer/nef/s3/cacb_6.json
@@ -25,16 +25,8 @@
   "email_recipients": [
     {
       "email_addresses": [
-        "notice-efile@rodan13.com",
-        "bhestonecf@gmail.com",
-        "benheston@recap.emailNexusBankruptcy@jubileebk.net",
-        "sith@cookseylaw.com",
-        "christinao@mclaw.org",
-        "CACD_ECF@mclaw.org;mcecfnotices@ecf.courtdrive.com",
-        "christinao@mclaw.org",
-        "CACD_ECF@mclaw.org;mcecfnotices@ecf.courtdrive.com",
-        "claims@recoverycorp.com",
-        "ustpregion16.rs.ecf@usdoj.gov"
+        "testing_a@gexample.com",
+        "testing_a_a@gexample.com"
       ],
       "name": ""
     }

--- a/tests/examples/pacer/nef/s3/cacb_6.txt
+++ b/tests/examples/pacer/nef/s3/cacb_6.txt
@@ -1,7 +1,7 @@
 Return-Path: <cmecfhelpdesk@cacb.uscourts.gov>
 Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
  by inbound-smtp.us-west-2.amazonaws.com with SMTP id eipjvcrk1ug51406eka0sgs0och9hlcptotqh5g1
- for recipient@example.com;
+ for benheston@recap.email;
  Wed, 08 Mar 2023 18:41:39 +0000 (UTC)
 X-SES-Spam-Verdict: PASS
 X-SES-Virus-Verdict: PASS
@@ -80,8 +80,27 @@ Hearing Rescheduled/Continued (Motion) (BK Case - BNC Option) (RE: related docum
 </B>
 
 <BR>
-<BR><span class="personName">Test user</span>
-<br>testing_a@gexample.com, testing_a_a@gexample.com
+
+<BR><span class="personName">Rod  Danielson (TR)</span>
+<br>notice-efile@rodan13.com
+<BR>
+<BR><span class="personName">Benjamin  Heston on behalf of Debtor Lara  Fakhoury</span>
+<br>bhestonecf@gmail.com,  benheston@recap.email,NexusBankruptcy@jubileebk.net
+<BR>
+<BR><span class="personName">Sheryl K Ith on behalf of Creditor   ACAR Leasing LTD d/b/a GM Financial Leasing</span>
+<br>sith@cookseylaw.com
+<BR>
+<BR><span class="personName">Christina J Khil on behalf of Creditor   ServiceMac, LLC as servicer for Wilmington Trust, National Association, not in its individual capacity but solely as trustee of MFRA Trust 2015-2</span>
+<br>christinao@mclaw.org,  CACD_ECF@mclaw.org;mcecfnotices@ecf.courtdrive.com
+<BR>
+<BR><span class="personName">Christina J Khil on behalf of Creditor   Wilmington Trust, National Association, not in its individual Capacity but solely as Trustee of MFRA Trust 2015-2</span>
+<br>christinao@mclaw.org,  CACD_ECF@mclaw.org;mcecfnotices@ecf.courtdrive.com
+<BR>
+<BR><span class="personName">Valerie  Smith on behalf of Interested Party   Courtesy NEF</span>
+<br>claims@recoverycorp.com
+<BR>
+<BR><span class="personName">  United States Trustee (RS)</span>
+<br>ustpregion16.rs.ecf@usdoj.gov
 <BR>
 
 <BR>

--- a/tests/examples/pacer/nef/s3/cacb_6.txt
+++ b/tests/examples/pacer/nef/s3/cacb_6.txt
@@ -1,7 +1,7 @@
 Return-Path: <cmecfhelpdesk@cacb.uscourts.gov>
 Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
  by inbound-smtp.us-west-2.amazonaws.com with SMTP id eipjvcrk1ug51406eka0sgs0och9hlcptotqh5g1
- for benheston@recap.email;
+ for recipient@example.com;
  Wed, 08 Mar 2023 18:41:39 +0000 (UTC)
 X-SES-Spam-Verdict: PASS
 X-SES-Virus-Verdict: PASS
@@ -80,27 +80,8 @@ Hearing Rescheduled/Continued (Motion) (BK Case - BNC Option) (RE: related docum
 </B>
 
 <BR>
-
-<BR><span class="personName">Rod  Danielson (TR)</span>
-<br>notice-efile@rodan13.com
-<BR>
-<BR><span class="personName">Benjamin  Heston on behalf of Debtor Lara  Fakhoury</span>
-<br>bhestonecf@gmail.com,  benheston@recap.email,NexusBankruptcy@jubileebk.net
-<BR>
-<BR><span class="personName">Sheryl K Ith on behalf of Creditor   ACAR Leasing LTD d/b/a GM Financial Leasing</span>
-<br>sith@cookseylaw.com
-<BR>
-<BR><span class="personName">Christina J Khil on behalf of Creditor   ServiceMac, LLC as servicer for Wilmington Trust, National Association, not in its individual capacity but solely as trustee of MFRA Trust 2015-2</span>
-<br>christinao@mclaw.org,  CACD_ECF@mclaw.org;mcecfnotices@ecf.courtdrive.com
-<BR>
-<BR><span class="personName">Christina J Khil on behalf of Creditor   Wilmington Trust, National Association, not in its individual Capacity but solely as Trustee of MFRA Trust 2015-2</span>
-<br>christinao@mclaw.org,  CACD_ECF@mclaw.org;mcecfnotices@ecf.courtdrive.com
-<BR>
-<BR><span class="personName">Valerie  Smith on behalf of Interested Party   Courtesy NEF</span>
-<br>claims@recoverycorp.com
-<BR>
-<BR><span class="personName">  United States Trustee (RS)</span>
-<br>ustpregion16.rs.ecf@usdoj.gov
+<BR><span class="personName">Test user</span>
+<br>testing_a@gexample.com, testing_a_a@gexample.com
 <BR>
 
 <BR>

--- a/tests/examples/pacer/nef/s3/cand_1.json
+++ b/tests/examples/pacer/nef/s3/cand_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "401001",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": ""
         }
       ],
       "docket_number": "4:22-cv-05541"

--- a/tests/examples/pacer/nef/s3/cand_3.json
+++ b/tests/examples/pacer/nef/s3/cand_3.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "318403",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Motion Hearing"
         }
       ],
       "docket_number": "3:17-cv-06011"
@@ -32,7 +33,8 @@
           "pacer_case_id": "318404",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Motion Hearing"
         }
       ],
       "docket_number": "3:17-cv-06012"

--- a/tests/examples/pacer/nef/s3/ctb_1.json
+++ b/tests/examples/pacer/nef/s3/ctb_1.json
@@ -1,0 +1,26 @@
+{
+  "appellate": false,
+  "contains_attachments": true,
+  "court_id": "ctb",
+  "dockets": [
+    {
+      "case_name": "Alan E. Waskowicz",
+      "date_filed": "2023-02-16",
+      "docket_entries": [
+        {
+          "date_filed": "2023-02-16",
+          "description": "Corrected Amendment Filed by Michael J. Habib on behalf of Alan E. Waskowicz Debtor, (Attachments: (1) Certificate of Service) (Habib, Michael)",
+          "document_number": "10",
+          "document_url": "https://ecf.ctb.uscourts.gov/doc1/040014673506?pdf_header=&magic_num=5573258&de_seq_num=33&caseid=309656",
+          "pacer_case_id": "309656",
+          "pacer_doc_id": "040014673506",
+          "pacer_magic_num": "5573258",
+          "pacer_seq_no": "33",
+          "short_description": "Corrected Amendment"
+        }
+      ],
+      "docket_number": "23-20091"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nef/s3/ctb_1.txt
+++ b/tests/examples/pacer/nef/s3/ctb_1.txt
@@ -1,0 +1,110 @@
+Return-Path: <CTBECF_Courtmail@ctb.uscourts.gov>
+Received: from icmecf202.gtwy.uscourts.gov (icmecf202.gtwy.uscourts.gov [63.241.40.205])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 0m6bkhf4rdlbmok7hlg4cn109alh3gn6ijhn0jg1
+ for recipient@example.com;
+ Fri, 17 Feb 2023 01:13:57 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ctb.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=CTBECF_Courtmail@ctb.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ctb.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=CTBECF_Courtmail@ctb.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+ dmarc=none header.from=ctb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFWjBlM3ZTa205aTd2SEN3dlE4QkU0aSszY2xhZDdhd3VVeWRNeEpDeEhCdnNSVGI4NTZiMkFVenNuNEpFektKUVJyN2YrL3VTUSt4V0FzWlhEa2tWOWpTa1BtdGpKNHlYL3VXazVxNVgyNWR2cmEvZSt2RmUvTUt4dEVRY2Erb3VxOUVSQjdwQzJZcVF6RzZrdW9tTStyQk5FR0ZKQUdKQXlYcDFrRnRoVEd3NVFKU3I0eXpXay9XMDZ6S0Y0QTQ4YVBMekZFdlNpaXhsVzcrTXcvOGt2aDl4SVRUUTJPT292bURQSWdYcjFWTUZBYU45THlHaDJhU283Q0RhZ2RpMzN3c1FqZkdFa2dxYmFicjAyVWd2S05BT2VVdjRrcUlMd2xubzc5NUhkb1ZvSllaaWNqMldvMGJhOXdudEY2dFE9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=STzU1nILtQ2/c24v2IjHZ262lSVtivG777dqycem/JF81vtNtrjKnUXaGMCqjzU65apRSj+Bv99IDeDZnIPWO5fKDB6+hSBph/2ACWoJS+k7oTuuZGCBg6j4vxITWyjhJzW5wWQ6A/7KpE95ffwUDm0VTNHd+DV3O+dNo/9ynRw=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1676596438; v=1; bh=esfxUY/36JcbSyjRPK73c0BBSqhFyHzDldqpkaCfPbs=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.191.114
+Received: from ctbdb.ctb.gtwy.dcn ([156.119.191.114])
+  by icmecf202.gtwy.uscourts.gov with ESMTP; 16 Feb 2023 20:13:56 -0500
+Received: from ctbdb.ctb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ctbdb.ctb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 31H1DpES094270;
+	Thu, 16 Feb 2023 20:13:51 -0500
+Received: (from ecf_web@localhost)
+	by ctbdb.ctb.gtwy.dcn (8.14.7/8.14.4/Submit) id 31H1DR8N092975;
+	Thu, 16 Feb 2023 20:13:27 -0500
+Date: Thu, 16 Feb 2023 20:13:27 -0500
+X-Authentication-Warning: ctbdb.ctb.gtwy.dcn: ecf_web set sender to CTBECF_Courtmail@ctb.uscourts.gov using -f
+MIME-Version:1.0
+From:CTBECF_Courtmail@ctb.uscourts.gov
+To:Courtmail@ctb.uscourts.gov
+Message-Id:<15040081@ctb.uscourts.gov>
+Subject:23-20091 Corrected Amendment
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of Connecticut</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Michael J. Habib entered on 2/16/2023 at 8:13 PM EST and filed on 2/16/2023 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Alan E. Waskowicz                                 </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.ctb.uscourts.gov/cgi-bin/DktRpt.pl?309656>23-20091</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.ctb.uscourts.gov/doc1/040014673506?pdf_header=&magic_num=5573258&de_seq_num=33&caseid=309656'>10</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Corrected Amendment <i>Schedule E/F</i>  Filed by  Michael J. Habib   on behalf of  Alan E. Waskowicz  Debtor,<font color=blue>   (RE: [9] Amended Schedules/Amended List of Creditors filed by Debtor Alan E. Waskowicz).  </font>   (Attachments: # (1)  Certificate of Service) (Habib, Michael)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>Corrected Amended Schedule EF_02.16.23.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1018027260 [Date=2/16/2023] [FileNumber=15040079-
+<BR><TAB>0] [65cd83242d26417153a5e5e93fa5711472ba7db3fcf67ab620c1e73ac6218a6af6
+<BR><TAB>770b40457ab63c40bd4cb9ee43573ceb5b2817073e07a1a725a7070879adf1]]
+<BR>
+<STRONG>Document description:</STRONG> Certificate of Service
+<BR><STRONG>Original filename:</STRONG>C:\fakepath\Cert of Srvc_Corrected Amended Schedule EF_Waskowicz_02.16.2023.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1018027260 [Date=2/16/2023] [FileNumber=15040079-
+<BR><TAB>1] [d01d62ff924de034471365dcb2e5806ecbb0f25028dab1a06686eab7c50dee34b7
+<BR><TAB>a5a284825bac415b89ad0285e4ec843620ee8bb579dd608cc022956685c94d]]
+<BR>
+
+</table>
+</div>
+
+
+
+<BR>
+<B>
+23-20091 Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR>
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/ctb_2.json
+++ b/tests/examples/pacer/nef/s3/ctb_2.json
@@ -1,0 +1,26 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "ctb",
+  "dockets": [
+    {
+      "case_name": "Alan E. Waskowicz",
+      "date_filed": "2023-02-17",
+      "docket_entries": [
+        {
+          "date_filed": "2023-02-17",
+          "description": "ECF No. 5 Generated for BNC Noticing.. (kpb)",
+          "document_number": "13",
+          "document_url": "https://ecf.ctb.uscourts.gov/doc1/040014673829?pdf_header=&magic_num=58206962&de_seq_num=40&caseid=309656",
+          "pacer_case_id": "309656",
+          "pacer_doc_id": "040014673829",
+          "pacer_magic_num": "58206962",
+          "pacer_seq_no": "40",
+          "short_description": "Generate BNC Notice/Form"
+        }
+      ],
+      "docket_number": "23-20091"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nef/s3/ctb_2.txt
+++ b/tests/examples/pacer/nef/s3/ctb_2.txt
@@ -1,0 +1,102 @@
+Return-Path: <CTBECF_Courtmail@ctb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id ul69tcvddn8mcbsbmdatf5fa07g5l2mp98eotc01
+ for recipient@example.com;
+ Fri, 17 Feb 2023 13:37:55 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ctb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=CTBECF_Courtmail@ctb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ctb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=CTBECF_Courtmail@ctb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ctb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFIZHlhcTBjTm5vaDBudnRrVkVCVVJVTzYrVFVjZGNLZGVnY2d6SW93UG1XNFNkR2wzaHdCVEgxaUZyT3REdDFyWjk5U01mbjlIUjhIQnBFL1pnMmRqai9Sd1dFY2N1dXNremJDMnlnSS9KZld6ei9wamxwd0xjZmtOb1U1MHZNMTVGN0ludU5sUHBjQjhLUnZXVVFIOE9oUXhla2RNRmpJaVB3UmQ5MWFZRVFoRjduY2xTR0MvdHhTeFMrQm9zTUdscWp6Qjd6R3FacVpTYXZ0TjZEWmg2YThwbTZGVnpkdi9mSHVNSUlGc0d6V0tSS2YrTGtDWUNDMnJReGI5TTUyZGJjcU9Kc0JYeERRYm41eldHUDRrbWRldzM4YWRGQllrSlEzamZySkRob0ZtT29yVTJ1cFdleGVRaVAxcmtUdjA9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=PIvL7qdaOzwv23iFCdu2kADr+Sz8yYKsGvu2J0itA8g5tAlyl8XcVWjZex+WrCEWpc2l16JQIlurtX6SVgJRNRKQ2QL0/XqfgfTskHVdA551AWJbAiputXEhWFvsGN3MzO/HQxtMl/556tQd0Y2eL6B5uOwPSjIuaWdPr/nFaQY=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1676641076; v=1; bh=3oBoiy/0L6ePxw9TXb3H0KqzbdCW3VS2AXEv7mehP8E=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.191.114
+Received: from ctbdb.ctb.gtwy.dcn ([156.119.191.114])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 17 Feb 2023 08:37:55 -0500
+Received: from ctbdb.ctb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by ctbdb.ctb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 31HDbq16030572;
+	Fri, 17 Feb 2023 08:37:53 -0500
+Received: (from ecf_web@localhost)
+	by ctbdb.ctb.gtwy.dcn (8.14.7/8.14.4/Submit) id 31HDblj3030471;
+	Fri, 17 Feb 2023 08:37:47 -0500
+Date: Fri, 17 Feb 2023 08:37:47 -0500
+X-Authentication-Warning: ctbdb.ctb.gtwy.dcn: ecf_web set sender to CTBECF_Courtmail@ctb.uscourts.gov using -f
+MIME-Version:1.0
+From:CTBECF_Courtmail@ctb.uscourts.gov
+To:Courtmail@ctb.uscourts.gov
+Message-Id:<15040387@ctb.uscourts.gov>
+Subject:23-20091 Generate BNC Notice/Form
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of Connecticut</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Clerks Office  kpb entered on 2/17/2023 at 8:37 AM EST and filed on 2/17/2023 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Alan E. Waskowicz                                 </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.ctb.uscourts.gov/cgi-bin/DktRpt.pl?309656>23-20091</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.ctb.uscourts.gov/doc1/040014673829?pdf_header=&magic_num=58206962&de_seq_num=40&caseid=309656'>13</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+ECF No. 5 Generated for BNC Noticing..      (kpb)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>ecf 5.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1018027260 [Date=2/17/2023] [FileNumber=15040385-
+<BR><TAB>0] [a64d9e7ab4be76c566e5ec126508e8eb2b4c523cde6aef028e3ed7f515932f8f99
+<BR><TAB>91eb4fc8a4e87027e6d728b7e378febe881f2ca65b2907fc723d46c9ef0e70]]
+<BR>
+
+</table>
+</div>
+
+
+
+<BR>
+<B>
+23-20091 Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR>
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/ded_1.json
+++ b/tests/examples/pacer/nef/s3/ded_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "76834",
           "pacer_doc_id": "04305714362",
           "pacer_magic_num": "156066",
-          "pacer_seq_no": "529"
+          "pacer_seq_no": "529",
+          "short_description": "Letter"
         }
       ],
       "docket_number": "1:21-cv-01456"

--- a/tests/examples/pacer/nef/s3/ded_2.json
+++ b/tests/examples/pacer/nef/s3/ded_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "76834",
           "pacer_doc_id": "04305716663",
           "pacer_magic_num": "28888345",
-          "pacer_seq_no": "531"
+          "pacer_seq_no": "531",
+          "short_description": "Letter"
         }
       ],
       "docket_number": "1:21-cv-01456"

--- a/tests/examples/pacer/nef/s3/gand_1.json
+++ b/tests/examples/pacer/nef/s3/gand_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "279164",
           "pacer_doc_id": "055013859630",
           "pacer_magic_num": "78443199",
-          "pacer_seq_no": "316"
+          "pacer_seq_no": "316",
+          "short_description": "Order"
         }
       ],
       "docket_number": "1:20-cv-02973"

--- a/tests/examples/pacer/nef/s3/ilnd_1.json
+++ b/tests/examples/pacer/nef/s3/ilnd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "404197",
           "pacer_doc_id": "067026041495",
           "pacer_magic_num": "83547811",
-          "pacer_seq_no": "56"
+          "pacer_seq_no": "56",
+          "short_description": "status report"
         }
       ],
       "docket_number": "1:21-cv-02975"

--- a/tests/examples/pacer/nef/s3/jpml_1.json
+++ b/tests/examples/pacer/nef/s3/jpml_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1308920",
           "pacer_doc_id": "85001321035",
           "pacer_magic_num": "85366409",
-          "pacer_seq_no": "424"
+          "pacer_seq_no": "424",
+          "short_description": "Notice of Change of Address"
         }
       ],
       "docket_number": "MDL No. 2967"
@@ -32,7 +33,8 @@
           "pacer_case_id": "1439502",
           "pacer_doc_id": "85001321035",
           "pacer_magic_num": null,
-          "pacer_seq_no": "77"
+          "pacer_seq_no": "77",
+          "short_description": "Notice of Change of Address"
         }
       ],
       "docket_number": "1:21-cv-02960"
@@ -49,7 +51,8 @@
           "pacer_case_id": "1309083",
           "pacer_doc_id": "85001321035",
           "pacer_magic_num": null,
-          "pacer_seq_no": "106"
+          "pacer_seq_no": "106",
+          "short_description": "Notice of Change of Address"
         }
       ],
       "docket_number": "1:20-cv-01296"
@@ -66,7 +69,8 @@
           "pacer_case_id": "1309086",
           "pacer_doc_id": "85001321035",
           "pacer_magic_num": null,
-          "pacer_seq_no": "130"
+          "pacer_seq_no": "130",
+          "short_description": "Notice of Change of Address"
         }
       ],
       "docket_number": "1:20-cv-03104"

--- a/tests/examples/pacer/nef/s3/laed_1.json
+++ b/tests/examples/pacer/nef/s3/laed_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "248571",
           "pacer_doc_id": "085013031004",
           "pacer_magic_num": "50101731",
-          "pacer_seq_no": "341"
+          "pacer_seq_no": "341",
+          "short_description": "Motion for Partial Summary Judgment"
         }
       ],
       "docket_number": "2:21-cv-00080"

--- a/tests/examples/pacer/nef/s3/laed_2.json
+++ b/tests/examples/pacer/nef/s3/laed_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "195449",
           "pacer_doc_id": "085013034901",
           "pacer_magic_num": "73113691",
-          "pacer_seq_no": "837"
+          "pacer_seq_no": "837",
+          "short_description": "Scheduling Order"
         }
       ],
       "docket_number": "2:17-cv-02797"

--- a/tests/examples/pacer/nef/s3/njb_1.json
+++ b/tests/examples/pacer/nef/s3/njb_1.json
@@ -1,0 +1,26 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "njb",
+  "dockets": [
+    {
+      "case_name": "Hollister Construction Services, LLC",
+      "date_filed": "2023-01-19",
+      "docket_entries": [
+        {
+          "date_filed": "2023-01-19",
+          "description": "Determination of Adjournment Request Granted. Hearing will be adjourned to FEBRUARY 16, 2023 at 10:00 am. The hearing date is Not Peremptory. (related document:[1973] Motion For Entry Of Order (I) Enforcing Confirmation Order And Plan Against Brendan Murray, (II) Enforcing Settlement Agreement By And Between Hollisters Members Against Brendan Murray, (III) Determining That State Court Litigation Violates Plan And Confirmation Order, And (IV) Granting Related Relief filed by Interested Party Christopher Johnson) (wiq)",
+          "document_number": "1977",
+          "document_url": "https://ecf.njb.uscourts.gov/doc1/118064451932?pdf_header=&magic_num=77673239&de_seq_num=7960&caseid=1051949",
+          "pacer_case_id": "1051949",
+          "pacer_doc_id": "118064451932",
+          "pacer_magic_num": "77673239",
+          "pacer_seq_no": "7960",
+          "short_description": "Determination of Adjournment Request"
+        }
+      ],
+      "docket_number": "19-27439"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nef/s3/njb_1.txt
+++ b/tests/examples/pacer/nef/s3/njb_1.txt
@@ -1,0 +1,98 @@
+Return-Path: <cmecf_help_desk@njb.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id uqrufsbqepfke095ualenafh8qjhsmgsht2tdq01
+ for recipient@example.com;
+ Thu, 19 Jan 2023 19:42:07 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of njb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=cmecf_help_desk@njb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of njb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=cmecf_help_desk@njb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=njb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFGWkUydmxWNW1LVWpuQ2Vvb0F4L29MMEtCMS9kZzNDaTZueUFCejkybDB4dncwRWlnUU5vbk8vWUx2SjhkUzRBc1RieUNBSDhqbFY1MGJlNThDRHgrd3dwNGlEc1JuWGxkZzVoK2t4VjlEUFRnOEVRVW9mczZwQUY0QnBlbit5STRpMXZmQjdRQmpMTytnL0xKUUxhZnYvVEVGWlNSQkRVTlkxaGUxQjBEQ0VNVXYrNkV2ZE1HTEtzODJxeHpUVGRCVkVRQnhQbitmUHpTeGUrNFNIMHNNMXhCTmtQam9lTzlpVVpoWlBkRXp5ZHBjanIzblNpY1NxYVJKRHZWNUNVWHdnZngrUDYzK2Z2QzRIbXJ1UEc5Q3VFYlpaR0FSODlpNVdPWkkrMWZiRXoxa2tKTGpWRWF2cFFIVEdOWU4yRVU9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=bOsOvLoFF6HVTufskJaBhDbJHTyK6ZsPX/4/E4c7CWg2sZOZr+7QcpDVPBvnwTIgFTCCKlNdxR9+oPSip0xKrXMe96sl0Upho50KkWSKakTNlvN6sMUk/yfjW0QfDLpkS2TQfqvA6icCLSzWVIBllm/OZRPSzh72hlLIyUySkjM=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1674157328; v=1; bh=Y7q/5NHNciMLews5WJO0fT43fXnu/u26lGLAP7fvzT0=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.77
+Received: from unknown (HELO njbdb.njb.gtwy.dcn) ([156.119.190.77])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 19 Jan 2023 14:42:06 -0500
+Received: from njbdb.njb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by njbdb.njb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 30JJfKFF073730;
+	Thu, 19 Jan 2023 14:41:29 -0500
+Received: (from ecf_web@localhost)
+	by njbdb.njb.gtwy.dcn (8.14.7/8.14.4/Submit) id 30JJf9jw073380;
+	Thu, 19 Jan 2023 14:41:09 -0500
+Date: Thu, 19 Jan 2023 14:41:09 -0500
+MIME-Version:1.0
+From:cmecf_help_desk@njb.uscourts.gov
+To:no-reply@njb.uscourts.gov
+Message-Id:<60769936@njb.uscourts.gov>
+Subject:Ch-11 19-27439-MBK Determination of Adjournment Request - Hollister Construc
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of New Jersey</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from wiq entered on 1/19/2023 at 2:41 PM EST and filed on 1/19/2023 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Hollister Construction Services, LLC              </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.njb.uscourts.gov/cgi-bin/DktRpt.pl?1051949>19-27439-MBK</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.njb.uscourts.gov/doc1/118064451932?pdf_header=&magic_num=77673239&de_seq_num=7960&caseid=1051949'>1977</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Determination of Adjournment Request Granted. Hearing will be adjourned to FEBRUARY 16, 2023 at 10:00 am. The hearing date is Not Peremptory. (related document:[1973] Motion For Entry Of Order (I) Enforcing Confirmation Order And Plan Against Brendan Murray, (II) Enforcing Settlement Agreement By And Between Hollisters Members Against Brendan Murray, (III) Determining That State Court Litigation Violates Plan And Confirmation Order, And (IV) Granting Related Relief  filed by Interested Party Christopher  Johnson)   (wiq)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>19-27439 adj.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1002741850 [Date=1/19/2023] [FileNumber=60769934-
+<BR><TAB>0] [6c2217d57f45ab37954cfbefb29393e2826de3ce01a05d28d3c17ed52490b198db
+<BR><TAB>6c241fd898e2378bb5e965860d9536792e06e8e85131c44b2272b2a660e39b]]
+<BR>
+
+</table>
+</div>
+
+
+
+<BR><B>
+19-27439-MBK Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/njb_2.json
+++ b/tests/examples/pacer/nef/s3/njb_2.json
@@ -1,0 +1,26 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "njb",
+  "dockets": [
+    {
+      "case_name": "Hollister Construction Services, LLC",
+      "date_filed": "2023-01-27",
+      "docket_entries": [
+        {
+          "date_filed": "2023-01-27",
+          "description": "BNC Certificate of Notice - Order No. of Notices: 78. Notice Date 01/27/2023. (Admin.)",
+          "document_number": "1979",
+          "document_url": "https://ecf.njb.uscourts.gov/doc1/118064501082?pdf_header=&magic_num=76732728&de_seq_num=7968&caseid=1051949",
+          "pacer_case_id": "1051949",
+          "pacer_doc_id": "118064501082",
+          "pacer_magic_num": "76732728",
+          "pacer_seq_no": "7968",
+          "short_description": "BNC Certificate of Notice - Order"
+        }
+      ],
+      "docket_number": "19-27439"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nef/s3/njb_2.txt
+++ b/tests/examples/pacer/nef/s3/njb_2.txt
@@ -1,0 +1,93 @@
+Return-Path: <cmecf_help_desk@njb.uscourts.gov>
+Received: from icmecf201.gtwy.uscourts.gov (icmecf201.gtwy.uscourts.gov [63.241.40.204])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 3t36arimmoe2kl45q2p9tuoiiprstdtbsbumsk01
+ for recipient@example.com;
+ Sat, 28 Jan 2023 05:26:26 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of njb.uscourts.gov designates 63.241.40.204 as permitted sender) client-ip=63.241.40.204; envelope-from=cmecf_help_desk@njb.uscourts.gov; helo=icmecf201.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of njb.uscourts.gov designates 63.241.40.204 as permitted sender) client-ip=63.241.40.204; envelope-from=cmecf_help_desk@njb.uscourts.gov; helo=icmecf201.gtwy.uscourts.gov;
+ dmarc=none header.from=njb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFIR2pjbVR6OHJDS3cvQk5SNVJxNTBTL1Q1MkxnY0JlbUpNaFhUL0wraUJ1K3g2UjZVNzdMcVR6ZGdnK2Z0SmpCc2F0Q1FiRXBxeXdQY0ZnN09KTzJzRThFR0FrV1FKeDRVNEF0cmdWc1dMS3Z3YzZET1djQmdoY0NFSHhiWGtjTmJWTVFyZVQvMjYxSElmTzdRNjBuR0MwTUY1RmRWK0cwWFNnQ1ZqQVlsYWloZFY4bDhvbFBPNExKUlZXM2FROWhmM3V4akhSSm9FT25YU3lwSGEvTTFiRnNWeUhsMkZTOWhrZXpBOUkxZGtNUmcrN0lsY1BjOW41c3hGV0Zsc21FRnhEOGtJWGlzMHpkMGJ3SnZFS0cyaXBLUEJzOXM5SzJ3UUJGSndXd3gvSDc4b09uRElmY2R1SHpjOVEycHdYb2M9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=XPFH0L6lyrK0VYfSuvA+kxBfRa9x7ao2J/x+uwgAcELOgLbz2vpenIE9lnMtmLIGYBMUJGHFnv9hpFyeGirzI07jDv9H3VWR/nR2uZ7SAc7sv/SDBSrGh7OwDwpkI0f9GTTMewTZ2lzTiRQGTXOjyUXreKnzy7DFQpX+ZN2PPaM=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1674883586; v=1; bh=p25ypWmbiZZJDb1BZhCk816aViU3ofPJVzqqtSGHzJw=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.77
+Received: from unknown (HELO njbdb.njb.gtwy.dcn) ([156.119.190.77])
+  by icmecf201.gtwy.uscourts.gov with ESMTP; 28 Jan 2023 00:26:25 -0500
+Received: from njbdb.njb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by njbdb.njb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 30S5Ntpb054070;
+	Sat, 28 Jan 2023 00:25:09 -0500
+Received: (from ecf_web@localhost)
+	by njbdb.njb.gtwy.dcn (8.14.7/8.14.4/Submit) id 30S5NpZ8053631;
+	Sat, 28 Jan 2023 00:23:51 -0500
+Date: Sat, 28 Jan 2023 00:23:51 -0500
+MIME-Version:1.0
+From:cmecf_help_desk@njb.uscourts.gov
+To:no-reply@njb.uscourts.gov
+Message-Id:<60816012@njb.uscourts.gov>
+Subject:Ch-11 19-27439-MBK BNC Certificate of Notice - Order  - Hollister Construc
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of New Jersey</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Admin entered on 01/28/2023  at 00:17 AM EST and filed on 01/27/2023 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Hollister Construction Services, LLC              </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.njb.uscourts.gov/cgi-bin/DktRpt.pl?1051949>19-27439-MBK</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.njb.uscourts.gov/doc1/118064501082?pdf_header=&magic_num=76732728&de_seq_num=7968&caseid=1051949'>1979</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+BNC Certificate of Notice - Order No. of Notices: 78. Notice Date 01/27/2023. (Admin.)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Imaged Certificate of Notice
+<BR><STRONG>Original filename:</STRONG>P31927439orderntc7963.pdf
+<BR><STRONG>Electronic document Stamp:</STRONG>
+<BR>[STAMP bkecfStamp_ID=1002741850 [Date=1/28/2023] [FileNumber=60815138-0] [08c81971bdca2918f0147ec0cc23b5e25238d73a1e80afc9e7f1430e225b14b1ce4f66b704ef8cfbe649d23435c7ce243c1f128d0046bc24b0e775ade212b121]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+19-27439-MBK Notice will be electronically mailed to:
+</B>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/njd_1.json
+++ b/tests/examples/pacer/nef/s3/njd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "504363",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Status Conference"
         }
       ],
       "docket_number": "2:22-cv-06575"

--- a/tests/examples/pacer/nef/s3/nyed_1.json
+++ b/tests/examples/pacer/nef/s3/nyed_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "475249",
           "pacer_doc_id": "123019137279",
           "pacer_magic_num": "79492711",
-          "pacer_seq_no": "70"
+          "pacer_seq_no": "70",
+          "short_description": "Case Management Statement"
         }
       ],
       "docket_number": "1:22-cv-00588"

--- a/tests/examples/pacer/nef/s3/nyed_2.json
+++ b/tests/examples/pacer/nef/s3/nyed_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "475224",
           "pacer_doc_id": "123019152448",
           "pacer_magic_num": "43557990",
-          "pacer_seq_no": "72"
+          "pacer_seq_no": "72",
+          "short_description": "Letter"
         }
       ],
       "docket_number": "1:22-cv-00576"

--- a/tests/examples/pacer/nef/s3/nysb_1.json
+++ b/tests/examples/pacer/nef/s3/nysb_1.json
@@ -1,0 +1,26 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "nysb",
+  "dockets": [
+    {
+      "case_name": "Gerasimos Stefanitsis",
+      "date_filed": "2022-12-21",
+      "docket_entries": [
+        {
+          "date_filed": "2022-12-21",
+          "description": "Affidavit (related document(s)[50]) Filed by Lawrence Morrison on behalf of Gerasimos Stefanitsis. (Morrison, Lawrence)",
+          "document_number": "53",
+          "document_url": "https://ecf.nysb.uscourts.gov/doc1/126022507628?pdf_header=&magic_num=21715953&de_seq_num=193&caseid=313115",
+          "pacer_case_id": "313115",
+          "pacer_doc_id": "126022507628",
+          "pacer_magic_num": "21715953",
+          "pacer_seq_no": "193",
+          "short_description": "Affidavit"
+        }
+      ],
+      "docket_number": "22-22507"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nef/s3/nysb_1.txt
+++ b/tests/examples/pacer/nef/s3/nysb_1.txt
@@ -1,0 +1,102 @@
+Return-Path: <nysbinfo@nysb.uscourts.gov>
+Received: from icmecf202.gtwy.uscourts.gov (icmecf202.gtwy.uscourts.gov [63.241.40.205])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 7grid8fu10m5f7grnu4lcrktg1gtgohlc6agce01
+ for recipient@example.com;
+ Wed, 21 Dec 2022 16:55:11 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of nysb.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=nysbinfo@nysb.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of nysb.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=nysbinfo@nysb.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+ dmarc=none header.from=nysb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHYzZtRE1oVDBVdGM5dkY3VFRia3dNZ0tzUk5kKzlJZVp5UnBtcnQ2akMxbllZOW5BWFlSOW1jeU5HMGgzY29POCt1OEtEK0MxZ0w3TzRUK1RlUW8vZVRyYnFzOFAxZ0VVMlJ1RlFKdG5zOFEyNFhKeFU1c0pwZUN1dnU2VjlZbzZxRlI3M3dLQWFadkdsZ3BKalNISjltN05vMWdxY2ZVREpWZm5lSlpGa3RGOXVMUGk0SUVzQTVaSWhxQVJMTks3QStHL2FPcGd5dmh1OE1rUDdkc0NoRkVRd0lpeS9ZQm10cVhHcTRYUWRvS1JGQnNZVkRRbGd4VDBYQ2tpUkM1aHRnK3N0YjgvNDc0TG5FRXlsVTA4MWVjUUllazdyT2wwUzJkbjJKSGpmUUE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=h4NkCNd1ntYSFWHqR/53WJL/0Krb2D6/hMy62KMT9oLo/BO5jP/CIEuxfKtApXQaJ14jun+Nj1XkyAmISN5jgCKvEHIofAhNm/vxM35+lsImVsKzoLc8ipoAu2EjtkHwJmQ2Ki2SNn5moN83UPfD/CcFpoSV5KJvs+U5wOBOL5E=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1671641712; v=1; bh=Fqr2thLvi8Laz+mWXaQRCuFHLbHbkyojHX87/dORvVg=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.118
+Received: from nysbdb.nysb.gtwy.dcn ([156.119.190.118])
+  by icmecf202.gtwy.uscourts.gov with ESMTP; 21 Dec 2022 11:55:11 -0500
+Received: from nysbdb.nysb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by nysbdb.nysb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 2BLGsLNv091876;
+	Wed, 21 Dec 2022 11:54:22 -0500
+Received: (from ecf_web@localhost)
+	by nysbdb.nysb.gtwy.dcn (8.14.7/8.14.4/Submit) id 2BLGs7L3091634;
+	Wed, 21 Dec 2022 11:54:07 -0500
+Date: Wed, 21 Dec 2022 11:54:07 -0500
+X-Authentication-Warning: nysbdb.nysb.gtwy.dcn: ecf_web set sender to nysbinfo@nysb.uscourts.gov using -f
+MIME-Version:1.0
+From:nysbinfo@nysb.uscourts.gov
+To:courtmail@nysb.uscourts.gov
+Message-Id:<20579366@nysb.uscourts.gov>
+Subject:NEF: 22-22507-cgm Ch13 Affidavit Re: Gerasimos Stefanitsis
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>Southern District of New York</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Lawrence Morrison entered on 12/21/2022 at 11:54 AM  and filed on 12/21/2022 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Gerasimos Stefanitsis                             </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.nysb.uscourts.gov/cgi-bin/DktRpt.pl?313115>22-22507-cgm</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.nysb.uscourts.gov/doc1/126022507628?pdf_header=&magic_num=21715953&de_seq_num=193&caseid=313115'>53</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Affidavit <i>/Declaration of Debtor</i>  (related document(s)[50]) Filed by  Lawrence  Morrison  on behalf of  Gerasimos  Stefanitsis.  (Morrison, Lawrence)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>signedstefanitsisdeclaration.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP NYSBStamp_ID=842906028 [Date=12/21/2022] [FileNumber=20579364-0
+<BR><TAB>] [17fac1c3470a3dbf06f669bc796db10d973b74b4cb797379e7093425d341ccc932c
+<BR><TAB>5ddc82ab3e4ee93984eac987b18df4d9d457ecfcde6b3c116d9f98b5b4c07]]
+<BR>
+
+</table>
+</div>
+
+
+
+<BR>
+<B>
+22-22507-cgm Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR>
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/nysb_2.json
+++ b/tests/examples/pacer/nef/s3/nysb_2.json
@@ -1,0 +1,26 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "nysb",
+  "dockets": [
+    {
+      "case_name": "Gerasimos Stefanitsis",
+      "date_filed": "2023-02-27",
+      "docket_entries": [
+        {
+          "date_filed": "2023-02-27",
+          "description": "Affidavit Filed by Lawrence Morrison on behalf of Gerasimos Stefanitsis. (Morrison, Lawrence)",
+          "document_number": "55",
+          "document_url": "https://ecf.nysb.uscourts.gov/doc1/126022597368?pdf_header=&magic_num=73840684&de_seq_num=204&caseid=313115",
+          "pacer_case_id": "313115",
+          "pacer_doc_id": "126022597368",
+          "pacer_magic_num": "73840684",
+          "pacer_seq_no": "204",
+          "short_description": "Affidavit"
+        }
+      ],
+      "docket_number": "22-22507"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nef/s3/nysb_2.txt
+++ b/tests/examples/pacer/nef/s3/nysb_2.txt
@@ -1,0 +1,102 @@
+Return-Path: <nysbinfo@nysb.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id lnku40dkpjle72vnu3o0atq01vn58jr53f7loog1
+ for recipient@example.com;
+ Mon, 27 Feb 2023 21:57:27 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of nysb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=nysbinfo@nysb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of nysb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=nysbinfo@nysb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=nysb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFMlJwRldsVCs2M2p4Z3RUenVkd1k3VWk2YlorWGVXSkRyRktlWlgvZGdRMDk1NThjNmlmUWRFbEZWNm9FQmo5QkVTaFE2YTJwbHJhNzRqQml1dmllUHdkQU9vb3FMNG5TYlhyV1JSVDlUNVJRT1hUNjdSbmpjWDZDQngrZWt4cERSNmRJQTY1bHl0bWRMY2tGRStUVmgvZ1dlMVFQRkdSQVN3cXludXFYdnhxSmt1RVBOeEJmSW1sam44VUFVK0tUblloRlBPZXV6cnREcXcxWEFRNUJCQitFVTkranByaGlqN0hnSlpmZXJyYUxlSTRPQ0psZ0NEYjZLSkxOZzJ1VWNvMUkwazRhMldhT2JpTzIzcC8ra1gyeVdBSVZQakVOUTJ1VVU4eG9ta2c9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=VEYuR55mw2zUNWukqeVr5o8+AbAlaYxz4PIJHYJpc2W6JLP8tSKTWeiDNJj4yelaW6xKWxleGj+ZmSsckhPNyAyG/EiUAthh7WzoSpHTcqEzjp36Fdd+8E+CzY5vOfgxjogsi2+c73WGZywY11/XNfLwXkNDzCJtZYF2xi5XZZM=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1677535048; v=1; bh=DY+MoPdr7FvM4EiLcv5A85GTyz8MYAOc0kd03iu1988=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.118
+Received: from nysbdb.nysb.gtwy.dcn ([156.119.190.118])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 27 Feb 2023 16:57:26 -0500
+Received: from nysbdb.nysb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by nysbdb.nysb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 31RLufdw111011;
+	Mon, 27 Feb 2023 16:56:42 -0500
+Received: (from ecf_web@localhost)
+	by nysbdb.nysb.gtwy.dcn (8.14.7/8.14.4/Submit) id 31RLtw18109961;
+	Mon, 27 Feb 2023 16:55:58 -0500
+Date: Mon, 27 Feb 2023 16:55:58 -0500
+X-Authentication-Warning: nysbdb.nysb.gtwy.dcn: ecf_web set sender to nysbinfo@nysb.uscourts.gov using -f
+MIME-Version:1.0
+From:nysbinfo@nysb.uscourts.gov
+To:courtmail@nysb.uscourts.gov
+Message-Id:<20659323@nysb.uscourts.gov>
+Subject:NEF: 22-22507-cgm Ch13 Affidavit Re: Gerasimos Stefanitsis
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>Southern District of New York</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Lawrence Morrison entered on 2/27/2023 at 4:55 PM  and filed on 2/27/2023 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Gerasimos Stefanitsis                             </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.nysb.uscourts.gov/cgi-bin/DktRpt.pl?313115>22-22507-cgm</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.nysb.uscourts.gov/doc1/126022597368?pdf_header=&magic_num=73840684&de_seq_num=204&caseid=313115'>55</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Affidavit <i></i>   Filed by  Lawrence  Morrison  on behalf of  Gerasimos  Stefanitsis.  (Morrison, Lawrence)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>Affirmation  02.27.2023 (2).pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP NYSBStamp_ID=842906028 [Date=2/27/2023] [FileNumber=20659321-0]
+<BR><TAB> [7f7ef2c9db9f8523915cb3fb43568b1a2316bd3f725b89110dfd0452b87806c755a3
+<BR><TAB>2e9bf35948c5f629004fdc6dea13f11c5eab94203123e677136d4cb5ebe6]]
+<BR>
+
+</table>
+</div>
+
+
+
+<BR>
+<B>
+22-22507-cgm Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR>
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/nysb_3.json
+++ b/tests/examples/pacer/nef/s3/nysb_3.json
@@ -1,0 +1,26 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "nysb",
+  "dockets": [
+    {
+      "case_name": "Gerasimos Stefanitsis",
+      "date_filed": "2022-12-07",
+      "docket_entries": [
+        {
+          "date_filed": "2022-12-07",
+          "description": "Notice of Adjournment of Hearing re: Motion to Dismiss Case application and certificate of service filed by Krista M. Preuss on behalf of Krista M. Preuss (related document(s)[41]) Motion to Dismiss granted, submit order. Further hearing on 2016(b) Statement to be held 2/22/2023 at 09:00 AM at Videoconference (ZoomGov) (CGM) (DuBois, Linda).",
+          "document_number": "48",
+          "document_url": null,
+          "pacer_case_id": "313115",
+          "pacer_doc_id": null,
+          "pacer_magic_num": null,
+          "pacer_seq_no": null,
+          "short_description": "Notice of Adjournment of Hearing"
+        }
+      ],
+      "docket_number": "22-22507"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nef/s3/nysb_3.txt
+++ b/tests/examples/pacer/nef/s3/nysb_3.txt
@@ -1,0 +1,94 @@
+Return-Path: <nysbinfo@nysb.uscourts.gov>
+Received: from icmecf202.gtwy.uscourts.gov (icmecf202.gtwy.uscourts.gov [63.241.40.205])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id o6qgqpvcdf2j0ffc7lo7su9ok50fh01v131l0rg1
+ for recipient@example.com;
+ Fri, 09 Dec 2022 15:14:55 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of nysb.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=nysbinfo@nysb.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of nysb.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=nysbinfo@nysb.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+ dmarc=none header.from=nysb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFNFg1MjZKZUtIRXNZbDI4bk9kRitGUkNZcFBUTUhUTTZIamJMa1ZraXB6K2hsVUxOV05vRmZtd3I2bGdLd1MrMmljSjNYQ1FQVFFuOGg2Vk5xVVFLZlhyckZaajNSQ1V2NldvaUNrY0hSaDlab0J6aWZlMDVIL2dMU082cTlzZ0FzcUdhZFBLSnQ3WHlzNWZma3pqMDZCVm1ZeWt2NFI2WlYrYktIVzd6TVFreWdneC81L0tVNmxXS2FxRllrR1A5UkNUcjB1UFp0MWcvb3FJSkpETGFWbXd6QUV1RmdZd09CRFBVcnQrbzVLVE02enlVRFl4ekFHS1htbkdieWl5RlpiS2ZUZW9QV2UwazN5SWhnbExmdThUUXREVDJ0bzB6WlNidXhWdTVzQkE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=bqxv7r/CctbT1/QTjwNo/oK6wX4lQB3P71lCZGtowpC3uGUSt5LIv2NHk9d5W/4OKhDP2PbjCy8LOm9FmlNOQHpU+a0XMqI0izCZYCImVfNqHN6t374HF8A5S1Rl10Cvp9RZYjCNDfxZrUzAZxJTPVHIkglSzE7cpJX+By8qaN8=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1670598896; v=1; bh=akc7vsyRUwRbfC3aeGqafAleMcBCNyem0PZEtSenYPk=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.118
+Received: from nysbdb.nysb.gtwy.dcn ([156.119.190.118])
+  by icmecf202.gtwy.uscourts.gov with ESMTP; 09 Dec 2022 10:14:55 -0500
+Received: from nysbdb.nysb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by nysbdb.nysb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 2B9FE90O008626;
+	Fri, 9 Dec 2022 10:14:09 -0500
+Received: (from ecf_web@localhost)
+	by nysbdb.nysb.gtwy.dcn (8.14.7/8.14.4/Submit) id 2B9FE20c008096;
+	Fri, 9 Dec 2022 10:14:02 -0500
+Date: Fri, 9 Dec 2022 10:14:02 -0500
+X-Authentication-Warning: nysbdb.nysb.gtwy.dcn: ecf_web set sender to nysbinfo@nysb.uscourts.gov using -f
+MIME-Version:1.0
+From:nysbinfo@nysb.uscourts.gov
+To:courtmail@nysb.uscourts.gov
+Message-Id:<20563575@nysb.uscourts.gov>
+Subject:NEF: 22-22507-cgm Ch13 Notice of Adjournment of Hearing Re: Gerasimos Stefanitsis
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>Southern District of New York</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from DuBois, Linda entered on 12/9/2022 at 10:14 AM  and filed on 12/7/2022 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Gerasimos Stefanitsis                             </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.nysb.uscourts.gov/cgi-bin/DktRpt.pl?313115>22-22507-cgm</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+48
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Notice of Adjournment of Hearing re: Motion to Dismiss Case application and certificate of service filed by Krista M. Preuss on behalf of Krista M. Preuss  (related document(s)[41]);  Motion to Dismiss granted, submit order.  Further hearing on 2016(b) Statement to be held 2/22/2023 at 09:00 AM at Videoconference (ZoomGov) (CGM)  (DuBois, Linda).
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+
+</table>
+</div>
+
+
+
+<BR>
+<B>
+22-22507-cgm Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR>
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/nysd_1.json
+++ b/tests/examples/pacer/nef/s3/nysd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "546923",
           "pacer_doc_id": "127031722970",
           "pacer_magic_num": "95806321",
-          "pacer_seq_no": "2447"
+          "pacer_seq_no": "2447",
+          "short_description": "Motion for Extension of Time to Complete Discovery"
         }
       ],
       "docket_number": "1:20-cv-08924"

--- a/tests/examples/pacer/nef/s3/nysd_2.json
+++ b/tests/examples/pacer/nef/s3/nysd_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "546923",
           "pacer_doc_id": "127031741309",
           "pacer_magic_num": "25849322",
-          "pacer_seq_no": "2463"
+          "pacer_seq_no": "2463",
+          "short_description": "Letter"
         }
       ],
       "docket_number": "1:20-cv-08924"

--- a/tests/examples/pacer/nef/s3/nysd_3.json
+++ b/tests/examples/pacer/nef/s3/nysd_3.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "546923",
           "pacer_doc_id": "127032041950",
           "pacer_magic_num": "51520574",
-          "pacer_seq_no": "2598"
+          "pacer_seq_no": "2598",
+          "short_description": "Motion for Extension of Time"
         }
       ],
       "docket_number": "1:20-cv-08924"
@@ -32,7 +33,8 @@
           "pacer_case_id": "550445",
           "pacer_doc_id": "127032041950",
           "pacer_magic_num": null,
-          "pacer_seq_no": "479"
+          "pacer_seq_no": "479",
+          "short_description": "Motion for Extension of Time"
         }
       ],
       "docket_number": "1:20-cv-10541"
@@ -49,7 +51,8 @@
           "pacer_case_id": "552145",
           "pacer_doc_id": "127032041950",
           "pacer_magic_num": null,
-          "pacer_seq_no": "514"
+          "pacer_seq_no": "514",
+          "short_description": "Motion for Extension of Time"
         }
       ],
       "docket_number": "1:21-cv-00322"
@@ -66,10 +69,29 @@
           "pacer_case_id": "549912",
           "pacer_doc_id": "127032041950",
           "pacer_magic_num": null,
-          "pacer_seq_no": "567"
+          "pacer_seq_no": "567",
+          "short_description": "Motion for Extension of Time"
         }
       ],
       "docket_number": "1:20-cv-10291"
+    },
+    {
+      "case_name": "Gray v. City of New York",
+      "date_filed": "2022-09-29",
+      "docket_entries": [
+        {
+          "date_filed": "2022-09-29",
+          "description": "CONSENT LETTER MOTION for Extension of Time to file fee applications in Minett and Hernandez addressed to Judge Colleen McMahon from Remy Green dated 2022-09-29. Document filed by Krystin Hernandez.Filed In Associated Cases: 1:20-cv-08924-CM et al..(Green, Remy)",
+          "document_number": "88",
+          "document_url": "https://ecf.nysd.uscourts.gov/doc1/127132041950?caseid=564508&de_seq_num=381&magic_num=MAGIC",
+          "pacer_case_id": "564508",
+          "pacer_doc_id": "127032041950",
+          "pacer_magic_num": null,
+          "pacer_seq_no": "381",
+          "short_description": "Motion for Extension of Time"
+        }
+      ],
+      "docket_number": "1:21-cv-06610"
     }
   ],
   "email_recipients": [

--- a/tests/examples/pacer/nef/s3/nysd_3.txt
+++ b/tests/examples/pacer/nef/s3/nysd_3.txt
@@ -174,6 +174,38 @@ Remy)
 </p>
 
 
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Gray et al v. City of New York 
+et al</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A 
+HREF=https://ecf.nysd.uscourts.gov/cgi-bin/DktRpt.pl?564508>1:21-cv-06610-CM</A></td></tr>
+
+<tr><td><strong>Filer:</strong></td><td></td></tr>
+
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href="https://ecf.nysd.uscourts.gov/doc1/127132041950?caseid=564508&de_seq_num=381&magic_num=MAGIC" 
+>88</a> 
+</td></tr>
+<tr><td><strong></strong></td><td></td></tr>
+</table>
+<p>
+<strong>Docket Text:</strong>
+<BR>
+<FONT  FACE="arial,helvetica" COLOR="#0000cc" SIZE=3><b>
+CONSENT  LETTER MOTION  for Extension 
+of Time <i>to file fee applications in Minett and Hernandez</i>  addressed 
+to Judge Colleen McMahon from Remy Green dated 2022-09-29. Document filed 
+by Krystin Hernandez.Filed In Associated Cases: 1:20-cv-08924-CM et al..(Green, 
+Remy) 
+</b></Font>
+</p>
+
+
+
 <BR>
 <B>
 1:20-cv-08924-CM Notice has been electronically mailed to:

--- a/tests/examples/pacer/nef/s3/nysd_4.json
+++ b/tests/examples/pacer/nef/s3/nysd_4.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "546923",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Mediation Conference Scheduled/Re-Scheduled"
         }
       ],
       "docket_number": "1:20-cv-08924"
@@ -32,7 +33,8 @@
           "pacer_case_id": "550445",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Mediation Conference Scheduled/Re-Scheduled"
         }
       ],
       "docket_number": "1:20-cv-10541"

--- a/tests/examples/pacer/nef/s3/nysd_5.json
+++ b/tests/examples/pacer/nef/s3/nysd_5.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "546923",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Mediation Conference"
         }
       ],
       "docket_number": "1:20-cv-08924"
@@ -32,7 +33,8 @@
           "pacer_case_id": "550445",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Mediation Conference"
         }
       ],
       "docket_number": "1:20-cv-10541"

--- a/tests/examples/pacer/nef/s3/ohnd_1.json
+++ b/tests/examples/pacer/nef/s3/ohnd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "238517",
           "pacer_doc_id": "141012215024",
           "pacer_magic_num": "33122478",
-          "pacer_seq_no": "2123"
+          "pacer_seq_no": "2123",
+          "short_description": "Motion for attorney fees"
         }
       ],
       "docket_number": "1:17-md-02807"

--- a/tests/examples/pacer/nef/s3/ohsd_2.json
+++ b/tests/examples/pacer/nef/s3/ohsd_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "270109",
           "pacer_doc_id": "14309223490",
           "pacer_magic_num": "82294018",
-          "pacer_seq_no": "29"
+          "pacer_seq_no": "29",
+          "short_description": "Motion for Extension of Time to File Response/Reply"
         }
       ],
       "docket_number": "1:22-cv-00376"

--- a/tests/examples/pacer/nef/s3/oknd_1.json
+++ b/tests/examples/pacer/nef/s3/oknd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "44613",
           "pacer_doc_id": "14702800417",
           "pacer_magic_num": "4094057",
-          "pacer_seq_no": "189"
+          "pacer_seq_no": "189",
+          "short_description": "Joint Status Report per LCvR16-1(b)(1)"
         }
       ],
       "docket_number": "4:18-cv-00499"

--- a/tests/examples/pacer/nef/s3/pawb_2.json
+++ b/tests/examples/pacer/nef/s3/pawb_2.json
@@ -1,0 +1,26 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "pawb",
+  "dockets": [
+    {
+      "case_name": "U LOCK INC",
+      "date_filed": "2023-01-24",
+      "docket_entries": [
+        {
+          "date_filed": "2023-01-24",
+          "description": "Reply Regarding the Hearing on 1/27/2023. Filed by George Snyder (RE: related document(s): [298] Response filed by Creditor Christine Biros). (nsha)",
+          "document_number": "303",
+          "document_url": "https://ecf.pawb.uscourts.gov/doc1/156029022118?pdf_header=&magic_num=80042011&de_seq_num=1161&caseid=376948",
+          "pacer_case_id": "376948",
+          "pacer_doc_id": "156029022118",
+          "pacer_magic_num": "80042011",
+          "pacer_seq_no": "1161",
+          "short_description": "Reply"
+        }
+      ],
+      "docket_number": "22-20823"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nef/s3/pawb_2.txt
+++ b/tests/examples/pacer/nef/s3/pawb_2.txt
@@ -1,0 +1,95 @@
+Return-Path: <Courtmail@pawb.uscourts.gov>
+Received: from icmecf202.gtwy.uscourts.gov (icmecf202.gtwy.uscourts.gov [63.241.40.205])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id khn7insae4slmjj3svo3i5sp3rvkcbb5uu8g4f01
+ for recipient@example.com;
+ Tue, 24 Jan 2023 16:01:41 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of pawb.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=Courtmail@pawb.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of pawb.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=Courtmail@pawb.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+ dmarc=none header.from=pawb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFYlhrYUFjV0JkVElUUExBTTdNZXFMdlNSSndNeTFFbS9QMGZ0YWlIVis4NHd1b0NQSzZrYjBnWXBDaExRSHUxeStRNVZmUGhSQ1hvV1pkTlNVS3gvV2xKYXlBVkF4Nlg5L3FkM0k5RmlCR3kwYW1VTXZIamI5c2FIeDlmV1ZzU2pyNFpRelhLRFg4Q3d1eXVyYUc5VFNLM2JuT0lFTnZ1QnRmcktQb1NlNFNmRjZjMlI3bkNqbTZnUnpRRFppV0lQcjZPdmswMW5MTUo2NU1UdjVVTU1QSkEvdDVhOEdlRXZWWTZWR2VVcmNYWDZmTEpoYzI1RGpvZHZrd0ExbDd3N3FjaWtWK0ZiY3A5UkRyMDlRdklCZzQvdnpZQ2czMElFc1FQQVl2OFZKb1E9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=YvpWzQ5luV0euggPNSyiuPWXwtyHkjCJp7SgVnwNeMI1abM+belGhqJR4FbPoSQYJ4m7R7wyl++we++lW6v8Kyr60C4VY4oQKJJpC3wxC5GUjAhC8UEJiTSBCYgSK5jbN4mTtwZ3npuWA0+ufp3SGJjHJcwshWJ0uoj4xgn9CI8=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1674576103; v=1; bh=KSJ5dCTgmu1C27aCL1UNeO3oZHeMybbQti2SR11r/nM=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.26
+Received: from pawbdb.pawb.gtwy.dcn ([156.119.190.26])
+  by icmecf202.gtwy.uscourts.gov with ESMTP; 24 Jan 2023 11:01:41 -0500
+Received: from pawbdb.pawb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by pawbdb.pawb.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 30OG1SrX063633;
+	Tue, 24 Jan 2023 11:01:28 -0500
+Received: (from ecf_web@localhost)
+	by pawbdb.pawb.gtwy.dcn (8.14.4/8.14.4/Submit) id 30OG0xX6063185;
+	Tue, 24 Jan 2023 11:00:59 -0500
+Date: Tue, 24 Jan 2023 11:00:59 -0500
+X-Authentication-Warning: pawbdb.pawb.gtwy.dcn: ecf_web set sender to Courtmail@pawb.uscourts.gov using -f
+MIME-Version:1.0
+From:Courtmail@pawb.uscourts.gov
+To:Courtmail@pawb.uscourts.gov
+Message-Id:<26960780@pawb.uscourts.gov>
+Subject:Ch-7   22-20823-GLT U LOCK INC         Reply
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>WESTERN DISTRICT OF PENNSYLVANIA</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from nsha,   entered on 1/24/2023 at 11:00 AM EST and filed on 1/24/2023 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>U LOCK INC                                        </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.pawb.uscourts.gov/cgi-bin/DktRpt.pl?376948>22-20823-GLT</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.pawb.uscourts.gov/doc1/156029022118?pdf_header=&magic_num=80042011&de_seq_num=1161&caseid=376948'>303</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+  Reply <i>to the Response re: Show Cause</i> Regarding the Hearing on 1/27/2023. Filed by  George  Snyder   (RE: related document(s): [298] Response filed by Creditor Christine  Biros).   (nsha)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>edss-22-20823-reply.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1000342144 [Date=1/24/2023] [FileNumber=26960778-
+<BR><TAB>0] [1414aa5511aab53a12ce0f9cccc8b8d9a1e7fb55163bc413dd7d003adf115f4ea1
+<BR><TAB>1bd6321a26677ec1f4da0ee7d8f23e0aaebc2bd6f7900d312233442e65202f]]
+<BR>
+
+</table>
+</div>
+
+
+<BR><B>
+22-20823-GLT Notice will be electronically mailed to:
+</B>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/pawb_3.json
+++ b/tests/examples/pacer/nef/s3/pawb_3.json
@@ -1,0 +1,26 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "pawb",
+  "dockets": [
+    {
+      "case_name": "Daniel J. Adamson",
+      "date_filed": "2023-02-27",
+      "docket_entries": [
+        {
+          "date_filed": "2023-02-27",
+          "description": "Notice of Additional Filing Deficiencies. Assigned Judge: TADDONIO. Appointed Trustee: ZEBLEY. Pursuant to Local Rule 1017-2, the United States Trustee is deemed to have filed a Motion To Dismiss this case, and that Motion will be deemed GRANTED, if any deadline set forth in the first docket entry or any of the following deadlines is not met. Incomplete Filings: CERTIFICATE OF CREDIT COUNSELING AND EMPLOYEE INCOME RECORDS OR A STATEMENT THAT THERE ARE NONE (RE: related document(s): [1] Voluntary Petition Chapter 7 filed by Debtor Daniel J. Adamson). Incomplete Filings due by 3/10/2023. (mgut)",
+          "document_number": "3",
+          "document_url": null,
+          "pacer_case_id": "380029",
+          "pacer_doc_id": null,
+          "pacer_magic_num": null,
+          "pacer_seq_no": null,
+          "short_description": "Notice of Additional Filing Deficiencies"
+        }
+      ],
+      "docket_number": "23-20396"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nef/s3/pawb_3.txt
+++ b/tests/examples/pacer/nef/s3/pawb_3.txt
@@ -1,0 +1,94 @@
+Return-Path: <Courtmail@pawb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id nlb6ps3uot6egl1cqm9088ajca1ji8n4vclbj1o1
+ for recipient@example.com;
+ Mon, 27 Feb 2023 18:05:29 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of pawb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=Courtmail@pawb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of pawb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=Courtmail@pawb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=pawb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFT0xHL0FPRFp3WGV5RkxLbFFkSDdOWWxDUHI2SUlOaE9XaXhnM1hCL1JCdUFQM3BHYVVkUlpONjJzRnhhTGxWNmo2QS9HcWIwTytueVVVTjJvSkZWeEd4OW5Wa1g4MmgwMzlYNlpwWVdWZWQ1YmYzOXFRaHlJdlJHcUNValdURmsyVzI2NEg2Nm1aMER1RTJMNFRSMlJURm8zM3liSWZGMmZEeXRpdjdnOFczNkJmVnFuWEp5K1dZWXc2bTNxME1jVWt4dkpXMnQvb2NjOFA2MTJ0Y0JJaE1uSFR0cklyTEFzcWo2aWRpMk9KWnZrWHI0SXI4NUYzeWZ2ZnZwZTdWcXBPbDJTa2M2Vi9TTmRHdGtGcmQ1OVo3QkZkeFI4aWt4RUlsMUwwQ1lpQmc9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=iLU5h83jlOZBr6+zo10z0s7Kfc+r6OpobWT7wJehalXOEnrjubGC8ZEeLO9opiQUaH06K1Gt3Q9c3qWMGlgRjEUYouhaASy82+aUoG6T5jqkJOWR+AUN/NGMOjZ6+bWbji3PgBod+9Webh2LFSrGGRF6Xrg59j8HbyRQ13BK7aU=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1677521129; v=1; bh=Tw++C9dbUoZXG4e+He8QTOy9aZJXDq1zlxPUV+oK5iw=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.26
+Received: from pawbdb.pawb.gtwy.dcn ([156.119.190.26])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 27 Feb 2023 13:05:28 -0500
+Received: from pawbdb.pawb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by pawbdb.pawb.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 31RI51Ju129068;
+	Mon, 27 Feb 2023 13:05:02 -0500
+Received: (from ecf_web@localhost)
+	by pawbdb.pawb.gtwy.dcn (8.14.4/8.14.4/Submit) id 31RI46n4127661;
+	Mon, 27 Feb 2023 13:04:06 -0500
+Date: Mon, 27 Feb 2023 13:04:06 -0500
+X-Authentication-Warning: pawbdb.pawb.gtwy.dcn: ecf_web set sender to Courtmail@pawb.uscourts.gov using -f
+MIME-Version:1.0
+From:Courtmail@pawb.uscourts.gov
+To:Courtmail@pawb.uscourts.gov
+Message-Id:<27022782@pawb.uscourts.gov>
+Subject:Ch-7   23-20396-GLT Daniel J. Adamson  Notice of Additional Filing Deficiencies
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>WESTERN DISTRICT OF PENNSYLVANIA</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from mgut entered on 2/27/2023 at 1:04 PM EST and filed on 2/27/2023 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Daniel J. Adamson</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.pawb.uscourts.gov/cgi-bin/DktRpt.pl?380029>23-20396-GLT</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+3
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Notice of Additional Filing Deficiencies. Assigned Judge: TADDONIO. Appointed Trustee: ZEBLEY. Pursuant to Local Rule  1017-2, the United States Trustee is deemed to have filed a Motion To Dismiss this case, and that Motion will be deemed GRANTED, if any deadline set forth in the first docket entry or any of the following deadlines is not met. Incomplete Filings: CERTIFICATE OF CREDIT COUNSELING AND EMPLOYEE INCOME RECORDS OR A STATEMENT THAT THERE ARE NONE (RE: related document(s): [1] Voluntary Petition Chapter 7 filed by Debtor Daniel J. Adamson).  Incomplete Filings due by 3/10/2023.   (mgut)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+23-20396-GLT Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR>
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/pawb_4.json
+++ b/tests/examples/pacer/nef/s3/pawb_4.json
@@ -1,0 +1,26 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "pawb",
+  "dockets": [
+    {
+      "case_name": "Moses Dolz",
+      "date_filed": "2023-01-24",
+      "docket_entries": [
+        {
+          "date_filed": "2023-01-24",
+          "description": "CORRECTIVE ENTRY: COUNSEL MUST REFILE PAWB LOCAL FORM 29 ENSURING TO ATTACH THE MAILING MATRIX UPLOADED INTO CM/ECF. (RE: related document(s): [9] Notice Regarding Filing of Mailing Matrix filed by Debtor Moses Dolz). (dkam)",
+          "document_number": "12",
+          "document_url": null,
+          "pacer_case_id": "379645",
+          "pacer_doc_id": null,
+          "pacer_magic_num": null,
+          "pacer_seq_no": null,
+          "short_description": "Corrective Entry"
+        }
+      ],
+      "docket_number": "23-70022"
+    }
+  ],
+  "email_recipients": []
+}

--- a/tests/examples/pacer/nef/s3/pawb_4.txt
+++ b/tests/examples/pacer/nef/s3/pawb_4.txt
@@ -1,0 +1,91 @@
+Return-Path: <Courtmail@pawb.uscourts.gov>
+Received: from icmecf202.gtwy.uscourts.gov (icmecf202.gtwy.uscourts.gov [63.241.40.205])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id pie9i27k2qd9u583inovt1puca1jkke2gflnghg1
+ for recipient@example.com;
+ Tue, 24 Jan 2023 15:14:31 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of pawb.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=Courtmail@pawb.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of pawb.uscourts.gov designates 63.241.40.205 as permitted sender) client-ip=63.241.40.205; envelope-from=Courtmail@pawb.uscourts.gov; helo=icmecf202.gtwy.uscourts.gov;
+ dmarc=none header.from=pawb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHdXVtdUVrVStQMWlKWFVnb1RZT0ZrRFRVbWQweUdBNDhoenNVaWd3VGdtamwwN1RRYkoxemFsSXZmLzY3U3Rqcm5wbGtWejlKaHdqb2VMVUlQUncwRXhEemNVKzRMaFd5NmFGY0F2YkJMQnErNlduMFJHV0QrMlJIWmlIbWV2b01IWG5NOXpOZDV1L0tsRFFjNzVSa0d3S3BEZmxzTzZnS3JvQXBJVEVKOXhaSm5NdTNoQkV6U3RjSDh4TFBNMHlHNXl5NE5jdkE2MmthQlB5a29ub2JvN0tLVjNSWlo3alZYa3N3bVJIdnRodXlrU0FQaXJxa0ZTam5OckI5OXoxRTVrYzVvdC9jNmwwMVE3cWNtR2pLUW5tWVJNaDVKdVYyVzNIQ0o0V0piK1E9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=VsdLcqVjW21+Ph7vrCjZAuLgzqXqBIUTSD+th3T7gasVw0NTFJnKLFo0onG/EbGXSdUUuFWRQ3Na9af1+c77NyX4P9dP1coLLIoMrlYu+vrsLbxaW6EnmQJp4sSXOo0g+CEqqdlDa8ezn+/m7O92Hkd80qO0kAUeWbSEt/wa3WY=; c=relaxed/simple; s=gdwg2y3kokkkj5a55z2ilkup5wp5hhxx; d=amazonses.com; t=1674573272; v=1; bh=90uAEPoy+7aVNDlliGMhuhtiTE5OcoFXrtvmP1QKYZU=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.26
+Received: from pawbdb.pawb.gtwy.dcn ([156.119.190.26])
+  by icmecf202.gtwy.uscourts.gov with ESMTP; 24 Jan 2023 10:14:30 -0500
+Received: from pawbdb.pawb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by pawbdb.pawb.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 30OFEKxu008229;
+	Tue, 24 Jan 2023 10:14:20 -0500
+Received: (from ecf_web@localhost)
+	by pawbdb.pawb.gtwy.dcn (8.14.4/8.14.4/Submit) id 30OFDLVi006965;
+	Tue, 24 Jan 2023 10:13:21 -0500
+Date: Tue, 24 Jan 2023 10:13:21 -0500
+X-Authentication-Warning: pawbdb.pawb.gtwy.dcn: ecf_web set sender to Courtmail@pawb.uscourts.gov using -f
+MIME-Version:1.0
+From:Courtmail@pawb.uscourts.gov
+To:Courtmail@pawb.uscourts.gov
+Message-Id:<26960597@pawb.uscourts.gov>
+Subject:Ch-7   23-70022-JAD Moses Dolz         Corrective Entry
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>WESTERN DISTRICT OF PENNSYLVANIA</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from dkam entered on 1/24/2023 at 10:13 AM EST and filed on 1/24/2023 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Moses Dolz</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.pawb.uscourts.gov/cgi-bin/DktRpt.pl?379645>23-70022-JAD</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+12
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+CORRECTIVE ENTRY: COUNSEL MUST REFILE PAWB LOCAL FORM 29 ENSURING TO ATTACH THE MAILING MATRIX UPLOADED INTO CM/ECF. (RE: related document(s): [9] Notice Regarding Filing of Mailing Matrix filed by Debtor Moses  Dolz).    (dkam)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+
+</table>
+</div>
+
+
+
+
+<BR>
+<B>
+23-70022-JAD Notice will not be electronically mailed to:
+</B>
+
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/txnd_1.json
+++ b/tests/examples/pacer/nef/s3/txnd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "351843",
           "pacer_doc_id": "177014458489",
           "pacer_magic_num": "37789082",
-          "pacer_seq_no": "14"
+          "pacer_seq_no": "14",
+          "short_description": "Notice of Attorney Appearance"
         }
       ],
       "docket_number": "4:21-cv-00953"

--- a/tests/examples/pacer/nef/s3/txsd_1.json
+++ b/tests/examples/pacer/nef/s3/txsd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1263056",
           "pacer_doc_id": "179041128562",
           "pacer_magic_num": "41371379",
-          "pacer_seq_no": "81"
+          "pacer_seq_no": "81",
+          "short_description": "Motion for Partial Summary Judgment"
         }
       ],
       "docket_number": "2:15-cv-00208"

--- a/tests/examples/pacer/nef/s3/txwd_1.json
+++ b/tests/examples/pacer/nef/s3/txwd_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "909716",
           "pacer_doc_id": "181026556738",
           "pacer_magic_num": "19887507",
-          "pacer_seq_no": "559"
+          "pacer_seq_no": "559",
+          "short_description": "Response"
         }
       ],
       "docket_number": "5:17-cv-01246"

--- a/tests/examples/pacer/nef/s3/txwd_2.json
+++ b/tests/examples/pacer/nef/s3/txwd_2.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1116753",
           "pacer_doc_id": "181026609114",
           "pacer_magic_num": "27958125",
-          "pacer_seq_no": "66"
+          "pacer_seq_no": "66",
+          "short_description": "Order on Motion for Leave to File"
         }
       ],
       "docket_number": "5:20-cv-01403"

--- a/tests/examples/pacer/nef/s3/txwd_3.json
+++ b/tests/examples/pacer/nef/s3/txwd_3.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1139592",
           "pacer_doc_id": "181026609784",
           "pacer_magic_num": "12877118",
-          "pacer_seq_no": "17"
+          "pacer_seq_no": "17",
+          "short_description": "Summons Issued"
         }
       ],
       "docket_number": "5:21-cv-00634"

--- a/tests/examples/pacer/nef/s3/txwd_4.json
+++ b/tests/examples/pacer/nef/s3/txwd_4.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1128108",
           "pacer_doc_id": "181026784434",
           "pacer_magic_num": "74452586",
-          "pacer_seq_no": "62"
+          "pacer_seq_no": "62",
+          "short_description": "Motion for Extension of Time to File"
         }
       ],
       "docket_number": "5:21-cv-00306"

--- a/tests/examples/pacer/nef/s3/txwd_5.json
+++ b/tests/examples/pacer/nef/s3/txwd_5.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1093174",
           "pacer_doc_id": "181026769712",
           "pacer_magic_num": "78172631",
-          "pacer_seq_no": "133"
+          "pacer_seq_no": "133",
+          "short_description": "Response in Opposition to Motion"
         }
       ],
       "docket_number": "7:20-cv-00083"

--- a/tests/examples/pacer/nef/s3/txwd_6.json
+++ b/tests/examples/pacer/nef/s3/txwd_6.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1116583",
           "pacer_doc_id": "181026785306",
           "pacer_magic_num": "70834513",
-          "pacer_seq_no": "80"
+          "pacer_seq_no": "80",
+          "short_description": "Motion for Extension of Time to File"
         }
       ],
       "docket_number": "1:20-cv-01202"

--- a/tests/examples/pacer/nef/s3/txwd_7.json
+++ b/tests/examples/pacer/nef/s3/txwd_7.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1167732",
           "pacer_doc_id": "181029021191",
           "pacer_magic_num": "8606983",
-          "pacer_seq_no": "99"
+          "pacer_seq_no": "99",
+          "short_description": "Redacted Copy"
         }
       ],
       "docket_number": "6:22-cv-00351"

--- a/tests/examples/pacer/nef/s3/vaed_1.json
+++ b/tests/examples/pacer/nef/s3/vaed_1.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "360024",
           "pacer_doc_id": null,
           "pacer_magic_num": null,
-          "pacer_seq_no": null
+          "pacer_seq_no": null,
+          "short_description": "Case Assigned/Reassigned"
         }
       ],
       "docket_number": "2:17-cv-00109"

--- a/tests/examples/pacer/nef/txed.json
+++ b/tests/examples/pacer/nef/txed.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "204173",
           "pacer_doc_id": "175011894066",
           "pacer_magic_num": "11505292",
-          "pacer_seq_no": "37"
+          "pacer_seq_no": "37",
+          "short_description": ""
         }
       ],
       "docket_number": "9:21-cv-00029"

--- a/tests/examples/pacer/nef/txnd.json
+++ b/tests/examples/pacer/nef/txnd.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "343024",
           "pacer_doc_id": "177014286449",
           "pacer_magic_num": "79356691",
-          "pacer_seq_no": "47"
+          "pacer_seq_no": "47",
+          "short_description": ""
         }
       ],
       "docket_number": "3:21-cv-00071"

--- a/tests/examples/pacer/nef/txwd.json
+++ b/tests/examples/pacer/nef/txwd.json
@@ -15,7 +15,8 @@
           "pacer_case_id": "1039197",
           "pacer_doc_id": "181026461180",
           "pacer_magic_num": "54735545",
-          "pacer_seq_no": "212"
+          "pacer_seq_no": "212",
+          "short_description": ""
         }
       ],
       "docket_number": "7:19-cv-00150"


### PR DESCRIPTION
This PR solves https://github.com/freelawproject/courtlistener/issues/2638

Now the `short_description` is parsed from the email subject, there are some variations depending on the type of notifications as described below:

**For District notifications:**
e.g: Activity in Case 1:21-cv-01456-MN CBV, Inc. v. ChanBond, LLC Letter
short_description: `Letter`
The short description is after the case name (e.g: CBV, Inc. v. ChanBond, LLC) and it works every time according to our examples.

**For Appellate notifications:**
e.g: 21-1975 New York State Telecommunicati v. James "Letter RECEIVED"
short_description: `Letter RECEIVED`
The short description is after the case name (e.g: New York State Telecommunicati v. James) contained within `""`, sometimes there are additional chars after the short description that's why it uses regex to capture the short description within`""` and it works every time according to our examples.

**For Bankruptcy notifications:**
Unfortunately, there is no unique subject format for bankruptcy notifications, it seems that every court can have its own subject format. That's why we can only ensure getting the right `short_description` for courts we have examples.

`cacb` and `ctb`
e.g: 6:22-bk-13643-SY Request for courtesy Notice of Electronic Filing (NEF)
short_description: `Request for courtesy Notice of Electronic Filing (NEF)`
The short description is after the docket number (6:22-bk-13643), so we need to remove docket number traces like `-SY`.

`njb`
e.g: Ch-11 19-27439-MBK Determination of Adjournment Request - Hollister Construc
short_description: `Determination of Adjournment Request`
The short description is after the docket number (19-27439), so we need to remove docket number traces like `-MBK`.
Also is needed to remove additional strings after the last `-`

`nysb`
e.g: 22-22507-cgm Ch13 Affidavit Re: Gerasimos Stefanitsis
short_description: `Affidavit`
Here we need to remove the case_name, remove strings like `Re:` and also remove the Chapter (strings that start with Ch), finally remote the docket number and its traces like -cgm

`pawb`
e.g: Ch-7 22-20823-GLT U LOCK INC Reply
short_description: `Reply`
In this court the short_description is just right after the `case_name`

In case we receive a notification where we can't parse the `short_description`, it will be left blank. We may return here later to look for new bankruptcy examples from other courts and add support for them.

Let me know what you think.