### PR TITLE
663 Bypass free look confirmation page.

### DIFF
--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -210,6 +210,7 @@ class BaseReport:
                 params = {
                     "caseid": pacer_case_id,
                     "magic_num": pacer_magic_num,
+                    "use_magic": "1",  # Bypass the free look confirmation.
                 }
 
             # Add parameters to the PACER base url and make a GET request


### PR DESCRIPTION
This PR fixes #663 

It's a simple solution that adds the parameter `use_magic=1` to the free look download request in order to bypass the Free Look confirmation page.

This only works for district and bankruptcy notifications, since the appellate uses a different magic link format, and we don't have any examples (I looked for NDAs from the user that reported this issue, but found none) to see if there is a similar confirmation page for appellate magic links or not. So, we would need to know an NDA user that has this setting available to look for an example.

I tested this locally using magic links with this setting that were not used (due to the issue), and it worked properly. The confirmation page is bypassed, and the document is downloaded.
