### PR TITLE
Replace unmaintained cchardet with charset-normalizer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/juriscraper/lib/html_utils.py
+++ b/juriscraper/lib/html_utils.py
@@ -11,8 +11,8 @@ from lxml.html.clean import Cleaner
 from requests import Response
 
 try:
-    # Use cchardet for performance to detect the character encoding.
-    import cchardet as chardet
+    # Use charset-normalizer for performance to detect the character encoding.
+    import charset_normalizer as chardet
 except ImportError:
     import chardet
 
@@ -185,7 +185,7 @@ def get_visible_text(html_content):
 def set_response_encoding(request):
     """Set the encoding if it isn't set already.
 
-    Use cchardet for added performance.
+    Use charset-normalizer for added performance.
     """
     if request:
         # If the encoding is iso-8859-1, switch it to cp1252 (a superset)
@@ -194,12 +194,13 @@ def set_response_encoding(request):
 
         if request.encoding is None:
             # Requests detects the encoding when the item is GET'ed using
-            # HTTP headers, and then when r.text is accessed, if the encoding
-            # hasn't been set by that point. By setting the encoding here, we
-            # ensure that it's done by cchardet, if it hasn't been done with
-            # HTTP headers. This way it is done before r.text is accessed
-            # (which would do it with vanilla chardet). This is a big
-            # performance boon, and can be removed once requests is upgraded
+            # HTTP headers, and then when r.text is accessed, if the
+            # encoding hasn't been set by that point. By setting the
+            # encoding here, we ensure that it's done by charset-normalizer,
+            # if it hasn't been done with HTTP headers. This way it is done
+            # before r.text is accessed (which would do it with vanilla
+            # chardet). This is a big performance boon, and can be removed
+            # once requests is upgraded
             if isinstance(request.content, str):
                 as_bytes = request.content.encode()
                 request.encoding = chardet.detect(as_bytes)["encoding"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 argparse
-cchardet>=1.1.2
+charset-normalizer>=3.1.0
 certifi>=2017.4.17
 chardet>=3.0.2,<5.2.0
 cssselect

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: Implementation :: CPython",
         "Programming Language :: Python :: Implementation :: PyPy",
         "Topic :: Software Development :: Libraries :: Python Modules",

--- a/tests/examples/opinions/united_states/nh_example_4.compare.json
+++ b/tests/examples/opinions/united_states/nh_example_4.compare.json
@@ -201,7 +201,7 @@
   },
   {
     "case_dates": "2015-09-22",
-    "case_names": "Town of Bartlett v. Edward C. Furlong, III d/b/a Lil\u00e2\u20ac\u2122 Man Snowmobile Rentals",
+    "case_names": "Town of Bartlett v. Edward C. Furlong, III d/b/a Lil' Man Snowmobile Rentals",
     "download_urls": "https://www.courts.nh.gov/sites/g/files/ehbemt471/files/documents/2021-08/2015074furlong.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,


### PR DESCRIPTION
The cchardet package doesn't properly support python 3.11.