### PR TITLE
687 Fix docket report parsing on view multiple documents layout

### DIFF
--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -1004,12 +1004,8 @@ class DocketReport(BaseDocketReport, BaseReport):
         # option enabled.
         view_multiple_documents = False
         view_selected_btn = self.tree.xpath("//input[@value='View Selected']")
-        download_selected_btn = self.tree.xpath(
-            "//input[@value='Download Selected']"
-        )
-        if view_selected_btn and download_selected_btn:
+        if view_selected_btn:
             view_multiple_documents = True
-
         docket_entries = []
         for row in docket_entry_rows:
             de = {}

--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -1000,10 +1000,36 @@ class DocketReport(BaseDocketReport, BaseReport):
         docket_entry_all_rows = self._get_docket_entry_rows()
         docket_entry_rows = docket_entry_all_rows[1:]  # Skip the first row.
 
+        # Detect if the report was generated with "View multiple documents"
+        # option enabled.
+        view_multiple_documents = False
+        view_selected_btn = self.tree.xpath("//input[@value='View Selected']")
+        download_selected_btn = self.tree.xpath(
+            "//input[@value='Download Selected']"
+        )
+        if view_selected_btn and download_selected_btn:
+            view_multiple_documents = True
+
         docket_entries = []
         for row in docket_entry_rows:
             de = {}
             cells = row.xpath("./td[not(./input)]")
+
+            # If view_multiple_documents report, remove the "checkbox" cell on
+            # rows that lack a checkbox, as observed in sealed documents.
+            if view_multiple_documents and len(cells) == 4:
+                # In bankruptcy reports, there is an additional cell preceding
+                # the entry number which will be removed later. For now avoid
+                # removing the entry number in index [2]. See alnb_1.html.
+                cell_2_value = cells[2].text_content().strip()
+                if not cell_2_value:
+                    # This is the empty "checkbox" cell, remove it. See dcd_3.html
+                    del cells[2]
+            if view_multiple_documents and len(cells) == 5:
+                # In bankruptcy reports for entries that do not have a checkbox,
+                #  remove the empty "checkbox" cell. See alnb_1.html.
+                del cells[3]
+
             if len(cells) == 0:
                 # In some instances, the document entry table has an empty row
                 # <tr></tr>. See docket bankruptcy wiwb examples.

--- a/tests/examples/pacer/dockets/district/alnb_1.html
+++ b/tests/examples/pacer/dockets/district/alnb_1.html
@@ -1,0 +1,181 @@
+
+<!-- saved from url=(0071)https://ecf.alnb.uscourts.gov/cgi-bin/DktRpt.pl?218721703744501-L_1_0-1 -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><link rel="shortcut icon" href="https://ecf.alnb.uscourts.gov/favicon.ico"><title>ALNB Live Database Area</title>
+<script type="text/javascript">document.cookie = "PRTYPE=aty; path=/;"</script> <script>var default_base_path = "/"; </script> <link rel="stylesheet" type="text/css" href="./alnb_1_files/default.css"><script type="text/javascript" src="./alnb_1_files/core.js"></script><script type="text/javascript" src="./alnb_1_files/autocomplete.js"></script><script type="text/javascript" src="./alnb_1_files/DisableAJTALinks.js"></script><script type="text/javascript">if (top!=self) {top.location.replace(location.href);}</script><script>var default_base_path = "/"; </script></head><body bgcolor="FFFFCC" text="000000" onload="SetFocus()"><script type="text/javascript"> CMECF.whenPageHasLoaded(CMECF.MainMenu.setMainContentSize); CMECF.util.Event.addListener(window, "resize", CMECF.MainMenu.setMainContentSize);</script> <div id="cmecfMainContent" style="height: 862px;"><input type="hidden" id="cmecfMainContentScroll" value="0"><script language="JavaScript">
+		var IsForm = false;
+		var FirstField;
+		function SetFocus() {
+			if(IsForm) {
+				if(FirstField) {
+					var ind = FirstField.indexOf('document.',0);
+					if(ind == 0)
+					{
+						eval(FirstField);
+					}
+					else
+					{
+						var Code = "document.forms[0]."+FirstField+".focus();";
+						eval(Code);
+					}
+				} else {
+					var Cnt = 0;
+					while(document.forms[0].elements[Cnt] != null) {
+						try {
+							if(document.forms[0].elements[Cnt].type != "hidden" &&
+									!document.forms[0].elements[Cnt].disabled &&
+									!document.forms[0].elements[Cnt].readOnly) {
+								document.forms[0].elements[Cnt].focus();
+								break;
+							}
+						}
+						catch(e) {}
+						Cnt += 1;
+					}
+				}
+			}
+			return(true);
+		}
+		</script>
+<script type="text/JavaScript">
+document.cookie="PDFNoHeaderReferer=218721703744501; path=/";
+</script>
+		<script type="text/javascript" src="./alnb_1_files/widgits.js"></script>
+		<script>
+		var debtorPanel = null;
+
+		function create_panel(clid, message) {
+		    if (!debtorPanel) {
+		        debtorPanel = new CMECF.widget.Panel('debtorPanel', {
+				close:true,
+				draggable:false,
+				context:[clid, 'tl', 'br'],
+				width: "250" + "px",
+				height: "110" + "px",
+				constraintoviewport:true
+			});
+			debtorPanel.setHeader("Barred Debtor Information");
+			debtorPanel.setBody(message);
+			debtorPanel.body.style.height = "8em";
+			debtorPanel.render(document.body);
+		    } else {
+		        debtorPanel.show();
+		    }
+		}
+
+		function close_panel() {
+		    if (debtorPanel) {
+		        debtorPanel.destroy();
+		        debtorPanel = null;
+		    }
+		}
+		</script>
+
+   <style>
+	table.DktRpt
+	{
+	font-family:times,serif,arial,helvetica,clean,sans-serif;
+	font-size: 14px;
+	}
+   </style>
+	<table class="DktRpt" width="100%" align="right" border="0" cellspacing="5"><tbody><tr><div class="btn-group" id="recap-action-button"><a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-spinner fa-spin recap-btn-spinner-hidden" id="recap-button-spinner"></i> RECAP Actions<span class="caret"></span></a><ul class="dropdown-menu"><h2 class="dropdown-header" id="action-button-dropdown-header">CourtListener</h2><li id="create-alert-button"><a href="https://www.courtlistener.com/alert/docket/new/?pacer_case_id=640479&amp;court_id=alnb" target="_blank">Create alert</a></li><li id="search-docket-button"><a href="https://www.courtlistener.com/?type=r&amp;q=docket_id%3A7012824" target="_blank">Search this Docket</a></li><li id="view-docket-button"><a href="https://www.courtlistener.com/recap/gov.uscourts.alnb.640479/" target="_blank">View this docket</a></li><div class="recap-dropdown-divider"></div><li><a href="javascript:void(0);" id="refresh-recap-links" role="button">Refresh RECAP Links</a></li></ul></div></tr><tr><td align="right"><h2> <font size="3">CONVERTED, MEANSNO, DschDebt, CLOSED</font></h2></td></tr></tbody></table><br><br><br><center><b><font size="+1">U.S. BANKRUPTCY COURT<br>NORTHERN DISTRICT OF ALABAMA (Decatur)<br>Bankruptcy Petition #: 17-80033-CRJ7</font></b></center><table class="DktRpt" width="100%" border="0" cellspacing="1"><tbody><tr>	<td valign="top" width="50%"><font size="+0"><br><i>Assigned to:</i>       Clifton R. Jessup Jr.<br>Chapter          7<br>Previous chapter 13<br>Original chapter 13<br>Voluntary<br>No asset<div class="noprint"><a href="https://ecf.alnb.uscourts.gov/cgi-bin/SearchClaims.pl?caseid=640479;sc">Claims Register</a></div><br><br><br><i>Debtor disposition:</i>&nbsp;&nbsp;Standard Discharge<br><i>Joint debtor disposition:</i> Standard Discharge	</font></td>
+	<td valign="top" width="50%" align="right"><font size="+0"><table class="DktRpt" border="0" cellspacing="0" cellpadding="0" align="center"><tbody><tr><td align="right" valign="top"><i>Date filed:</i></td><td align="left" valign="top">&nbsp;&nbsp;01/05/2017</td></tr><tr><td align="right" valign="top"><i>Date converted:</i></td><td align="left" valign="top">&nbsp;&nbsp;11/30/2017</td></tr><tr><td align="right" valign="top"><i>Date terminated:</i></td><td align="left" valign="top">&nbsp;&nbsp;06/12/2018</td></tr><tr><td align="right" valign="top"><i>Debtor discharged:</i></td><td align="left" valign="top">&nbsp;&nbsp;03/30/2018</td></tr><tr><td align="right" valign="top"><i>Joint debtor discharged:</i></td><td align="left" valign="top">&nbsp;&nbsp;03/30/2018</td></tr><tr><td align="right" valign="top"><i>341 meeting:</i></td><td align="left" valign="top">&nbsp;&nbsp;12/27/2017</td></tr><tr><td align="right" valign="top"><i>Deadline for objecting to discharge:</i></td><td align="left" valign="top">&nbsp;&nbsp;02/26/2018  </td></tr></tbody></table>	</font></td>
+</tr>
+</tbody></table><br><font size="5"><b></b>
+		</font><table class="DktRpt" width="100%" border="0" cellspacing="1"><tbody><tr></tr><tr>	<td valign="top" width="50%"><font size="+0"><i><b>Debtor</b></i><br><b>Michael Appling</b>
+<br>320 County Road 338
+<br>Killen, AL 35645-3832
+<br>LAUDERDALE-AL
+<br>SSN / ITIN: xxx-xx-4033<br><br>	</font></td>
+	<td valign="top" align="right"><font size="+0">represented by	</font></td>
+<td valign="top" width="40%">
+  						<font size="+0"><b>Damon Q. Smith</b>
+<br> Damon Smith &amp; Associates LLC.
+<br>126 East Tennessee Street
+<br>Florence, AL 35630
+<br>256 718-2311
+<br>Fax  : 256-718-2377
+<br>Email:&nbsp;<a href="mailto:damon@smithbankruptcy.com">damon@smithbankruptcy.com</a><br><br></font></td></tr><tr>	<td valign="top" width="50%"><font size="+0"><i><b>Joint Debtor</b></i><br><b>Shawn Appling</b>
+<br>320 County Road 338
+<br>Killen, AL 35645-3832
+<br>LAUDERDALE-AL
+<br>SSN / ITIN: xxx-xx-9340<br><br>	</font></td>
+	<td valign="top" align="right"><font size="+0">represented by	</font></td>
+<td valign="top" width="40%">
+  						<font size="+0"><b>Damon Q. Smith</b>
+<br>(See above for address)<br><br></font></td></tr><tr>	<td valign="top" width="50%"><font size="+0"><i><b>Trustee</b></i><br><b>Tazewell Shepard</b>
+<br>Tazewell Shepard, Trustee
+<br>PO Box 19045
+<br>Huntsville, AL 35804
+<br>256 512-9924	</font></td>
+	<td valign="top" width="20%" align="right"><font size="+0">&nbsp;	</font></td>
+	<td valign="top" width="40%"><font size="+0">&nbsp;	</font></td>
+</tr></tbody></table><br><script>
+function calculateTotal(inputItem, bytes) {
+  max_file_size = 52428800;
+  with (inputItem.form) {
+		if (inputItem.checked == false) {   // unchecked - subtract from total
+			calculatedTotal.value = eval(calculatedTotal.value) - bytes;
+		} else {   // checked - add to total
+			calculatedTotal.value = eval(calculatedTotal.value) + bytes;
+		}
+		if (calculatedTotal.value > max_file_size) {
+			document.view_multi_docs.view_selected.disabled = true;
+			document.view_multi_docs.dl_selected.disabled = true;
+			document.getElementById('file_too_big').style.display = 'block';
+		} else {
+			document.view_multi_docs.view_selected.disabled = false;
+			document.view_multi_docs.dl_selected.disabled = false;
+			document.getElementById('file_too_big').style.display = 'none';
+		}
+    return(calculatedTotal.value / 1000000);
+  }
+}
+</script>
+<form enctype="multipart/form-data" method="post" action="https://ecf.alnb.uscourts.gov/cgi-bin/show_multidocs.pl?caseid=640479&amp;pdf_header=0" name="view_multi_docs" autocomplete="off"><input type="hidden" name="caseid" value="640479"><script language="javascript">
+<!-- Begin
+function checkAll(field) {
+if (field.length) {
+						for (i = 0; i < field.length; i++) field[i].checked = true;
+					} else {
+						if (! field.checked) {
+							field.checked = true;
+						}
+					}
+		}
+function uncheckAll(field) {
+if (field.length) {
+						for (i = 0; i < field.length; i++) field[i].checked = false;
+					} else {
+						if (field.checked) {
+							field.checked = false;
+						}
+					}
+		}
+//  End -->
+</script>
+<table class="DktRpt" border="1" cellpadding="10" cellspacing="0"><tbody><tr><th width="94" nowrap="">Filing Date</th>
+<th colspan="2" align="center">#</th>
+			<th white-space:nowrap'=""><small>
+			<a href="https://ecf.alnb.uscourts.gov/cgi-bin/DktRpt.pl?218721703744501-L_1_0-1#" onclick="uncheckAll(document.view_multi_docs.arr_de_seq_nums)" '="">clear</a></small></th>
+		<th align="center">Docket Text</th></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/05/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033396437" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033396437&quot;">1</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="2"></td><td valign="bottom">  Chapter 13 Voluntary Petition Individual <i></i>. Receipt Number O, Fee Amount $310 Filed by Michael Appling, Shawn Appling Section 316 Incomplete Filing Date 02/21/2017 Incomplete Filings due by 01/19/2017. (Davidson, Adam) (Entered: 01/05/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/05/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033396452" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033396452&quot;">2</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="10"></td><td valign="bottom">  Chapter 13 Plan <i></i> Filed by Debtor Michael Appling. (Davidson, Adam) (Entered: 01/05/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/05/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033396536" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033396536&quot;">3</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="13"></td><td valign="bottom">  Notice of Intent to Pay Chapter 13 Case Filing Fee through Chapter 13 Plan <i></i> Filed by Debtor Michael Appling, Joint Debtor Shawn Appling. (Davidson, Adam) (Entered: 01/05/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/05/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033396550" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033396550&quot;">4</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="15"></td><td valign="bottom">  Application to Pay Filing Fee in Installments Through the Chapter 13 Trustee Assigned to the Case Filed by Debtor Michael Appling, Joint Debtor Shawn Appling (Davidson, Adam) (Entered: 01/05/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/05/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033396583" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033396583&quot;">6</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="19"></td><td valign="bottom">  Certificate of Credit Counseling for Debtor and Joint Debtor Filed <i></i> Filed by Debtor Michael Appling, Joint Debtor Shawn Appling. (Attachments: # <a href="https://ecf.alnb.uscourts.gov/doc1/018133396584">1</a> cc sps) (Davidson, Adam) (Entered: 01/05/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/05/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033396631" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033396631&quot;">7</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="21"></td><td valign="bottom">  Employee Income Records <i></i> Filed by Debtor Michael Appling, Joint Debtor Shawn Appling. (Attachments: # <a href="https://ecf.alnb.uscourts.gov/doc1/018133396632">1</a> pay) (Davidson, Adam) (Entered: 01/05/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/05/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033396957" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033396957&quot;">8</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="25"></td><td valign="bottom">  Meeting of Creditors with 341(a) meeting to be held on 01/31/2017 at 09:00 AM at 3rd Floor Courtroom (CRJ) Florence. Confirmation hearing to be held on 03/08/2017 at 10:00 AM at 2nd Floor Courtroom (CRJ) Florence. Proof of Claim due by 05/01/2017. Government Proof of Claim due by 07/05/2017 Objection to Dischargeability of Certain Debts due by 04/03/2017. (Entered: 01/05/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/05/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px">9</td><td align="center">&nbsp;</td><td valign="bottom">  Order Approving Application for Payment of Filing Fees In Installments: IT IS ORDERED that the Debtor may pay the filing fee in installments as proposed in the application. A discharge shall not be granted until the filing fee has been paid in full. IT IS FURTHER ORDERED that all installments of the filing fee must be paid in full before the Debtor or Trustee may make further payments to an attorney or any other person who renders services to the Debtor in connection with the case. (Fee Amount $310.00) (RE: related document(s)<a href="https://ecf.alnb.uscourts.gov/doc1/018033396550">4</a> Application to Pay Filing Fees in Installments filed by Debtor Michael Appling, Joint Debtor Shawn Appling). (ksv) (Entered: 01/05/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/06/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033404729" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033404729&quot;">10</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="30"></td><td valign="bottom">  Notice of Requirement to Complete Course in Financial Management . (Admin) (Entered: 01/06/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/07/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033411867" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033411867&quot;">11</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="34"></td><td valign="bottom">  BNC Certificate of Notice (RE: related document(s)<a href="https://ecf.alnb.uscourts.gov/doc1/018033396957">8</a> Meeting (AutoAssign Chapter 13)). Notice Date 01/07/2017. (Admin.) (Entered: 01/08/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/07/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px">12</td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="37"></td><td valign="bottom">  BNC Certificate of Notice (RE: related document(s)<a href="https://ecf.alnb.uscourts.gov/doc1/018033396452">2</a> Chapter 13 Plan filed by Debtor Michael Appling). Notice Date 01/07/2017. (Admin.) (Entered: 01/08/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/08/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033413551" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033413551&quot;">13</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="40"></td><td valign="bottom">  BNC Certificate of Notice (RE: related document(s)<a href="https://ecf.alnb.uscourts.gov/doc1/018033404729">10</a> Notice of Requirement to Complete Course in Financial Management). Notice Date 01/08/2017. (Admin.) (Entered: 01/09/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/12/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033444758" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033444758&quot;">14</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="43"></td><td valign="bottom">  Notice of Appearance and Request for Notice <i></i> by Leonard N Math Filed by Creditor FAMILY SECURITY CREDIT UNION. (Math, Leonard) (Entered: 01/12/2017)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">01/13/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.alnb.uscourts.gov/doc1/018033452472" oncontextmenu="this.href=&quot;https://ecf.alnb.uscourts.gov/doc1/018033452472&quot;">15</a></td><td align="center"><input type="checkbox" name="arr_de_seq_nums" value="47"></td><td valign="bottom">  Withdrawal of Claims: 1 <i></i> Filed by Creditor FAMILY SECURITY CREDIT UNION. (Math, Leonard) (Entered: 01/13/2017)</td></tr>
+</tbody></table><br><br><br><br><input type="hidden" name="zipit" value="0">
+<input type="submit" value="View Selected" onclick="document.view_multi_docs.zipit.value=0;"><br> or <br>
+<input type="submit" value="Download Selected" name="dl_selected" onclick="document.view_multi_docs.zipit.value=1;">
+			<script type="text/javascript">
+				document.cookie = 'RECENT_CASES=' + "640479;";
+			</script>
+		<hr><center><table border="1" bgcolor="white" width="400"><tbody><tr><th colspan="4"><font size="+1" color="DARKRED">PACER Service Center </font></th></tr><tr><th colspan="4"><font color="DARKBLUE">Transaction Receipt </font></th></tr><tr></tr><tr></tr><tr><td colspan="4" align="CENTER"><font size="-1" color="DARKBLUE">05/30/2023 20:02:49</font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> PACER Login: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> jesus13law </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Client Code: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE">  </font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> Description: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> Docket Report </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Search Criteria: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 17-80033-CRJ7 Fil or Ent: filed From: 1/1/1990 To: 5/30/2023 Doc From: 1 Doc To: 15     Multiple Docs: on Format: html  </font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> Billable Pages: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 2 </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Cost: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 0.20 </font></td></tr><tr></tr><tr></tr></tbody></table></center><br><br></form></div></body></html>

--- a/tests/examples/pacer/dockets/district/alnb_1.json
+++ b/tests/examples/pacer/dockets/district/alnb_1.json
@@ -1,0 +1,167 @@
+{
+  "assigned_to_str": "Clifton R. Jessup Jr.",
+  "case_name": "Michael Appling",
+  "cause": "",
+  "court_id": "alnb",
+  "date_converted": "2017-11-30",
+  "date_discharged": "2018-03-30",
+  "date_filed": "2017-01-05",
+  "date_terminated": "2018-06-12",
+  "demand": "",
+  "docket_entries": [
+    {
+      "date_entered": "2017-01-05",
+      "date_filed": "2017-01-05",
+      "description": "Chapter 13 Voluntary Petition Individual . Receipt Number O, Fee Amount $310 Filed by Michael Appling, Shawn Appling Section 316 Incomplete Filing Date 02/21/2017 Incomplete Filings due by 01/19/2017. (Davidson, Adam) (Entered: 01/05/2017)",
+      "document_number": "1",
+      "pacer_doc_id": "018033396437",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-05",
+      "date_filed": "2017-01-05",
+      "description": "Chapter 13 Plan Filed by Debtor Michael Appling. (Davidson, Adam) (Entered: 01/05/2017)",
+      "document_number": "2",
+      "pacer_doc_id": "018033396452",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-05",
+      "date_filed": "2017-01-05",
+      "description": "Notice of Intent to Pay Chapter 13 Case Filing Fee through Chapter 13 Plan Filed by Debtor Michael Appling, Joint Debtor Shawn Appling. (Davidson, Adam) (Entered: 01/05/2017)",
+      "document_number": "3",
+      "pacer_doc_id": "018033396536",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-05",
+      "date_filed": "2017-01-05",
+      "description": "Application to Pay Filing Fee in Installments Through the Chapter 13 Trustee Assigned to the Case Filed by Debtor Michael Appling, Joint Debtor Shawn Appling (Davidson, Adam) (Entered: 01/05/2017)",
+      "document_number": "4",
+      "pacer_doc_id": "018033396550",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-05",
+      "date_filed": "2017-01-05",
+      "description": "Certificate of Credit Counseling for Debtor and Joint Debtor Filed Filed by Debtor Michael Appling, Joint Debtor Shawn Appling. (Attachments: # 1 cc sps) (Davidson, Adam) (Entered: 01/05/2017)",
+      "document_number": "6",
+      "pacer_doc_id": "018033396583",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-05",
+      "date_filed": "2017-01-05",
+      "description": "Employee Income Records Filed by Debtor Michael Appling, Joint Debtor Shawn Appling. (Attachments: # 1 pay) (Davidson, Adam) (Entered: 01/05/2017)",
+      "document_number": "7",
+      "pacer_doc_id": "018033396631",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-05",
+      "date_filed": "2017-01-05",
+      "description": "Meeting of Creditors with 341(a) meeting to be held on 01/31/2017 at 09:00 AM at 3rd Floor Courtroom (CRJ) Florence. Confirmation hearing to be held on 03/08/2017 at 10:00 AM at 2nd Floor Courtroom (CRJ) Florence. Proof of Claim due by 05/01/2017. Government Proof of Claim due by 07/05/2017 Objection to Dischargeability of Certain Debts due by 04/03/2017. (Entered: 01/05/2017)",
+      "document_number": "8",
+      "pacer_doc_id": "018033396957",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-05",
+      "date_filed": "2017-01-05",
+      "description": "Order Approving Application for Payment of Filing Fees In Installments: IT IS ORDERED that the Debtor may pay the filing fee in installments as proposed in the application. A discharge shall not be granted until the filing fee has been paid in full. IT IS FURTHER ORDERED that all installments of the filing fee must be paid in full before the Debtor or Trustee may make further payments to an attorney or any other person who renders services to the Debtor in connection with the case. (Fee Amount $310.00) (RE: related document(s)4 Application to Pay Filing Fees in Installments filed by Debtor Michael Appling, Joint Debtor Shawn Appling). (ksv) (Entered: 01/05/2017)",
+      "document_number": "9",
+      "pacer_doc_id": null,
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-06",
+      "date_filed": "2017-01-06",
+      "description": "Notice of Requirement to Complete Course in Financial Management . (Admin) (Entered: 01/06/2017)",
+      "document_number": "10",
+      "pacer_doc_id": "018033404729",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-08",
+      "date_filed": "2017-01-07",
+      "description": "BNC Certificate of Notice (RE: related document(s)8 Meeting (AutoAssign Chapter 13)). Notice Date 01/07/2017. (Admin.) (Entered: 01/08/2017)",
+      "document_number": "11",
+      "pacer_doc_id": "018033411867",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-08",
+      "date_filed": "2017-01-07",
+      "description": "BNC Certificate of Notice (RE: related document(s)2 Chapter 13 Plan filed by Debtor Michael Appling). Notice Date 01/07/2017. (Admin.) (Entered: 01/08/2017)",
+      "document_number": "12",
+      "pacer_doc_id": null,
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-09",
+      "date_filed": "2017-01-08",
+      "description": "BNC Certificate of Notice (RE: related document(s)10 Notice of Requirement to Complete Course in Financial Management). Notice Date 01/08/2017. (Admin.) (Entered: 01/09/2017)",
+      "document_number": "13",
+      "pacer_doc_id": "018033413551",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-12",
+      "date_filed": "2017-01-12",
+      "description": "Notice of Appearance and Request for Notice by Leonard N Math Filed by Creditor FAMILY SECURITY CREDIT UNION. (Math, Leonard) (Entered: 01/12/2017)",
+      "document_number": "14",
+      "pacer_doc_id": "018033444758",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2017-01-13",
+      "date_filed": "2017-01-13",
+      "description": "Withdrawal of Claims: 1 Filed by Creditor FAMILY SECURITY CREDIT UNION. (Math, Leonard) (Entered: 01/13/2017)",
+      "document_number": "15",
+      "pacer_doc_id": "018033452472",
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "17-80033",
+  "jurisdiction": "",
+  "jury_demand": "",
+  "mdl_status": "",
+  "nature_of_suit": "",
+  "ordered_by": "date_filed",
+  "parties": [
+    {
+      "attorneys": [
+        {
+          "contact": "Damon Smith & Associates LLC.\n126 East Tennessee Street\nFlorence, AL 35630\n256 718-2311\nFax : 256-718-2377\nEmail:\n",
+          "name": "Damon Q. Smith",
+          "roles": []
+        }
+      ],
+      "date_terminated": null,
+      "extra_info": "320 County Road 338\nKillen, AL 35645-3832\nLAUDERDALE-AL\nSSN / ITIN: xxx-xx-4033",
+      "name": "Michael Appling",
+      "type": "Debtor"
+    },
+    {
+      "attorneys": [
+        {
+          "contact": "Damon Smith & Associates LLC.\n126 East Tennessee Street\nFlorence, AL 35630\n256 718-2311\nFax : 256-718-2377\nEmail:\n",
+          "name": "Damon Q. Smith",
+          "roles": []
+        }
+      ],
+      "date_terminated": null,
+      "extra_info": "320 County Road 338\nKillen, AL 35645-3832\nLAUDERDALE-AL\nSSN / ITIN: xxx-xx-9340",
+      "name": "Shawn Appling",
+      "type": "Joint Debtor"
+    },
+    {
+      "attorneys": [],
+      "date_terminated": null,
+      "extra_info": "Tazewell Shepard, Trustee\nPO Box 19045\nHuntsville, AL 35804\n256 512-9924",
+      "name": "Tazewell Shepard",
+      "type": "Trustee"
+    }
+  ],
+  "referred_to_str": ""
+}

--- a/tests/examples/pacer/dockets/district/dcd_3.html
+++ b/tests/examples/pacer/dockets/district/dcd_3.html
@@ -1,0 +1,136 @@
+<head><link rel="shortcut icon" href="/favicon.ico"><title>District of Columbia live database</title>
+<script type="text/javascript">var default_base_path = "/"; </script><script type="text/javascript">if (top!=self) {top.location.replace(location.href);}</script><link rel="stylesheet" type="text/css" href="/css/default.css"><script type="text/javascript" src="/lib/core.js"></script><link rel="stylesheet" type="text/css" href="/css/print.css" media="print"><script type="text/javascript" src="/cgi-bin/menu.pl?id=-1"></script></head><body text="000000" bgcolor="FFFFFF"><iframe id="_yuiResizeMonitor" style="position: absolute; visibility: visible; width: 10em; height: 10em; top: -164px; left: -164px; border-width: 0px;"></iframe>        <div id="topmenu" class="yuimenubar yui-module yui-overlay visible" style="position: static; display: block; z-index: 30; visibility: visible;">
+				<div class="bd"><img src="/graphics/logo-cmecf-sm.png" class="cmecfLogo" id="cmecfLogo" alt="CM/ECF" title="">
+				<ul class="first-of-type">
+<li class="yuimenubaritem first-of-type" id="yui-gen0" groupindex="0" index="0"><a class="yuimenubaritemlabel" href="/cgi-bin/iquery.pl"><u>Q</u>uery</a></li>
+<li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen1" groupindex="0" index="1"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="/cgi-bin/DisplayMenu.pl?Reports">Reports <div class="spritedownarrow"></div></a></li>
+<li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen2" groupindex="0" index="2"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="/cgi-bin/DisplayMenu.pl?Utilities"><u>U</u>tilities <div class="spritedownarrow"></div></a></li>
+				<li class="yuimenubaritem" id="yui-gen3" groupindex="0" index="3">
+				<a class="yuimenubaritemlabel" onclick="CMECF.MainMenu.showHelpPage(); return false">Help</a></li>
+
+<li class="yuimenubaritem" id="yui-gen4" groupindex="0" index="4"><a class="yuimenubaritemlabel" href="/cgi-bin/login.pl?logout">Log Out</a></li></ul><hr class="hrmenuseparator"></div></div><script type="text/javascript">if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout(CMECF.MainMenu.createMenu, 0);}else{CMECF.util.Event.addListener(window, "load", CMECF.MainMenu.createMenu);}</script> <div id="cmecfMainContent" style="height: 857px;"><input type="hidden" id="cmecfMainContentScroll" value="0">
+				<table width="100%" cellspacing="0" border="0">
+					<tbody><tr><div class="btn-group" id="recap-action-button"><a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-spinner fa-spin recap-btn-spinner-hidden" id="recap-button-spinner"></i> RECAP Actions<span class="caret"></span></a><ul class="dropdown-menu"><h2 class="dropdown-header" id="action-button-dropdown-header">CourtListener</h2><li id="view-docket-button"><a href="https://www.courtlistener.com/recap/gov.uscourts.dcd.223205/" target="_blank">View this docket</a></li><div class="recap-dropdown-divider"></div><li><a href="javascript:void(0);" id="refresh-recap-links" role="button">Refresh RECAP Links</a></li></ul></div></tr><tr><td align="right"><span>CONSOL</span>,<span>TYPE-A</span></td></tr>
+				</tbody></table>
+			<h3 align="center">U.S. District Court<br>
+District of Columbia (Washington, DC)<br>
+CIVIL DOCKET FOR CASE #: 1:20-cv-03010-APM</h3>
+<table width="100%" cellspacing="5" border="0"><tbody><tr>
+<td width="60%" valign="top"><br>UNITED STATES OF AMERICA et al v. GOOGLE LLC<br>
+Assigned to: Judge Amit P. Mehta<br>
+<table cellspacing="0" border="0"><tbody><tr><td valign="top">&nbsp;Cases:&nbsp;</td><td><a href="/cgi-bin/DktRpt.pl?223681">1:20-cv-03158-APM</a></td></tr>
+<tr><td></td><td><a href="/cgi-bin/DktRpt.pl?223360">1:20-cv-03057-TNM</a></td></tr>
+<tr><td></td><td><a href="/cgi-bin/DktRpt.pl?225161">1:20-cv-03715-APM</a></td></tr>
+<tr><td></td><td><a href="/cgi-bin/DktRpt.pl?242045">1:22-cv-00937-APM</a></td></tr>
+<tr><td></td><td><a href="/cgi-bin/DktRpt.pl?241261">1:22-cv-00712-APM</a></td></tr></tbody></table>
+Cause: 15:1 Antitrust Litigation</td>
+<td width="40%" valign="top"><br>Date Filed: 10/20/2020<br>
+Jury Demand: None<br>
+Nature of Suit: 410 Anti-Trust<br>
+Jurisdiction: U.S. Government Plaintiff</td>
+</tr></tbody></table>
+
+	<form enctype="multipart/form-data" method="post" name="view_multi_docs" action="show_multidocs.pl?caseid=223205&amp;pdf_header=2&amp;pdf_toggle_possible=0"><input type="hidden" name="caseid" value="223205"><input type="hidden" name="docket_caseid" value="223205"><input type="hidden" name="download_documents" value=""><input type="hidden" name="sort1" value="oldest date first"><input type="hidden" name="date_range_type" value="Filed"><br><table rules="all" width="99%" cellspacing="0" cellpadding="5" border="1" align="center">
+<tbody><tr><td style="font-weight:bold; width=94; white-space:nowrap">Date Filed</td>
+<th>#</th><td style="font-weight:bold; white-space:nowrap"><small>Select<br><a href="#" onclick="select_all_documents(true, false)" '="">all</a> / <a href="#" onclick="select_all_documents(false, false)" '="">clear</a></small></td><td style="font-weight:bold">Docket Text</td></tr>
+<tr><td width="94" valign="top" nowrap="">10/20/2020</td><td style="white-space:nowrap" valign="top" align="right"><a href="https://ecf.dcd.uscourts.gov/doc1/04508117526" onclick="goDLS('/doc1/04508117526','223205','15','','2','','','','');return(false);">1</a>&nbsp;</td><td valign="top" align="center"><input type="checkbox" name="all_documents" value="223205_15" onclick="select_all_attachments(this);"><br><div class="show_filesize">  1.2 MB</div></td>
+<td valign="top"><!--SB-->COMPLAINT against GOOGLE LLC filed by UNITED STATES OF AMERICA. (Attachments: # <a href="https://ecf.dcd.uscourts.gov/doc1/04518117527" onclick="goDLS('/doc1/04518117527','223205','15','','2','','','','');return(false);">1</a> Civil Cover Sheet, # <a href="https://ecf.dcd.uscourts.gov/doc1/04518117528" onclick="goDLS('/doc1/04518117528','223205','15','','2','','','','');return(false);">2</a> Summons)(ztnr) (Entered: 10/20/2020)</td></tr>
+<tr><td></td><td></td><td></td><td><table style="margin:10px;width:500px"> <tbody><tr>
+			<td style="width:20px"><input name="document_223205_15_0" type="checkbox" value="8117526-1074119-64" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>0</td><td>Main Document</td>
+			<td>64 pages</td>
+			<td>  1.0 MB</td>
+		</tr>  <tr>
+			<td style="width:20px"><input name="document_223205_15_1" type="checkbox" value="8117527-38495-2" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>1</td><td>Civil Cover Sheet</td>
+			<td>2 pages</td>
+			<td>37.6 KB</td>
+		</tr>  <tr>
+			<td style="width:20px"><input name="document_223205_15_2" type="checkbox" value="8117528-75539-2" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>2</td><td>Summons</td>
+			<td>2 pages</td>
+			<td>73.8 KB</td>
+		</tr></tbody></table></td></tr>
+
+<tr><td width="94" valign="top" nowrap="">08/19/2021</td><td style="white-space:nowrap" valign="top" align="right">&nbsp;</td><td align="center">&nbsp;</td><td valign="top"><!--SB-->MINUTE ORDER. Pursuant to the discovery hearing held on August 19, 2021, the court orders the following with respect to further proceedings: (1) non-party Apple will provide deconstructed hit reports for the top five remaining disputed search strings (by hit volume) to the United States by August 23, 2021. Apple and the United States will meet and confer about the disputed remaining search strings by August 25, 2021, and they will submit to the court a Joint Status Report concerning those search strings by August 26, 2021. (2) Apple will complete substantial production of its response to the United States' subpoena for records by September 30, 2021. (3) The United States will submit to Apple a revised list of codename requests, limiting its request to 35 subject matters or inquiries, by August 23, 2021. Apple will submit to the United States responses to that list by August 30, 2021. (4) The parties will appear for the status conference already scheduled for August 31, 2021, at 11:00 a.m., prepared to update the court on these matters. Signed by Judge Amit P. Mehta on 8/19/2021. (lcapm2) (Entered: 08/19/2021)</td></tr>
+<tr><td width="94" valign="top" nowrap="">08/19/2021</td><td style="white-space:nowrap" valign="top" align="right">179&nbsp;</td><td align="center">&nbsp;</td><td valign="top"><!--SB-->MINUTE ORDER granting <a href="https://ecf.dcd.uscourts.gov/doc1/04508673716" onclick="goDLS('/doc1/04508673716','223205','661','','2','','','','');return(false);">164</a> Sealed Motion for Leave to File Document Under Seal; granting <a href="https://ecf.dcd.uscourts.gov/doc1/04508713958" onclick="goDLS('/doc1/04508713958','223205','707','','2','','','','');return(false);">176</a> Sealed Motion for Leave to File Document Under Seal; and granting <a href="https://ecf.dcd.uscourts.gov/doc1/04508714353" onclick="goDLS('/doc1/04508714353','223205','711','','2','','','','');return(false);">178</a> Sealed Motion for Leave to File Document Under Seal. Signed by Judge Amit P. Mehta on 8/19/2021. (lcapm2) (Entered: 08/19/2021)</td></tr>
+<tr><td width="94" valign="top" nowrap="">03/14/2022</td><td style="white-space:nowrap" valign="top" align="right"><a href="https://ecf.dcd.uscourts.gov/doc1/04519105256" onclick="goDLS('/doc1/04519105256','223205','1174','','2','','','','');return(false);">324</a>&nbsp;</td><td align="center">&nbsp;</td><td valign="top"><!--SB-->ENTERED IN ERROR.....TRANSCRIPT OF STATUS CONFERENCE VIA ZOOM PROCEEDINGS before Judge Amit P. Mehta held on March 9, 2022; Page Numbers: 1-72. Date of Issuance: March 14, 2022. Court Reporter/Transcriber: William Zaremba; Telephone number: (202) 354-3249. Transcripts may be ordered by submitting the <a href="http://www.dcd.uscourts.gov/node/110">Transcript Order Form</a><p></p><p></p>For the first 90 days after this filing date, the transcript may be viewed at the courthouse at a public terminal or purchased from the court reporter referenced above. After 90 days, the transcript may be accessed via PACER. Other transcript formats, (multi-page, condensed, PDF or ASCII) may be purchased from the court reporter.<p><b><font color="red">NOTICE RE REDACTION OF TRANSCRIPTS: </font></b>The parties have twenty-one days to file with the court and the court reporter any request to redact personal identifiers from this transcript. If no such requests are filed, the transcript will be made available to the public via PACER without redaction after 90 days. The policy, which includes the five personal identifiers specifically covered, is located on our website at www.dcd.uscourts.gov.</p><p></p> Redaction Request due 4/4/2022. Redacted Transcript Deadline set for 4/14/2022. Release of Transcript Restriction set for 6/12/2022.(wz) Modified on 3/15/2022 (zeg). (Entered: 03/14/2022)</td></tr>
+
+<tr><td width="94" valign="top" nowrap="">05/04/2023</td><td style="white-space:nowrap" valign="top" align="right"><a href="https://ecf.dcd.uscourts.gov/doc1/04509911803" onclick="goDLS('/doc1/04509911803','223205','2035','','2','','','','');return(false);">588</a>&nbsp;</td><td align="center">&nbsp;</td><td valign="top"><!--SB-->SEALED DOCUMENT filed by UNITED STATES OF AMERICA re <a href="https://ecf.dcd.uscourts.gov/doc1/04509714689" onclick="goDLS('/doc1/04509714689','223205','1622','','2','','','','');return(false);">477</a> Sealed Document,,,,, <a href="https://ecf.dcd.uscourts.gov/doc1/04509744454" onclick="goDLS('/doc1/04509744454','223205','1677','','2','','','','');return(false);">492</a> Sealed Document,,, (This document is SEALED and only available to authorized persons.) (Attachments: # <a href="https://ecf.dcd.uscourts.gov/doc1/04519911804" onclick="goDLS('/doc1/04519911804','223205','2035','','2','','','','');return(false);">1</a> Exhibit (Pls. Ex. 22), # <a href="https://ecf.dcd.uscourts.gov/doc1/04519911805" onclick="goDLS('/doc1/04519911805','223205','2035','','2','','','','');return(false);">2</a> Exhibit (Pls. Ex. 24), # <a href="https://ecf.dcd.uscourts.gov/doc1/04519911806" onclick="goDLS('/doc1/04519911806','223205','2035','','2','','','','');return(false);">3</a> Certificate of Service)(Herrmann, Karl) (Entered: 05/04/2023)</td></tr>
+<tr><td width="94" valign="top" nowrap="">05/05/2023</td><td style="white-space:nowrap" valign="top" align="right"><a href="https://ecf.dcd.uscourts.gov/doc1/04509914787" onclick="goDLS('/doc1/04509914787','223205','2039','','2','','','','');return(false);">589</a>&nbsp;</td><td align="center">&nbsp;</td><td valign="top"><!--SB-->SEALED DOCUMENT filed by STATE OF COLORADO re <a href="https://ecf.dcd.uscourts.gov/doc1/04509887132" onclick="goDLS('/doc1/04509887132','223205','2025','','2','','','','');return(false);">584</a> Sealed Document, (This document is SEALED and only available to authorized persons.) (Attachments: # <a href="https://ecf.dcd.uscourts.gov/doc1/04519914788" onclick="goDLS('/doc1/04519914788','223205','2039','','2','','','','');return(false);">1</a> Exhibit A, # <a href="https://ecf.dcd.uscourts.gov/doc1/04519914789" onclick="goDLS('/doc1/04519914789','223205','2039','','2','','','','');return(false);">2</a> Certificate of Service)(Sallet, Jonathan) (Entered: 05/05/2023)</td></tr>
+<tr><td width="94" valign="top" nowrap="">05/09/2023</td><td style="white-space:nowrap" valign="top" align="right"><a href="https://ecf.dcd.uscourts.gov/doc1/04509920629" onclick="goDLS('/doc1/04509920629','223205','2042','','2','','','','');return(false);">590</a>&nbsp;</td><td valign="top" align="center"><input type="checkbox" name="all_documents" value="223205_2042" onclick="select_all_attachments(this);"><br><div class="show_filesize">  1.7 MB</div></td>
+<td valign="top"><!--SB-->REDACTED DOCUMENT- Plaintiff States' Motion for Leave to File a Supplemental Response to Certain Questions of the Court at Oral Argument to <a href="https://ecf.dcd.uscourts.gov/doc1/04509887132" onclick="goDLS('/doc1/04509887132','223205','2025','','2','','','','');return(false);">584</a> Sealed Document, <i></i> by STATE OF COLORADO. (Attachments: # <a href="https://ecf.dcd.uscourts.gov/doc1/04519920630" onclick="goDLS('/doc1/04519920630','223205','2042','','2','','','','');return(false);">1</a> Memorandum in Support A, # <a href="https://ecf.dcd.uscourts.gov/doc1/04519920631" onclick="goDLS('/doc1/04519920631','223205','2042','','2','','','','');return(false);">2</a> Exhibit B, # <a href="https://ecf.dcd.uscourts.gov/doc1/04519920632" onclick="goDLS('/doc1/04519920632','223205','2042','','2','','','','');return(false);">3</a> Exhibit C, # <a href="https://ecf.dcd.uscourts.gov/doc1/04519920633" onclick="goDLS('/doc1/04519920633','223205','2042','','2','','','','');return(false);">4</a> Exhibit D, # <a href="https://ecf.dcd.uscourts.gov/doc1/04519920634" onclick="goDLS('/doc1/04519920634','223205','2042','','2','','','','');return(false);">5</a> Exhibit E, # <a href="https://ecf.dcd.uscourts.gov/doc1/04519920635" onclick="goDLS('/doc1/04519920635','223205','2042','','2','','','','');return(false);">6</a> Exhibit F, # <a href="https://ecf.dcd.uscourts.gov/doc1/04519920636" onclick="goDLS('/doc1/04519920636','223205','2042','','2','','','','');return(false);">7</a> Exhibit G, # <a href="https://ecf.dcd.uscourts.gov/doc1/04519920637" onclick="goDLS('/doc1/04519920637','223205','2042','','2','','','','');return(false);">8</a> Certificate of Service)(Sallet, Jonathan) (Entered: 05/09/2023)</td></tr>
+<tr><td></td><td></td><td></td><td><table style="margin:10px;width:500px"> <tbody><tr>
+			<td style="width:20px"><input name="document_223205_2042_0" type="checkbox" value="9920629-318094-16" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>0</td><td>Main Document</td>
+			<td>16 pages</td>
+			<td>310.6 KB</td>
+		</tr>  <tr>
+			<td style="width:20px"><input name="document_223205_2042_1" type="checkbox" value="9920630-636671-21" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>1</td><td>Memorandum in Support A</td>
+			<td>21 pages</td>
+			<td>621.7 KB</td>
+		</tr>  <tr>
+			<td style="width:20px"><input name="document_223205_2042_2" type="checkbox" value="9920631-82508-1" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>2</td><td>Exhibit B</td>
+			<td>1 page</td>
+			<td>80.6 KB</td>
+		</tr>  <tr>
+			<td style="width:20px"><input name="document_223205_2042_3" type="checkbox" value="9920632-81952-1" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>3</td><td>Exhibit C</td>
+			<td>1 page</td>
+			<td>80.0 KB</td>
+		</tr>  <tr>
+			<td style="width:20px"><input name="document_223205_2042_4" type="checkbox" value="9920633-81921-1" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>4</td><td>Exhibit D</td>
+			<td>1 page</td>
+			<td>80.0 KB</td>
+		</tr>  <tr>
+			<td style="width:20px"><input name="document_223205_2042_5" type="checkbox" value="9920634-81623-1" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>5</td><td>Exhibit E</td>
+			<td>1 page</td>
+			<td>79.7 KB</td>
+		</tr>  <tr>
+			<td style="width:20px"><input name="document_223205_2042_6" type="checkbox" value="9920635-81950-1" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>6</td><td>Exhibit F</td>
+			<td>1 page</td>
+			<td>80.0 KB</td>
+		</tr>  <tr>
+			<td style="width:20px"><input name="document_223205_2042_7" type="checkbox" value="9920636-54121-1" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>7</td><td>Exhibit G</td>
+			<td>1 page</td>
+			<td>52.9 KB</td>
+		</tr>  <tr>
+			<td style="width:20px"><input name="document_223205_2042_8" type="checkbox" value="9920637-319680-1" autocomplete="off" onchange="update_sizes(this)"></td>
+			<td>8</td><td>Certificate of Service</td>
+			<td>1 page</td>
+			<td>312.2 KB</td>
+		</tr></tbody></table></td></tr>
+</tbody></table><br>
+<input type="hidden" name="zipit" value="0">
+<input type="hidden" name="terminated_parties" value="on">
+<input type="hidden" name="list_of_member_cases" value="on">
+<input type="hidden" name="show_related_docs" value="">
+<input type="hidden" name="show_related_summary_text" value="">
+<input type="hidden" name="list_of_parties_and_counsel" value="on">
+
+                        <table>
+                                <tbody><tr><td>
+                                <input type="button" value="View Selected" id="view_button" onclick="submit_form(0)" disabled="">
+                                <br> or <br>
+                                <input type="button" value="Download Selected" id="download_button" onclick="submit_form(1);" disabled="">
+                                </td><td>&nbsp;&nbsp;&nbsp;&nbsp;</td>
+                                <td><div id="file_too_big" style="display:none"><strong><font color="red">You must select fewer
+                                documents because the combined PDF would be over the 500 MB size limit.</font></strong><br>
+				</div><div style="display:block">
+                                Total filesize of selected documents (MB):
+                                <input type="hidden" id="total_size_counter" value="0">
+                                <input type="hidden" id="total_page_counter" value="0">
+                                <input type="text" id="total_size_display" autocomplete="off" value="0" onfocus="this.blur();"><br>
+                                Maximum filesize allowed: 500 MB<br>
+                                <input type="hidden" id="total_page_display" value="0" onfocus="this.blur();"><br>
+				</div>
+                                </td></tr>
+                        </tbody></table>
+                        <script>CMECF.util.Event.addListener(window, 'pageshow', select_all_documents(false));</script>
+	<hr><center><table width="400" border="1" bgcolor="white"><tbody><tr><th colspan="4"><font size="+1" color="DARKRED">PACER Service Center </font></th></tr><tr><th colspan="4"><font color="DARKBLUE">Transaction Receipt </font></th></tr><tr></tr><tr></tr><tr><td colspan="4" align="CENTER"><font size="-1" color="DARKBLUE">05/28/2023 05:35:38</font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> PACER Login: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 57uwr63Yv </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Client Code: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE">  </font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> Description: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> Docket Report </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Search Criteria: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 1:20-cv-03010-APM     </font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> Billable Pages: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 30 </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Cost: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 3.00 </font></td></tr><tr></tr><tr></tr></tbody></table></center></form></div><button style="position: fixed !important; top: 0 !important; right: 0 !important;">Open Links</button></body>

--- a/tests/examples/pacer/dockets/district/dcd_3.json
+++ b/tests/examples/pacer/dockets/district/dcd_3.json
@@ -1,0 +1,77 @@
+{
+  "assigned_to_str": "Amit P. Mehta",
+  "case_name": "UNITED STATES OF AMERICA v. GOOGLE LLC",
+  "cause": "15:1 Antitrust Litigation",
+  "court_id": "dcd",
+  "date_converted": null,
+  "date_discharged": null,
+  "date_filed": "2020-10-20",
+  "date_terminated": null,
+  "demand": "",
+  "docket_entries": [
+    {
+      "date_entered": "2020-10-20",
+      "date_filed": "2020-10-20",
+      "description": "COMPLAINT against GOOGLE LLC filed by UNITED STATES OF AMERICA. (Attachments: # 1 Civil Cover Sheet, # 2 Summons)(ztnr) (Entered: 10/20/2020)",
+      "document_number": "1",
+      "pacer_doc_id": "04508117526",
+      "pacer_seq_no": "15"
+    },
+    {
+      "date_entered": "2021-08-19",
+      "date_filed": "2021-08-19",
+      "description": "MINUTE ORDER. Pursuant to the discovery hearing held on August 19, 2021, the court orders the following with respect to further proceedings: (1) non-party Apple will provide deconstructed hit reports for the top five remaining disputed search strings (by hit volume) to the United States by August 23, 2021. Apple and the United States will meet and confer about the disputed remaining search strings by August 25, 2021, and they will submit to the court a Joint Status Report concerning those search strings by August 26, 2021. (2) Apple will complete substantial production of its response to the United States' subpoena for records by September 30, 2021. (3) The United States will submit to Apple a revised list of codename requests, limiting its request to 35 subject matters or inquiries, by August 23, 2021. Apple will submit to the United States responses to that list by August 30, 2021. (4) The parties will appear for the status conference already scheduled for August 31, 2021, at 11:00 a.m., prepared to update the court on these matters. Signed by Judge Amit P. Mehta on 8/19/2021. (lcapm2) (Entered: 08/19/2021)",
+      "document_number": null,
+      "pacer_doc_id": null,
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2021-08-19",
+      "date_filed": "2021-08-19",
+      "description": "MINUTE ORDER granting 164 Sealed Motion for Leave to File Document Under Seal; granting 176 Sealed Motion for Leave to File Document Under Seal; and granting 178 Sealed Motion for Leave to File Document Under Seal. Signed by Judge Amit P. Mehta on 8/19/2021. (lcapm2) (Entered: 08/19/2021)",
+      "document_number": "179",
+      "pacer_doc_id": null,
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2022-03-14",
+      "date_filed": "2022-03-14",
+      "description": "ENTERED IN ERROR.....TRANSCRIPT OF STATUS CONFERENCE VIA ZOOM PROCEEDINGS before Judge Amit P. Mehta held on March 9, 2022; Page Numbers: 1-72. Date of Issuance: March 14, 2022. Court Reporter/Transcriber: William Zaremba; Telephone number: (202) 354-3249. Transcripts may be ordered by submitting the Transcript Order FormFor the first 90 days after this filing date, the transcript may be viewed at the courthouse at a public terminal or purchased from the court reporter referenced above. After 90 days, the transcript may be accessed via PACER. Other transcript formats, (multi-page, condensed, PDF or ASCII) may be purchased from the court reporter.NOTICE RE REDACTION OF TRANSCRIPTS: The parties have twenty-one days to file with the court and the court reporter any request to redact personal identifiers from this transcript. If no such requests are filed, the transcript will be made available to the public via PACER without redaction after 90 days. The policy, which includes the five personal identifiers specifically covered, is located on our website at www.dcd.uscourts.gov. Redaction Request due 4/4/2022. Redacted Transcript Deadline set for 4/14/2022. Release of Transcript Restriction set for 6/12/2022.(wz) Modified on 3/15/2022 (zeg). (Entered: 03/14/2022)",
+      "document_number": "324",
+      "pacer_doc_id": "04509105256",
+      "pacer_seq_no": "1174"
+    },
+    {
+      "date_entered": "2023-05-04",
+      "date_filed": "2023-05-04",
+      "description": "SEALED DOCUMENT filed by UNITED STATES OF AMERICA re 477 Sealed Document,,,,, 492 Sealed Document,,, (This document is SEALED and only available to authorized persons.) (Attachments: # 1 Exhibit (Pls. Ex. 22), # 2 Exhibit (Pls. Ex. 24), # 3 Certificate of Service)(Herrmann, Karl) (Entered: 05/04/2023)",
+      "document_number": "588",
+      "pacer_doc_id": "04509911803",
+      "pacer_seq_no": "2035"
+    },
+    {
+      "date_entered": "2023-05-05",
+      "date_filed": "2023-05-05",
+      "description": "SEALED DOCUMENT filed by STATE OF COLORADO re 584 Sealed Document, (This document is SEALED and only available to authorized persons.) (Attachments: # 1 Exhibit A, # 2 Certificate of Service)(Sallet, Jonathan) (Entered: 05/05/2023)",
+      "document_number": "589",
+      "pacer_doc_id": "04509914787",
+      "pacer_seq_no": "2039"
+    },
+    {
+      "date_entered": "2023-05-09",
+      "date_filed": "2023-05-09",
+      "description": "REDACTED DOCUMENT- Plaintiff States' Motion for Leave to File a Supplemental Response to Certain Questions of the Court at Oral Argument to 584 Sealed Document, by STATE OF COLORADO. (Attachments: # 1 Memorandum in Support A, # 2 Exhibit B, # 3 Exhibit C, # 4 Exhibit D, # 5 Exhibit E, # 6 Exhibit F, # 7 Exhibit G, # 8 Certificate of Service)(Sallet, Jonathan) (Entered: 05/09/2023)",
+      "document_number": "590",
+      "pacer_doc_id": "04509920629",
+      "pacer_seq_no": "2042"
+    }
+  ],
+  "docket_number": "1:20-cv-03010",
+  "jurisdiction": "U.S. Government Plaintiff",
+  "jury_demand": "None",
+  "mdl_status": "",
+  "nature_of_suit": "410 Anti-Trust",
+  "ordered_by": "date_filed",
+  "parties": [],
+  "referred_to_str": ""
+}


### PR DESCRIPTION
This PR fixes the issue described in #687.

When the "View multiple documents" option is enabled on PACER, the docket entries table contains an extra column with a checkbox input to select the displayed documents.

![Screenshot 2023-05-31 at 12 02 36](https://github.com/freelawproject/juriscraper/assets/486004/9deb0c14-134c-482a-bb47-268bc2999cf2)


Previously, this extra cell was removed when the checkbox was present within the cell. However, the problem arose when there was no checkbox in this extra cell, such as with sealed documents or entries without an attached document. As a result, the cell was not removed, causing a parsing mismatch.

A similar issue occurred with bankruptcy dockets, where there is an extra empty cell before the entry number. As a result, the entry number was incorrectly placed in the description field, while the entry number itself remained null.
![Screenshot 2023-05-31 at 12 01 16](https://github.com/freelawproject/juriscraper/assets/486004/68cf093f-3b15-4f1c-8cee-7d057370042a)

To resolve the problem, the "View multiple documents" docket report is now detected by checking for the presence of the "View Selected" underneath the entries table so the correct indexes are used for each case.

Regarding tests, there are multiple tests for "View multiple documents" docket reports on appellate dockets. However, only two tests were available for bankruptcy dockets (nvb_368678.html, kywb_238163.html), but they did not cover the scenarios where this issue occurred (numbered entries without the checkbox input). So this issue was not previously detected.