### PR TITLE
690 Fix bankruptcy docket number parsing

### DIFF
--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -42,7 +42,7 @@ class BaseDocketReport:
         r"[tT]erminated:\s+(%s)" % date_regex, flags=re.IGNORECASE
     )
     docket_number_dist_regex = re.compile(
-        r"((\d{1,2}:)?\d\d-[a-zA-Z]{1,4}-\d{1,10})"
+        r"(?<!\d)((\d{1,2}:)?\d\d-[a-zA-Z]{1,4}-\d{1,10})"
     )
     docket_number_bankr_regex = re.compile(r"(?:#:\s+)?((\d-)?\d\d-\d*)")
     docket_number_jpml = re.compile(r"(MDL No.\s+\d*)")
@@ -1339,7 +1339,7 @@ class DocketReport(BaseDocketReport, BaseReport):
 
     def _get_docket_number(self):
         if self.is_bankruptcy:
-            docket_number_path = "//font"
+            docket_number_path = "//center//font"
         else:
             docket_number_path = "//h3"
         nodes = self.tree.xpath(docket_number_path)

--- a/tests/examples/pacer/claims_activity/insb_1.json
+++ b/tests/examples/pacer/claims_activity/insb_1.json
@@ -24,7 +24,7 @@
       "status": ""
     },
     "court_id": "insb",
-    "docket_number": "32-JJG-13",
+    "docket_number": "23-00332",
     "last_date_to_file_claims": "2023-04-11",
     "last_date_to_file_govt": null,
     "office": "1",

--- a/tests/examples/pacer/claims_registers/insb.json
+++ b/tests/examples/pacer/claims_registers/insb.json
@@ -749,7 +749,7 @@
   "date_filed": "2016-09-16",
   "date_last_to_file_claims": "2017-01-30",
   "date_last_to_file_govt": "2017-03-15",
-  "docket_number": "07-JMC-7",
+  "docket_number": "16-07207",
   "office": "Indianapolis",
   "total_number_of_claims": "28",
   "trustee_str": "Deborah J. Caruso"

--- a/tests/examples/pacer/dockets/bankruptcy/insb_1.html
+++ b/tests/examples/pacer/dockets/bankruptcy/insb_1.html
@@ -1,0 +1,183 @@
+
+<!-- saved from url=(0071)https://ecf.insb.uscourts.gov/cgi-bin/DktRpt.pl?885903701020717-L_1_0-1 -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><link rel="shortcut icon" href="https://ecf.insb.uscourts.gov/favicon.ico"><title>CM/ECF - U.S. Bankruptcy Court:insb</title>
+<script language="JavaScript">
+              document.cookie="PacerSession=B90JOTRSgZA4Puc8Vq5KjlzenbxRKY4Az4VIrQq6dK0vtrwWxSofXMgwjoMazfqruqIJ1NAknbYEgOBQsKo7oiTyEh1IGb7luu9klPowIZ2K45ZEXJ0iYoqqXTybND0X; path=/; domain=.uscourts.gov; secure;"
+              </script><script type="text/javascript">document.cookie = "PRTYPE=web; path=/;"</script> <script>var default_base_path = "/"; </script> <link rel="stylesheet" type="text/css" href="./14-80555-JJG-13_files/default.css"><script type="text/javascript" src="./14-80555-JJG-13_files/core.js"></script><script type="text/javascript" src="./14-80555-JJG-13_files/DisableAJTALinks.js"></script><script type="text/javascript">if (top!=self) {top.location.replace(location.href);}</script><script>var default_base_path = "/"; </script>
+<script language="JavaScript">
+/********************************************************************************************
+  Purpose: To open Procedures Manual page in a new window
+
+  Parameters:
+    tcPmLink: URL of Procedures Manual page
+
+  Return: Always false
+ ********************************************************************************************/
+
+function VisitPmLink(tcPmLink) {
+// Pull up Procedures Manual page in a new window
+
+  if (typeof(oPmWindow) == 'undefined' || oPmWindow.closed ||
+      typeof(cPmLink) == 'undefined' || cPmLink != tcPmLink) {
+                                                 // If window/link have never been activated...
+    cPmLink = tcPmLink;                          // Save URL to prevent duplicate windows
+    oPmWindow = window.open(cPmLink, 'PmLink', 'location=yes,resizable=yes,scrollbars=yes');
+                                                 // Open window with Procedures Manual page
+  }
+  oPmWindow.focus();                             // Make sure Procedures Manual window is on top
+
+// Exit method
+
+  return false;                                  // Prevent processing of HREF from onClick
+}
+</script><script type="text/javascript" src="./14-80555-JJG-13_files/menu.pl.download"></script></head><body bgcolor="F9F9F9" text="000000"><iframe id="_yuiResizeMonitor" title="Text Resize Monitor" style="position: absolute; visibility: visible; width: 2em; height: 2em; top: -33px; left: 0px; border-width: 0px;" src="./14-80555-JJG-13_files/saved_resource.html"></iframe>
+        <div class="noprint">
+        <div id="topmenu" class="yuimenubar yui-module yui-overlay visible" style="z-index: 2; position: static; display: block; visibility: visible;"><div class="bd">
+        <img id="cmecfLogo" class="cmecfLogo" src="./14-80555-JJG-13_files/logo-cmecf-sm.png" alt="CM/ECF" title="" onclick="CMECF.MainMenu.showCourtInformation(); return false">
+        <ul class="first-of-type">
+      
+<li class="yuimenubaritem first-of-type" id="yui-gen0" groupindex="0" index="0"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/iquery.pl"><u>Q</u>uery</a></li>
+<li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen1" groupindex="0" index="1"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Reports&amp;id=-1"><u>R</u>eports <div class="spritedownarrow"></div></a></li>
+<li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen2" groupindex="0" index="2"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Utilities&amp;id=-1"><u>U</u>tilities <div class="spritedownarrow"></div></a></li>
+<li class="yuimenubaritem" id="yui-gen3" groupindex="0" index="3"><a class="yuimenubaritemlabel" onclick="CMECF.MainMenu.showHelpPage(&#39;&#39;); return false">Help</a></li>
+<li class="yuimenubaritem" id="yui-gen4" groupindex="0" index="4"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/login.pl?logout">Log Out</a></li><li class="yuimenubaritem" id="placeholderForAlertsIcon" groupindex="0" index="5"></li>
+        </ul></div>
+        <hr class="hrmenuseparator"></div></div>
+        
+      <script type="text/javascript">
+callCreateMenu=function(){
+        var fn = "CMECF.MainMenu.createMenu";
+        if(typeof CMECF.MainMenu.createMenu == 'function') {
+          CMECF.MainMenu.createMenu();
+        }
+                        }
+if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout( function(){ callCreateMenu(); }, 1);}else{CMECF.util.Event.addListener(window, "load",  callCreateMenu());}</script> <div id="cmecfMainContent" style="height: 749px;"><input style="display:none" id="cmecfMainContentScroll" value="0">
+      <script type="text/javascript">
+        document.cookie = 'RECENT_CASES=' + "636471^620422^705266;";
+      </script>
+    <script language="JavaScript">
+              document.cookie="PacerSession=B90JOTRSgZA4Puc8Vq5KjlzenbxRKY4Az4VIrQq6dK0vtrwWxSofXMgwjoMazfqruqIJ1NAknbYEgOBQsKo7oiTyEh1IGb7luu9klPowIZ2K45ZEXJ0iYoqqXTybND0X; path=/; domain=.uscourts.gov; secure;"
+              </script><script language="JavaScript">
+		var IsForm = false;
+		var FirstField;
+		function SetFocus() {
+			if(IsForm) {
+				if(FirstField) {
+					var ind = FirstField.indexOf('document.',0);
+					if(ind == 0)
+					{
+						eval(FirstField);
+					}
+					else
+					{
+						var Code = "document.forms[0]."+FirstField+".focus();";
+						eval(Code);
+					}
+				} else {
+					var Cnt = 0;
+					while(document.forms[0].elements[Cnt] != null) {
+						try {
+							if(document.forms[0].elements[Cnt].type != "hidden" &&
+									!document.forms[0].elements[Cnt].disabled &&
+									!document.forms[0].elements[Cnt].readOnly) {
+								document.forms[0].elements[Cnt].focus();
+								break;
+							}
+						}
+						catch(e) {}
+						Cnt += 1;
+					}
+				}
+			}
+			return(true);
+		}
+		</script>
+<script type="text/JavaScript">
+document.cookie="PDFNoHeaderReferer=885903701020717; path=/";
+</script>
+    <script type="text/javascript" src="./14-80555-JJG-13_files/widgits.js"></script>
+    <script>
+    var debtorPanel = null;
+
+    function create_panel(clid, message) {
+        if (!debtorPanel) {
+            debtorPanel = new CMECF.widget.Panel('debtorPanel', {
+        close:true,
+        draggable:false,
+        context:[clid, 'tl', 'br'],
+        width: "250" + "px",
+        height: "110" + "px",
+        constraintoviewport:true
+      });
+      debtorPanel.setHeader("Barred Debtor Information");
+      debtorPanel.setBody(message);
+      debtorPanel.body.style.height = "8em";
+      debtorPanel.render(document.body);
+        } else {
+            debtorPanel.show();
+        }
+    }
+
+    function close_panel() {
+        if (debtorPanel) {
+            debtorPanel.destroy();
+            debtorPanel = null;
+        }
+    }
+    </script>
+    <table border="0" width="100%">
+  <tbody><tr><div class="btn-group" id="recap-action-button"><a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-spinner fa-spin recap-btn-spinner-hidden" id="recap-button-spinner"></i> RECAP Actions<span class="caret"></span></a><ul class="dropdown-menu"><h2 class="dropdown-header" id="action-button-dropdown-header">CourtListener</h2><li id="create-alert-button"><a href="https://www.courtlistener.com/alert/docket/new/?pacer_case_id=636471&amp;court_id=insb" target="_blank">Create alert</a></li><li id="search-docket-button"><a href="https://www.courtlistener.com/?type=r&amp;q=docket_id%3A54348782" target="_blank">Search this Docket</a></li><li id="view-docket-button"><a href="https://www.courtlistener.com/recap/gov.uscourts.insb.636471/" target="_blank">View this docket</a></li><div class="recap-dropdown-divider"></div><li><a href="javascript:void(0);" id="refresh-recap-links" role="button">Refresh RECAP Links</a></li></ul></div></tr><tr>
+    <td align="Right"><b>FMCertDue, PriorDISCH, CONFIRMED, DISMISSED, CLOSED</b></td>
+  </tr>
+</tbody></table>
+<center><b><font size="+1">U.S. Bankruptcy Court<br>Southern District of Indiana (Terre Haute)<br>Bankruptcy Petition #: <font color="Green">14-80555-JJG-13</font></font></b></center><table class="DktRpt" width="100%" border="0" cellspacing="1"><tbody><tr>	<td valign="top" width="50%"><font size="+0"><br><i>Assigned to:</i>       Jeffrey J. Graham<br>Chapter          13<br>Voluntary<br>Asset<br><i>Creditors:</i> 45<div class="noprint"><a href="https://ecf.insb.uscourts.gov/cgi-bin/SearchClaims.pl?caseid=636471;sc">Claims Register</a></div><br><br><br><i>Debtor disposition:</i>&nbsp;&nbsp;Dismissed for Other Reason	</font></td>
+	<td valign="top" width="50%" align="right"><font size="+0"><table class="DktRpt" border="0" cellspacing="0" cellpadding="0" align="center"><tbody><tr><td align="right" valign="top"><i>Date filed:</i></td><td align="left" valign="top">&nbsp;&nbsp;06/04/2014</td></tr><tr><td align="right" valign="top"><i>Date terminated:</i></td><td align="left" valign="top">&nbsp;&nbsp;03/07/2017</td></tr><tr><td align="right" valign="top"><i>Debtor dismissed:</i></td><td align="left" valign="top">&nbsp;&nbsp;02/03/2017</td></tr><tr><td align="right" valign="top"><i>Plan confirmed:</i></td><td align="left" valign="top">&nbsp;&nbsp;08/19/2014</td></tr><tr><td align="right" valign="top"><i>341 meeting:</i></td><td align="left" valign="top">&nbsp;&nbsp;07/11/2014 11:30 AM</td></tr><tr><td align="right" valign="top"><i>Deadline for filing claims:</i></td><td align="left" valign="top">&nbsp;&nbsp;10/09/2014  </td></tr><tr><td align="right" valign="top"><i>Deadline for filing claims (govt.):</i></td><td align="left" valign="top">&nbsp;&nbsp;12/01/2014  </td></tr></tbody></table>	</font></td>
+</tr>
+</tbody></table><br><font size="5"><b></b>
+    </font><table class="DktRpt" width="100%" border="0" cellspacing="1"><tbody><tr></tr><tr>	<td valign="top" width="50%"><font size="+0"><i><b>Debtor</b></i><br><b>Amanda Dawn Leavell</b>
+<br>3139 E. State Road 54
+<br>Sullivan, IN 47882
+<br>VIGO-IN
+<br>SSN / ITIN: xxx-xx-4993<span style="white-space:normal"></span><br><br><br><br>
+	</font></td>
+	<td valign="top" align="right"><font size="+0">represented by	</font></td>
+<td valign="top" width="40%">
+              <font size="+0"><b>Christopher Henry Belch</b>
+<br>Lynch &amp; Belch, PC
+<br>7210 Madison Ave Ste B
+<br>Indianapolis, IN 46227
+<br>317-888-0006
+<br>Fax  : 317-888-8282
+<br>Email:&nbsp;<a href="mailto:rob@lynchandbelch.com">rob@lynchandbelch.com</a><br><br><b>Robert B. Lynch</b>
+<br>Lynch &amp; Belch, P.C.
+<br>7210 Madison Ave Ste B
+<br>Indianapolis, IN 46227
+<br>317-888-0006
+<br>Fax  : 317-888-8282
+<br>Email:&nbsp;<a href="mailto:rob@lynchandbelch.com">rob@lynchandbelch.com</a><br><br></font></td></tr><tr>	<td valign="top" width="50%"><font size="+0"><i><b>Trustee</b></i><br><b>Donald L Decker</b>
+<br>Office of Donald L. Decker
+<br>PO Box 9237
+<br>Terre Haute, IN 47808-9237
+<br>812-234-2600<br>
+Email: <a href="mailto:ecfmail@decker13trustee.com">ecfmail@decker13trustee.com</a><span style="white-space:normal"></span><br><br><br><br>
+	</font></td>
+	<td valign="top" width="20%" align="right"><font size="+0">&nbsp;	</font></td>
+<td valign="top" width="40%" nowrap="">
+              <font size="+0">&nbsp;</font></td></tr><tr>	<td valign="top" width="50%"><font size="+0"><i><b>U.S. Trustee</b></i><br><b>U.S. Trustee</b>
+<br>Office of U.S. Trustee
+<br>46 E Ohio Street, Room 520
+<br>Indianapolis, IN 46204
+<br>317-226-6101<br>
+Email: <a href="mailto:ustpregion10.in.ecf@usdoj.gov">ustpregion10.in.ecf@usdoj.gov</a><span style="white-space:normal"></span>	</font></td>
+	<td valign="top" width="20%" align="right"><font size="+0">&nbsp;	</font></td>
+	<td valign="top" width="40%"><font size="+0">&nbsp;	</font></td>
+</tr></tbody></table><br><table class="DktRpt" border="1" cellpadding="10" cellspacing="0"><tbody><tr><th width="94" nowrap="">Filing Date</th>
+<th colspan="2" align="center">#</th><th align="center">Docket Text</th></tr>
+<tr><td width="94" nowrap="" valign="bottom">06/04/2014</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.insb.uscourts.gov/doc1/072030405408" oncontextmenu="this.href=&quot;https://ecf.insb.uscourts.gov/doc1/072030405408&quot;; document.cookie=&quot;CASE_NUM=2-14-bk-80555&quot;" onclick="document.cookie=&quot;CASE_NUM=2-14-bk-80555&quot;">1</a></td><td valign="bottom">  Chapter 13 Voluntary Petition with Statement of Financial Affairs, Schedule(s) A, B, C, D, E, F, G, H, I and J, Summary of Schedules, Statistical Summary of Liabilities and Attorney Disclosure of Compensation filed by Christopher Henry Belch on behalf of Amanda Dawn Leavell. (Belch, Christopher) (Entered: 06/04/2014)</td></tr>
+<tr><td width="94" nowrap="" valign="bottom">06/04/2014</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.insb.uscourts.gov/doc1/072030405414" oncontextmenu="this.href=&quot;https://ecf.insb.uscourts.gov/doc1/072030405414&quot;; document.cookie=&quot;CASE_NUM=2-14-bk-80555&quot;" onclick="document.cookie=&quot;CASE_NUM=2-14-bk-80555&quot;">2</a></td><td valign="bottom">  Chapter 13 Plan filed by Christopher Henry Belch on behalf of Debtor Amanda Dawn Leavell. (Belch, Christopher) (Entered: 06/04/2014)</td></tr>
+</tbody></table><i>Generated in 0.46 seconds</i><br>
+
+      <script type="text/javascript">
+        document.cookie = 'RECENT_CASES=' + "636471^620422^705266;";
+      </script>
+    <hr><center><table border="1" bgcolor="white" width="400"><tbody><tr><th colspan="4"><font size="+1" color="DARKRED">PACER Service Center </font></th></tr><tr><th colspan="4"><font color="DARKBLUE">Transaction Receipt </font></th></tr><tr></tr><tr></tr><tr><td colspan="4" align="CENTER"><font size="-1" color="DARKBLUE">06/15/2023 13:03:32</font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> PACER Login: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> jesus13law </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Client Code: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE">  </font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> Description: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> Docket Report </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Search Criteria: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 14-80555-JJG-13 Fil or Ent: filed   Doc From: 1 Doc To: 2     Format: html  </font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> Billable Pages: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 1 </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Cost: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 0.10 </font></td></tr><tr></tr><tr></tr></tbody></table></center><br><br></div></body></html>

--- a/tests/examples/pacer/dockets/bankruptcy/insb_1.html
+++ b/tests/examples/pacer/dockets/bankruptcy/insb_1.html
@@ -35,7 +35,7 @@ function VisitPmLink(tcPmLink) {
         <div id="topmenu" class="yuimenubar yui-module yui-overlay visible" style="z-index: 2; position: static; display: block; visibility: visible;"><div class="bd">
         <img id="cmecfLogo" class="cmecfLogo" src="./14-80555-JJG-13_files/logo-cmecf-sm.png" alt="CM/ECF" title="" onclick="CMECF.MainMenu.showCourtInformation(); return false">
         <ul class="first-of-type">
-      
+
 <li class="yuimenubaritem first-of-type" id="yui-gen0" groupindex="0" index="0"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/iquery.pl"><u>Q</u>uery</a></li>
 <li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen1" groupindex="0" index="1"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Reports&amp;id=-1"><u>R</u>eports <div class="spritedownarrow"></div></a></li>
 <li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen2" groupindex="0" index="2"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Utilities&amp;id=-1"><u>U</u>tilities <div class="spritedownarrow"></div></a></li>
@@ -43,7 +43,7 @@ function VisitPmLink(tcPmLink) {
 <li class="yuimenubaritem" id="yui-gen4" groupindex="0" index="4"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/login.pl?logout">Log Out</a></li><li class="yuimenubaritem" id="placeholderForAlertsIcon" groupindex="0" index="5"></li>
         </ul></div>
         <hr class="hrmenuseparator"></div></div>
-        
+
       <script type="text/javascript">
 callCreateMenu=function(){
         var fn = "CMECF.MainMenu.createMenu";

--- a/tests/examples/pacer/dockets/bankruptcy/insb_1.json
+++ b/tests/examples/pacer/dockets/bankruptcy/insb_1.json
@@ -1,0 +1,70 @@
+{
+  "assigned_to_str": "Jeffrey J. Graham",
+  "case_name": "Amanda Dawn Leavell",
+  "cause": "",
+  "court_id": "insb",
+  "date_converted": null,
+  "date_discharged": null,
+  "date_filed": "2014-06-04",
+  "date_terminated": "2017-03-07",
+  "demand": "",
+  "docket_entries": [
+    {
+      "date_entered": "2014-06-04",
+      "date_filed": "2014-06-04",
+      "description": "Chapter 13 Voluntary Petition with Statement of Financial Affairs, Schedule(s) A, B, C, D, E, F, G, H, I and J, Summary of Schedules, Statistical Summary of Liabilities and Attorney Disclosure of Compensation filed by Christopher Henry Belch on behalf of Amanda Dawn Leavell. (Belch, Christopher) (Entered: 06/04/2014)",
+      "document_number": "1",
+      "pacer_doc_id": "072030405408",
+      "pacer_seq_no": null
+    },
+    {
+      "date_entered": "2014-06-04",
+      "date_filed": "2014-06-04",
+      "description": "Chapter 13 Plan filed by Christopher Henry Belch on behalf of Debtor Amanda Dawn Leavell. (Belch, Christopher) (Entered: 06/04/2014)",
+      "document_number": "2",
+      "pacer_doc_id": "072030405414",
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "14-80555",
+  "jurisdiction": "",
+  "jury_demand": "",
+  "mdl_status": "",
+  "nature_of_suit": "",
+  "ordered_by": "date_filed",
+  "parties": [
+    {
+      "attorneys": [
+        {
+          "contact": "Lynch & Belch, PC\n7210 Madison Ave Ste B\nIndianapolis, IN 46227\n317-888-0006\nFax : 317-888-8282\nEmail:\n",
+          "name": "Christopher Henry Belch",
+          "roles": []
+        },
+        {
+          "contact": "Lynch & Belch, P.C.\n7210 Madison Ave Ste B\nIndianapolis, IN 46227\n317-888-0006\nFax : 317-888-8282\nEmail:\n",
+          "name": "Robert B. Lynch",
+          "roles": []
+        }
+      ],
+      "date_terminated": null,
+      "extra_info": "3139 E. State Road 54\nSullivan, IN 47882\nVIGO-IN\nSSN / ITIN: xxx-xx-4993",
+      "name": "Amanda Dawn Leavell",
+      "type": "Debtor"
+    },
+    {
+      "attorneys": [],
+      "date_terminated": null,
+      "extra_info": "Office of Donald L. Decker\nPO Box 9237\nTerre Haute, IN 47808-9237\n812-234-2600\nEmail:\necfmail@decker13trustee.com",
+      "name": "Donald L Decker",
+      "type": "Trustee"
+    },
+    {
+      "attorneys": [],
+      "date_terminated": null,
+      "extra_info": "Office of U.S. Trustee\n46 E Ohio Street, Room 520\nIndianapolis, IN 46204\n317-226-6101\nEmail:\nustpregion10.in.ecf@usdoj.gov",
+      "name": "U.S. Trustee",
+      "type": "U.S. Trustee"
+    }
+  ],
+  "referred_to_str": ""
+}

--- a/tests/examples/pacer/dockets/bankruptcy/insb_2.html
+++ b/tests/examples/pacer/dockets/bankruptcy/insb_2.html
@@ -1,0 +1,171 @@
+
+<!-- saved from url=(0071)https://ecf.insb.uscourts.gov/cgi-bin/DktRpt.pl?111322354870346-L_1_0-1 -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><link rel="shortcut icon" href="https://ecf.insb.uscourts.gov/favicon.ico"><title>CM/ECF - U.S. Bankruptcy Court:insb</title>
+<script type="text/javascript">document.cookie = "PRTYPE=web; path=/;"</script> <script>var default_base_path = "/"; </script> <link rel="stylesheet" type="text/css" href="./insb_2_files/default.css"><script type="text/javascript" src="./insb_2_files/core.js"></script><script type="text/javascript" src="./insb_2_files/DisableAJTALinks.js"></script><script type="text/javascript">if (top!=self) {top.location.replace(location.href);}</script><script>var default_base_path = "/"; </script>
+<script language="JavaScript">
+/********************************************************************************************
+  Purpose: To open Procedures Manual page in a new window
+
+  Parameters:
+    tcPmLink: URL of Procedures Manual page
+
+  Return: Always false
+ ********************************************************************************************/
+
+function VisitPmLink(tcPmLink) {
+// Pull up Procedures Manual page in a new window
+
+  if (typeof(oPmWindow) == 'undefined' || oPmWindow.closed ||
+      typeof(cPmLink) == 'undefined' || cPmLink != tcPmLink) {
+                                                 // If window/link have never been activated...
+    cPmLink = tcPmLink;                          // Save URL to prevent duplicate windows
+    oPmWindow = window.open(cPmLink, 'PmLink', 'location=yes,resizable=yes,scrollbars=yes');
+                                                 // Open window with Procedures Manual page
+  }
+  oPmWindow.focus();                             // Make sure Procedures Manual window is on top
+
+// Exit method
+
+  return false;                                  // Prevent processing of HREF from onClick
+}
+</script><script type="text/javascript" src="./insb_2_files/menu.pl.download"></script></head><body bgcolor="F9F9F9" text="000000" onload="SetFocus()"><iframe id="_yuiResizeMonitor" title="Text Resize Monitor" style="position: absolute; visibility: visible; width: 2em; height: 2em; top: -33px; left: 0px; border-width: 0px;" src="./insb_2_files/saved_resource.html"></iframe>
+        <div class="noprint">
+        <div id="topmenu" class="yuimenubar yui-module yui-overlay visible" style="z-index: 2; position: static; display: block; visibility: visible;"><div class="bd">
+        <img id="cmecfLogo" class="cmecfLogo" src="./insb_2_files/logo-cmecf-sm.png" alt="CM/ECF" title="" onclick="CMECF.MainMenu.showCourtInformation(); return false">
+        <ul class="first-of-type">
+      
+<li class="yuimenubaritem first-of-type" id="yui-gen0" groupindex="0" index="0"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/iquery.pl"><u>Q</u>uery</a></li>
+<li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen1" groupindex="0" index="1"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Reports&amp;id=-1"><u>R</u>eports <div class="spritedownarrow"></div></a></li>
+<li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen2" groupindex="0" index="2"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Utilities&amp;id=-1"><u>U</u>tilities <div class="spritedownarrow"></div></a></li>
+<li class="yuimenubaritem" id="yui-gen3" groupindex="0" index="3"><a class="yuimenubaritemlabel" onclick="CMECF.MainMenu.showHelpPage(&#39;&#39;); return false">Help</a></li>
+<li class="yuimenubaritem" id="yui-gen4" groupindex="0" index="4"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/login.pl?logout">Log Out</a></li><li class="yuimenubaritem" id="placeholderForAlertsIcon" groupindex="0" index="5"></li>
+        </ul></div>
+        <hr class="hrmenuseparator"></div></div>
+        
+      <script type="text/javascript">
+callCreateMenu=function(){
+        var fn = "CMECF.MainMenu.createMenu";
+        if(typeof CMECF.MainMenu.createMenu == 'function') {
+          CMECF.MainMenu.createMenu();
+        }
+                        }
+if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout( function(){ callCreateMenu(); }, 1);}else{CMECF.util.Event.addListener(window, "load",  callCreateMenu());}</script> <div id="cmecfMainContent" style="height: 756px;"><input style="display:none" id="cmecfMainContentScroll" value="0">
+      <script type="text/javascript">
+        document.cookie = 'RECENT_CASES=' + "677484^654963^636471^620422^705266;";
+      </script>
+    <script language="JavaScript">
+		var IsForm = false;
+		var FirstField;
+		function SetFocus() {
+			if(IsForm) {
+				if(FirstField) {
+					var ind = FirstField.indexOf('document.',0);
+					if(ind == 0)
+					{
+						eval(FirstField);
+					}
+					else
+					{
+						var Code = "document.forms[0]."+FirstField+".focus();";
+						eval(Code);
+					}
+				} else {
+					var Cnt = 0;
+					while(document.forms[0].elements[Cnt] != null) {
+						try {
+							if(document.forms[0].elements[Cnt].type != "hidden" &&
+									!document.forms[0].elements[Cnt].disabled &&
+									!document.forms[0].elements[Cnt].readOnly) {
+								document.forms[0].elements[Cnt].focus();
+								break;
+							}
+						}
+						catch(e) {}
+						Cnt += 1;
+					}
+				}
+			}
+			return(true);
+		}
+		</script>
+<script type="text/JavaScript">
+document.cookie="PDFNoHeaderReferer=111322354870346; path=/";
+</script>
+    <script type="text/javascript" src="./insb_2_files/widgits.js"></script>
+    <script>
+    var debtorPanel = null;
+
+    function create_panel(clid, message) {
+        if (!debtorPanel) {
+            debtorPanel = new CMECF.widget.Panel('debtorPanel', {
+        close:true,
+        draggable:false,
+        context:[clid, 'tl', 'br'],
+        width: "250" + "px",
+        height: "110" + "px",
+        constraintoviewport:true
+      });
+      debtorPanel.setHeader("Barred Debtor Information");
+      debtorPanel.setBody(message);
+      debtorPanel.body.style.height = "8em";
+      debtorPanel.render(document.body);
+        } else {
+            debtorPanel.show();
+        }
+    }
+
+    function close_panel() {
+        if (debtorPanel) {
+            debtorPanel.destroy();
+            debtorPanel = null;
+        }
+    }
+    </script>
+    <table border="0" width="100%">
+  <tbody><tr><div class="btn-group" id="recap-action-button"><a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-spinner fa-spin recap-btn-spinner-hidden" id="recap-button-spinner"></i> RECAP Actions<span class="caret"></span></a><ul class="dropdown-menu"><h2 class="dropdown-header" id="action-button-dropdown-header">CourtListener</h2><li id="create-alert-button"><a href="https://www.courtlistener.com/alert/docket/new/?pacer_case_id=677484&amp;court_id=insb" target="_blank">Create alert</a></li><li id="search-docket-button"><a href="https://www.courtlistener.com/?type=r&amp;q=docket_id%3A54966602" target="_blank">Search this Docket</a></li><li id="view-docket-button"><a href="https://www.courtlistener.com/recap/gov.uscourts.insb.677484/" target="_blank">View this docket</a></li><div class="recap-dropdown-divider"></div><li><a href="javascript:void(0);" id="refresh-recap-links" role="button">Refresh RECAP Links</a></li></ul></div></tr><tr>
+    <td align="Right"><b>CLOSED, FMCertDue, PriorDISM, FeeDueINST, DISMISSED</b></td>
+  </tr>
+</tbody></table>
+<center><b><font size="+1">U.S. Bankruptcy Court<br>Southern District of Indiana (New Albany)<br>Bankruptcy Petition #: <font color="Green">17-90266-BHL-13</font></font></b></center><table class="DktRpt" width="100%" border="0" cellspacing="1"><tbody><tr>	<td valign="top" width="50%"><font size="+0"><br><i>Assigned to:</i>       Basil H. Lorch III<br>Chapter          13<br>Voluntary<br>Asset<br><i>Creditors:</i> 22<div class="noprint"><a href="https://ecf.insb.uscourts.gov/cgi-bin/SearchClaims.pl?caseid=677484;sc">Claims Register</a></div><br><br><br><i>Debtor disposition:</i>&nbsp;&nbsp;Dismissed for Failure to Make Plan Payments	</font></td>
+	<td valign="top" width="50%" align="right"><font size="+0"><table class="DktRpt" border="0" cellspacing="0" cellpadding="0" align="center"><tbody><tr><td align="right" valign="top"><i>Date filed:</i></td><td align="left" valign="top">&nbsp;&nbsp;02/28/2017</td></tr><tr><td align="right" valign="top"><i>Date terminated:</i></td><td align="left" valign="top">&nbsp;&nbsp;06/22/2017</td></tr><tr><td align="right" valign="top"><i>Debtor dismissed:</i></td><td align="left" valign="top">&nbsp;&nbsp;05/22/2017</td></tr><tr><td align="right" valign="top"><i>341 meeting:</i></td><td align="left" valign="top">&nbsp;&nbsp;03/30/2017 03:00 PM</td></tr><tr><td align="right" valign="top"><i>Deadline for filing claims:</i></td><td align="left" valign="top">&nbsp;&nbsp;06/28/2017  </td></tr><tr><td align="right" valign="top"><i>Deadline for filing claims (govt.):</i></td><td align="left" valign="top">&nbsp;&nbsp;08/28/2017  </td></tr></tbody></table>	</font></td>
+</tr>
+</tbody></table><br><font size="5"><b></b>
+    </font><table class="DktRpt" width="100%" border="0" cellspacing="1"><tbody><tr></tr><tr>	<td valign="top" width="50%"><font size="+0"><i><b>Debtor</b></i><br><b>Deandre Shawntez Stewart</b>
+<br>27 Highpark Dr.
+<br>New Albany, IN 47150
+<br>FLOYD-IN
+<br>SSN / ITIN: xxx-xx-5243<span style="white-space:normal"></span><br><i><b>aka </b></i><b>Deandre S Stewart</b><br><i><b>aka </b></i><b>Deandre Stewart</b><br><br><br><br>
+	</font></td>
+	<td valign="top" align="right"><font size="+0">represented by	</font></td>
+<td valign="top" width="40%">
+              <font size="+0"><b>Lloyd E KoehlerD</b>
+<br>400 Pearl Street Ste 200
+<br>New Albany, IN 47150
+<br>812-949-2211
+<br>Fax  : (812) 941-3907
+<br>Email:&nbsp;<a href="mailto:lloydkoehler@hotmail.com">lloydkoehler@hotmail.com</a><br><br></font></td></tr><tr>	<td valign="top" width="50%"><font size="+0"><i><b>Trustee</b></i><br><b>Joseph M. Black, Jr.</b>
+<br>Office of Joseph M. Black, Jr.
+<br>PO Box 846
+<br>Seymour, IN 47274
+<br>812-524-7211<br>
+Email: <a href="mailto:jmbecf@trustee13.com">jmbecf@trustee13.com</a><span style="white-space:normal"></span><br><br><br><br>
+	</font></td>
+	<td valign="top" width="20%" align="right"><font size="+0">&nbsp;	</font></td>
+<td valign="top" width="40%" nowrap="">
+              <font size="+0">&nbsp;</font></td></tr><tr>	<td valign="top" width="50%"><font size="+0"><i><b>U.S. Trustee</b></i><br><b>U.S. Trustee</b>
+<br>Office of U.S. Trustee
+<br>46 E Ohio Street, Room 520
+<br>Indianapolis, IN 46204
+<br>317-226-6101<br>
+Email: <a href="mailto:ustpregion10.in.ecf@usdoj.gov">ustpregion10.in.ecf@usdoj.gov</a><span style="white-space:normal"></span>	</font></td>
+	<td valign="top" width="20%" align="right"><font size="+0">&nbsp;	</font></td>
+	<td valign="top" width="40%"><font size="+0">&nbsp;	</font></td>
+</tr></tbody></table><br><table class="DktRpt" border="1" cellpadding="10" cellspacing="0"><tbody><tr><th width="94" nowrap="">Filing Date</th>
+<th colspan="2" align="center">#</th><th align="center">Docket Text</th></tr>
+<tr><td width="94" nowrap="" valign="bottom">02/28/2017</td><td width="74" valign="top" align="right" style="border-right:0;padding-right:1px;padding-left:2px;white-space:nowrap"><nobr>  &nbsp;</nobr></td><td width="30" valign="top" align="left" style="border-left:0;padding-left:1px"><a href="https://ecf.insb.uscourts.gov/doc1/072036038185" oncontextmenu="this.href=&quot;https://ecf.insb.uscourts.gov/doc1/072036038185&quot;; document.cookie=&quot;CASE_NUM=4-17-bk-90266&quot;" onclick="document.cookie=&quot;CASE_NUM=4-17-bk-90266&quot;">1</a> <br><nobr>(50&nbsp;pgs)</nobr></td><td valign="bottom">  Chapter 13 Voluntary Petition (Individual) with Statement of Financial Affairs, Schedule(s) A/B, C, D, E/F, G, H, I and J, Summary of Assets and Liabilities and Certain Statistical Information, Attorney Disclosure of Compensation, Verification of Creditor List and Rights &amp; Responsibilities of Chapter 13 Debtors &amp; Their Attorneys filed by Lloyd E Koehler5 on behalf of Deandre Shawntez Stewart. (Koehler5, Lloyd) (Entered: 02/28/2017) <a href="https://www.insb.uscourts.gov/content/chapter-13-voluntary-petition" onclick="return VisitPmLink(&#39;https://www.insb.uscourts.gov/content/chapter-13-voluntary-petition&#39;)" title="Procedures Manual"><img border="0" src="./insb_2_files/PmLinkOld.gif" style="vertical-align:middle"></a></td></tr>
+</tbody></table><i>Generated in 0.48 seconds</i><br>
+
+      <script type="text/javascript">
+        document.cookie = 'RECENT_CASES=' + "677484^654963^636471^620422^705266;";
+      </script>
+    <hr><center><table border="1" bgcolor="white" width="400"><tbody><tr><th colspan="4"><font size="+1" color="DARKRED">PACER Service Center </font></th></tr><tr><th colspan="4"><font color="DARKBLUE">Transaction Receipt </font></th></tr><tr></tr><tr></tr><tr><td colspan="4" align="CENTER"><font size="-1" color="DARKBLUE">06/16/2023 22:35:39</font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> PACER Login: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> jesus13law </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Client Code: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE">  </font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> Description: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> Docket Report </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Search Criteria: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 17-90266-BHL-13 Fil or Ent: filed   Doc From: 1 Doc To: 1 Term: included    Format: html Page counts for documents: included </font></td></tr><tr><th align="LEFT"><font size="-1" color="DARKBLUE"> Billable Pages: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 2 </font></td><th align="LEFT"><font size="-1" color="DARKBLUE"> Cost: </font></th><td align="LEFT"><font size="-1" color="DARKBLUE"> 0.20 </font></td></tr><tr></tr><tr></tr></tbody></table></center><br><br></div></body></html>

--- a/tests/examples/pacer/dockets/bankruptcy/insb_2.html
+++ b/tests/examples/pacer/dockets/bankruptcy/insb_2.html
@@ -33,7 +33,7 @@ function VisitPmLink(tcPmLink) {
         <div id="topmenu" class="yuimenubar yui-module yui-overlay visible" style="z-index: 2; position: static; display: block; visibility: visible;"><div class="bd">
         <img id="cmecfLogo" class="cmecfLogo" src="./insb_2_files/logo-cmecf-sm.png" alt="CM/ECF" title="" onclick="CMECF.MainMenu.showCourtInformation(); return false">
         <ul class="first-of-type">
-      
+
 <li class="yuimenubaritem first-of-type" id="yui-gen0" groupindex="0" index="0"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/iquery.pl"><u>Q</u>uery</a></li>
 <li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen1" groupindex="0" index="1"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Reports&amp;id=-1"><u>R</u>eports <div class="spritedownarrow"></div></a></li>
 <li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen2" groupindex="0" index="2"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Utilities&amp;id=-1"><u>U</u>tilities <div class="spritedownarrow"></div></a></li>
@@ -41,7 +41,7 @@ function VisitPmLink(tcPmLink) {
 <li class="yuimenubaritem" id="yui-gen4" groupindex="0" index="4"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/login.pl?logout">Log Out</a></li><li class="yuimenubaritem" id="placeholderForAlertsIcon" groupindex="0" index="5"></li>
         </ul></div>
         <hr class="hrmenuseparator"></div></div>
-        
+
       <script type="text/javascript">
 callCreateMenu=function(){
         var fn = "CMECF.MainMenu.createMenu";

--- a/tests/examples/pacer/dockets/bankruptcy/insb_2.json
+++ b/tests/examples/pacer/dockets/bankruptcy/insb_2.json
@@ -1,0 +1,57 @@
+{
+  "assigned_to_str": "Basil H. Lorch III",
+  "case_name": "Deandre Shawntez Stewart",
+  "cause": "",
+  "court_id": "insb",
+  "date_converted": null,
+  "date_discharged": null,
+  "date_filed": "2017-02-28",
+  "date_terminated": "2017-06-22",
+  "demand": "",
+  "docket_entries": [
+    {
+      "date_entered": "2017-02-28",
+      "date_filed": "2017-02-28",
+      "description": "Chapter 13 Voluntary Petition (Individual) with Statement of Financial Affairs, Schedule(s) A/B, C, D, E/F, G, H, I and J, Summary of Assets and Liabilities and Certain Statistical Information, Attorney Disclosure of Compensation, Verification of Creditor List and Rights & Responsibilities of Chapter 13 Debtors & Their Attorneys filed by Lloyd E Koehler5 on behalf of Deandre Shawntez Stewart. (Koehler5, Lloyd) (Entered: 02/28/2017)",
+      "document_number": "1",
+      "pacer_doc_id": "072036038185",
+      "pacer_seq_no": null
+    }
+  ],
+  "docket_number": "17-90266",
+  "jurisdiction": "",
+  "jury_demand": "",
+  "mdl_status": "",
+  "nature_of_suit": "",
+  "ordered_by": "date_filed",
+  "parties": [
+    {
+      "attorneys": [
+        {
+          "contact": "400 Pearl Street Ste 200\nNew Albany, IN 47150\n812-949-2211\nFax : (812) 941-3907\nEmail:\n",
+          "name": "Lloyd E KoehlerD",
+          "roles": []
+        }
+      ],
+      "date_terminated": null,
+      "extra_info": "27 Highpark Dr.\nNew Albany, IN 47150\nFLOYD-IN\nSSN / ITIN: xxx-xx-5243",
+      "name": "Deandre Shawntez Stewart",
+      "type": "Debtor"
+    },
+    {
+      "attorneys": [],
+      "date_terminated": null,
+      "extra_info": "Office of Joseph M. Black, Jr.\nPO Box 846\nSeymour, IN 47274\n812-524-7211\nEmail:\njmbecf@trustee13.com",
+      "name": "Joseph M. Black, Jr.",
+      "type": "Trustee"
+    },
+    {
+      "attorneys": [],
+      "date_terminated": null,
+      "extra_info": "Office of U.S. Trustee\n46 E Ohio Street, Room 520\nIndianapolis, IN 46204\n317-226-6101\nEmail:\nustpregion10.in.ecf@usdoj.gov",
+      "name": "U.S. Trustee",
+      "type": "U.S. Trustee"
+    }
+  ],
+  "referred_to_str": ""
+}


### PR DESCRIPTION
This PR fixes #690 

The problem is that in some INSB bankruptcy dockets the docket number has the following format:
`17-90266-BHL-13`

Which was being parsed as: `66-BHL-13`

To parse bankruptcy docket numbers it can be used `docket_number_dist_regex` or `docket_number_bankr_regex` since both formats can be available in bankruptcy dockets.

The problem was that `docket_number_dist_regex` `((\d{1,2}:)?\d\d-[a-zA-Z]{1,4}-\d{1,10})` was matching `17-90266-BHL-13` as `66-BHL-13`.

To solve it I added a negative look-behind `(?<!\d)` so if the char before the first two digits is also a digit, then it's not matched.

So in this case `17-90266-BHL-13` is ignored by `docket_number_dist_regex`, so that solves the issue.

In addition by doing some testing, I also found that the `docket_number_bankr_regex` ` (?:#:\s+)?((\d-)?\d\d-\d*)` can match numbers that are not the docket number, like: 

`47808-9237`
![Screenshot 2023-06-16 at 20 56 39](https://github.com/freelawproject/juriscraper/assets/486004/48473d79-6371-4395-ad10-300fbb6cbee8)

Since this number is also contained in a `font` tag.

So I changed the bankruptcy docket number path to:
`docket_number_path = "//center//font"`

