### PR TITLE
2819 Fix insb and scb iquery pages parser

### DIFF
--- a/juriscraper/pacer/case_query.py
+++ b/juriscraper/pacer/case_query.py
@@ -139,6 +139,19 @@ class CaseQuery(BaseDocketReport, BaseReport):
         )
         # And case caption following the final <b></b> pair.
         case_name_raw = force_unicode(rows[0].find(".//b[last()]").tail or "")
+        if not case_name_raw:
+            # In some courts, such as INSB, the case name is within a font tag.
+            # <b><font size="+1">13-07422-RLM-7A</font></b><font size="+1">
+            #  Cedric Morris and Kateen Nicklondra Morris
+            # </font>
+            try:
+                case_name_raw = force_unicode(
+                    rows[0].xpath(
+                        ".//b[last()]/following-sibling::font[1]/text()"
+                    )[0]
+                )
+            except IndexError:
+                case_name_raw = ""
 
         # Our job as a parser is to return the data, not to filter, clean,
         # amend, or "harmonize" it. However downstream often expects harmonized
@@ -156,6 +169,7 @@ class CaseQuery(BaseDocketReport, BaseReport):
         field_names = {
             "date_of_last_filing": "date_last_filing",
             "judge": "assigned_to_str",
+            "chief_judge": "assigned_to_str",
             "plan_confirmed": "date_plan_confirmed",
             "debtor_discharged": "date_debtor_dismissed",
             "joint_debtor_discharged": "date_joint_debtor_dismissed",

--- a/tests/examples/pacer/case_queries/insb_1.html
+++ b/tests/examples/pacer/case_queries/insb_1.html
@@ -1,0 +1,63 @@
+
+<!-- saved from url=(0071)https://ecf.insb.uscourts.gov/cgi-bin/iquery.pl?896374492998043-L_1_0-1 -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><link rel="shortcut icon" href="https://ecf.insb.uscourts.gov/favicon.ico"><title>CM/ECF - U.S. Bankruptcy Court:insb</title>
+<script type="text/javascript">document.cookie = "PRTYPE=web; path=/;"</script> <script>var default_base_path = "/"; </script> <link rel="stylesheet" type="text/css" href="./insb_1_files/default.css"><script type="text/javascript" src="./insb_1_files/core.js"></script><script type="text/javascript" src="./insb_1_files/DisableAJTALinks.js"></script><script type="text/javascript">if (top!=self) {top.location.replace(location.href);}</script><script>var default_base_path = "/"; </script></head><body bgcolor="F9F9F9" text="000000"><script type="text/javascript"> CMECF.whenPageHasLoaded(CMECF.MainMenu.setMainContentSize); CMECF.util.Event.addListener(window, "resize", CMECF.MainMenu.setMainContentSize);</script> <div id="cmecfMainContent" style="height: 809px;"><input style="display:none" id="cmecfMainContentScroll" value="0">
+      <script type="text/javascript">
+        document.cookie = 'RECENT_CASES=' + "619624^558471^677484^654963^636471^620422^705266;";
+      </script>
+    <center>
+<b><font size="+1">13-07422-RLM-7A</font></b><font size="+1">
+Cedric Morris and Kateen Nicklondra Morris                          
+</font>
+<br>
+<b>Case type:</b> bk
+<b>Chapter:</b> 7
+<b>Asset:</b> Yes
+<b>Vol: </b> v
+<b>Judge:</b> Robyn L. Moberly 
+<br>
+<b>Date filed:</b> 07/12/2013
+<b>Date of last filing:</b> 06/28/2016
+<br><b>Debtor&nbsp;discharged:</b>&nbsp;12/31/2013
+<b>Joint&nbsp;debtor&nbsp;discharged:</b>&nbsp;12/31/2013
+<br><b>Date terminated:</b> 06/28/2016
+<br>
+</center><br>
+
+<div style="margin: 3px 0 1em 3px"><a href="https://ecf.insb.uscourts.gov/cgi-bin/mobile_query.pl?search=caseInfo&amp;caseid=619624">Mobile Query</a></div><font size="+1"><strong>Query</strong></font><br>
+	<table vspace="0" cellspacing="10" hspace="10" cellpadding="0" align="left" valign="top">
+		<tbody><tr align="left" valign="top">
+		<td align="top">
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryAlias.pl?619624">Alias</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryAscCases.pl?619624">Associated Cases</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryAttorneys.pl?619624">Attorney</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/QryRMSLocation.pl?619624">Case File Location</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qrySummary.pl?619624">Case Summary</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/SearchClaims.pl?619624">Claims Register</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/CreditorQry.pl?619624">Creditor</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/CredMatrixCase.pl?619624">List of Creditors</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/SchedQry.pl?619624">Deadline/Schedule</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/DktRpt.pl?619624">Docket Report ...</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/FilerQry.pl?619624">Filers</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/HistDocQry.pl?619624">History/Documents</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/NoticeOfFiling.pl?619624">Notice of Bankruptcy Case Filing</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryParties.pl?619624">Party</a><br>
+		</td>
+		
+		
+		<td>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/RelTransactQry.pl?619624">Related Transactions</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/StatusQry.pl?619624">Status</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryTrustee.pl?619624">Trustee</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryViewDocument.pl?619624">View Document</a><br>
+		</td>
+		</tr>	
+		</tbody></table>
+
+
+<script>
+function clearDesktopCookie(){
+  document.cookie = "uiexperience=dtp;secure;path=/;expires=Thu, 01-Jan-1970 00:00:01 GMT';";
+}
+</script>
+</div></body></html>

--- a/tests/examples/pacer/case_queries/insb_1.html
+++ b/tests/examples/pacer/case_queries/insb_1.html
@@ -7,14 +7,14 @@
       </script>
     <center>
 <b><font size="+1">13-07422-RLM-7A</font></b><font size="+1">
-Cedric Morris and Kateen Nicklondra Morris                          
+Cedric Morris and Kateen Nicklondra Morris
 </font>
 <br>
 <b>Case type:</b> bk
 <b>Chapter:</b> 7
 <b>Asset:</b> Yes
 <b>Vol: </b> v
-<b>Judge:</b> Robyn L. Moberly 
+<b>Judge:</b> Robyn L. Moberly
 <br>
 <b>Date filed:</b> 07/12/2013
 <b>Date of last filing:</b> 06/28/2016
@@ -43,15 +43,15 @@ Cedric Morris and Kateen Nicklondra Morris
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/NoticeOfFiling.pl?619624">Notice of Bankruptcy Case Filing</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryParties.pl?619624">Party</a><br>
 		</td>
-		
-		
+
+
 		<td>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/RelTransactQry.pl?619624">Related Transactions</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/StatusQry.pl?619624">Status</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryTrustee.pl?619624">Trustee</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryViewDocument.pl?619624">View Document</a><br>
 		</td>
-		</tr>	
+		</tr>
 		</tbody></table>
 
 

--- a/tests/examples/pacer/case_queries/insb_1.json
+++ b/tests/examples/pacer/case_queries/insb_1.json
@@ -1,0 +1,16 @@
+{
+  "asset": "Yes",
+  "assigned_to_str": "Robyn L. Moberly",
+  "case_name": "Cedric Morris and Kateen Nicklondra Morris",
+  "case_name_raw": "Cedric Morris and Kateen Nicklondra Morris",
+  "case_type": "bk",
+  "chapter": "7",
+  "court_id": "insb",
+  "date_debtor_dismissed": "2013-12-31",
+  "date_filed": "2013-07-12",
+  "date_joint_debtor_dismissed": "2013-12-31",
+  "date_last_filing": "2016-06-28",
+  "date_terminated": "2016-06-28",
+  "docket_number": "13-07422",
+  "vol": "v"
+}

--- a/tests/examples/pacer/case_queries/insb_2.html
+++ b/tests/examples/pacer/case_queries/insb_2.html
@@ -1,0 +1,112 @@
+
+<!-- saved from url=(0071)https://ecf.insb.uscourts.gov/cgi-bin/iquery.pl?141908407551343-L_1_0-1 -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><link rel="shortcut icon" href="https://ecf.insb.uscourts.gov/favicon.ico"><title>CM/ECF - U.S. Bankruptcy Court:insb</title>
+<script type="text/javascript">document.cookie = "PRTYPE=web; path=/;"</script> <script>var default_base_path = "/"; </script> <link rel="stylesheet" type="text/css" href="./insb_2_2_files/default.css"><script type="text/javascript" src="./insb_2_2_files/core.js"></script><script type="text/javascript" src="./insb_2_2_files/DisableAJTALinks.js"></script><script type="text/javascript">if (top!=self) {top.location.replace(location.href);}</script><script>var default_base_path = "/"; </script>
+<script language="JavaScript">
+/********************************************************************************************
+  Purpose: To open Procedures Manual page in a new window
+
+  Parameters:
+    tcPmLink: URL of Procedures Manual page
+
+  Return: Always false
+ ********************************************************************************************/
+
+function VisitPmLink(tcPmLink) {
+// Pull up Procedures Manual page in a new window
+
+  if (typeof(oPmWindow) == 'undefined' || oPmWindow.closed ||
+      typeof(cPmLink) == 'undefined' || cPmLink != tcPmLink) {
+                                                 // If window/link have never been activated...
+    cPmLink = tcPmLink;                          // Save URL to prevent duplicate windows
+    oPmWindow = window.open(cPmLink, 'PmLink', 'location=yes,resizable=yes,scrollbars=yes');
+                                                 // Open window with Procedures Manual page
+  }
+  oPmWindow.focus();                             // Make sure Procedures Manual window is on top
+
+// Exit method
+
+  return false;                                  // Prevent processing of HREF from onClick
+}
+</script><script type="text/javascript" src="./insb_2_2_files/menu.pl.download"></script></head><body bgcolor="F9F9F9" text="000000"><iframe id="_yuiResizeMonitor" title="Text Resize Monitor" style="position: absolute; visibility: visible; width: 2em; height: 2em; top: -33px; left: 0px; border-width: 0px;" src="./insb_2_2_files/saved_resource.html"></iframe>
+        <div class="noprint">
+        <div id="topmenu" class="yuimenubar yui-module yui-overlay visible" style="z-index: 2; position: static; display: block; visibility: visible;"><div class="bd">
+        <img id="cmecfLogo" class="cmecfLogo" src="./insb_2_2_files/logo-cmecf-sm.png" alt="CM/ECF" title="" onclick="CMECF.MainMenu.showCourtInformation(); return false">
+        <ul class="first-of-type">
+      
+<li class="yuimenubaritem first-of-type" id="yui-gen0" groupindex="0" index="0"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/iquery.pl"><u>Q</u>uery</a></li>
+<li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen1" groupindex="0" index="1"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Reports&amp;id=-1"><u>R</u>eports <div class="spritedownarrow"></div></a></li>
+<li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen2" groupindex="0" index="2"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Utilities&amp;id=-1"><u>U</u>tilities <div class="spritedownarrow"></div></a></li>
+<li class="yuimenubaritem" id="yui-gen3" groupindex="0" index="3"><a class="yuimenubaritemlabel" onclick="CMECF.MainMenu.showHelpPage(&#39;&#39;); return false">Help</a></li>
+<li class="yuimenubaritem" id="yui-gen4" groupindex="0" index="4"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/login.pl?logout">Log Out</a></li><li class="yuimenubaritem" id="placeholderForAlertsIcon" groupindex="0" index="5"></li>
+        </ul></div>
+        <hr class="hrmenuseparator"></div></div>
+        
+      <script type="text/javascript">
+callCreateMenu=function(){
+        var fn = "CMECF.MainMenu.createMenu";
+        if(typeof CMECF.MainMenu.createMenu == 'function') {
+          CMECF.MainMenu.createMenu();
+        }
+                        }
+if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout( function(){ callCreateMenu(); }, 1);}else{CMECF.util.Event.addListener(window, "load",  callCreateMenu());}</script> <div id="cmecfMainContent" style="height: 768px;"><input style="display:none" id="cmecfMainContentScroll" value="0">
+      <script type="text/javascript">
+        document.cookie = 'RECENT_CASES=' + "558471^619624^677484^654963^636471^620422^705266;";
+      </script>
+    <center>
+<b><font size="+1">10-15790-JMC-13</font></b><font size="+1">
+William Brian Stanley and Cecilia Ann Stanley                               
+</font>
+<br>
+<b>Case type:</b> bk
+<b>Chapter:</b> 13
+<b>Asset:</b> Yes
+<b>Vol: </b> v
+<b>Judge:</b> James M. Carr 
+<br>
+<b>Date filed:</b> 10/19/2010
+<b>Date of last filing:</b> 03/01/2016
+<b>Plan confirmed:</b> 04/01/2011
+<br><b>Debtor&nbsp;discharged:</b>&nbsp;12/12/2015
+<b>Joint&nbsp;debtor&nbsp;discharged:</b>&nbsp;12/12/2015
+<br><b>Date terminated:</b> 03/01/2016
+<br>
+</center><br>
+
+<div style="margin: 3px 0 1em 3px"><a href="https://ecf.insb.uscourts.gov/cgi-bin/mobile_query.pl?search=caseInfo&amp;caseid=558471">Mobile Query</a></div><font size="+1"><strong>Query</strong></font><br>
+	<table vspace="0" cellspacing="10" hspace="10" cellpadding="0" align="left" valign="top">
+		<tbody><tr align="left" valign="top">
+		<td align="top">
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryAlias.pl?558471">Alias</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryAscCases.pl?558471">Associated Cases</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryAttorneys.pl?558471">Attorney</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/QryRMSLocation.pl?558471">Case File Location</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qrySummary.pl?558471">Case Summary</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/SearchClaims.pl?558471">Claims Register</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/CreditorQry.pl?558471">Creditor</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/CredMatrixCase.pl?558471">List of Creditors</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/SchedQry.pl?558471">Deadline/Schedule</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/DktRpt.pl?558471">Docket Report ...</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/FilerQry.pl?558471">Filers</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/HistDocQry.pl?558471">History/Documents</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/NoticeOfFiling.pl?558471">Notice of Bankruptcy Case Filing</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryParties.pl?558471">Party</a><br>
+		</td>
+		
+		
+		<td>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/RelTransactQry.pl?558471">Related Transactions</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/StatusQry.pl?558471">Status</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryTrustee.pl?558471">Trustee</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryViewDocument.pl?558471">View Document</a><br>
+		</td>
+		</tr>	
+		</tbody></table>
+
+
+<script>
+function clearDesktopCookie(){
+  document.cookie = "uiexperience=dtp;secure;path=/;expires=Thu, 01-Jan-1970 00:00:01 GMT';";
+}
+</script>
+</div></body></html>

--- a/tests/examples/pacer/case_queries/insb_2.html
+++ b/tests/examples/pacer/case_queries/insb_2.html
@@ -33,7 +33,7 @@ function VisitPmLink(tcPmLink) {
         <div id="topmenu" class="yuimenubar yui-module yui-overlay visible" style="z-index: 2; position: static; display: block; visibility: visible;"><div class="bd">
         <img id="cmecfLogo" class="cmecfLogo" src="./insb_2_2_files/logo-cmecf-sm.png" alt="CM/ECF" title="" onclick="CMECF.MainMenu.showCourtInformation(); return false">
         <ul class="first-of-type">
-      
+
 <li class="yuimenubaritem first-of-type" id="yui-gen0" groupindex="0" index="0"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/iquery.pl"><u>Q</u>uery</a></li>
 <li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen1" groupindex="0" index="1"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Reports&amp;id=-1"><u>R</u>eports <div class="spritedownarrow"></div></a></li>
 <li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen2" groupindex="0" index="2"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.insb.uscourts.gov/cgi-bin/DisplayMenu.pl?Utilities&amp;id=-1"><u>U</u>tilities <div class="spritedownarrow"></div></a></li>
@@ -41,7 +41,7 @@ function VisitPmLink(tcPmLink) {
 <li class="yuimenubaritem" id="yui-gen4" groupindex="0" index="4"><a class="yuimenubaritemlabel" href="https://ecf.insb.uscourts.gov/cgi-bin/login.pl?logout">Log Out</a></li><li class="yuimenubaritem" id="placeholderForAlertsIcon" groupindex="0" index="5"></li>
         </ul></div>
         <hr class="hrmenuseparator"></div></div>
-        
+
       <script type="text/javascript">
 callCreateMenu=function(){
         var fn = "CMECF.MainMenu.createMenu";
@@ -55,14 +55,14 @@ if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout( function(){ cal
       </script>
     <center>
 <b><font size="+1">10-15790-JMC-13</font></b><font size="+1">
-William Brian Stanley and Cecilia Ann Stanley                               
+William Brian Stanley and Cecilia Ann Stanley
 </font>
 <br>
 <b>Case type:</b> bk
 <b>Chapter:</b> 13
 <b>Asset:</b> Yes
 <b>Vol: </b> v
-<b>Judge:</b> James M. Carr 
+<b>Judge:</b> James M. Carr
 <br>
 <b>Date filed:</b> 10/19/2010
 <b>Date of last filing:</b> 03/01/2016
@@ -92,15 +92,15 @@ William Brian Stanley and Cecilia Ann Stanley
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/NoticeOfFiling.pl?558471">Notice of Bankruptcy Case Filing</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryParties.pl?558471">Party</a><br>
 		</td>
-		
-		
+
+
 		<td>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/RelTransactQry.pl?558471">Related Transactions</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/StatusQry.pl?558471">Status</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryTrustee.pl?558471">Trustee</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.insb.uscourts.gov/cgi-bin/qryViewDocument.pl?558471">View Document</a><br>
 		</td>
-		</tr>	
+		</tr>
 		</tbody></table>
 
 

--- a/tests/examples/pacer/case_queries/insb_2.json
+++ b/tests/examples/pacer/case_queries/insb_2.json
@@ -1,0 +1,17 @@
+{
+  "asset": "Yes",
+  "assigned_to_str": "James M. Carr",
+  "case_name": "William Brian Stanley and Cecilia Ann Stanley",
+  "case_name_raw": "William Brian Stanley and Cecilia Ann Stanley",
+  "case_type": "bk",
+  "chapter": "13",
+  "court_id": "insb",
+  "date_debtor_dismissed": "2015-12-12",
+  "date_filed": "2010-10-19",
+  "date_joint_debtor_dismissed": "2015-12-12",
+  "date_last_filing": "2016-03-01",
+  "date_plan_confirmed": "2011-04-01",
+  "date_terminated": "2016-03-01",
+  "docket_number": "10-15790",
+  "vol": "v"
+}

--- a/tests/examples/pacer/case_queries/scb_1.html
+++ b/tests/examples/pacer/case_queries/scb_1.html
@@ -8,7 +8,7 @@
 				<div id="topmenu" class="yuimenubar"><div class="bd">
 				<img id="cmecfLogo" class="cmecfLogo" src="./scb_iquer_page_files/logo-cmecf-sm.png" alt="CM/ECF" title="">
 				<ul class="first-of-type">
-			
+
 <li class="yuimenubaritem"><a class="yuimenubaritemlabel" href="https://ecf.scb.uscourts.gov/cgi-bin/iquery.pl">Query</a></li>
 <li class="yuimenubaritem"><a class="yuimenubaritemlabel" href="https://ecf.scb.uscourts.gov/cgi-bin/DisplayMenu.pl?Reports&amp;id=-1">Reports <div class="spritedownarrow"></div></a></li>
 <li class="yuimenubaritem"><a class="yuimenubaritemlabel" href="https://ecf.scb.uscourts.gov/cgi-bin/DisplayMenu.pl?Utilities&amp;id=-1">Utilities <div class="spritedownarrow"></div></a></li>
@@ -16,7 +16,7 @@
 <li class="yuimenubaritem"><a class="yuimenubaritemlabel" href="https://ecf.scb.uscourts.gov/cgi-bin/login.pl?logout">Log Out</a></li><li class="yuimenubaritem" id="placeholderForAlertsIcon"></li>
 				</ul></div>
 				<hr class="hrmenuseparator"></div></div>
-				
+
 			<script type="text/javascript">
 callCreateMenu=function(){
 				var fn = "CMECF.MainMenu.renderSimpleMenu";
@@ -28,13 +28,13 @@ if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout( function(){ cal
 							document.cookie="PacerSession=ercNnFCARQ8HPkyMXJCE2ird1GCRZv4hTHJGznZr7gX9J91Rb8QXoWTaFbHYcCqLdmSnmIPQ1ceG9GBJig4SgkG3rEHNnuPjLDAcWYJH6BgSAKdA42Jt7YHlCZQbbw5G; path=/; domain=.uscourts.gov; secure;"
 							</script><center>
 <b><font size="+1">12-07357-hb</font></b>
-<b></b>Kenneth Edward Walker and Linda Jean Walker                                 
+<b></b>Kenneth Edward Walker and Linda Jean Walker
 <br>
 <b>Case type:</b> bk
 <b>Chapter:</b> 13
 <b>Asset:</b> Yes
 <b>Vol: </b> v
-<b>Chief Judge:</b> Helen E. Burris 
+<b>Chief Judge:</b> Helen E. Burris
 <br>
 <b>Date filed:</b> 11/29/2012
 <b>Date of last filing:</b> 11/02/2017
@@ -63,15 +63,15 @@ if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout( function(){ cal
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/RelTransactQry.pl?243953">Related Transactions</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/StatusQry.pl?243953">Status</a><br>
 		</td>
-		
-		
+
+
 		<td>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/qryTrustee.pl?243953">Trustee</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/qryViewDocument.pl?243953">View Document</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/SearchClaims.pl?243953">Claims Register</a><br>
 			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/CredMatrixCase.pl?243953">List of Creditors</a><br>
 		</td>
-		</tr>	
+		</tr>
 		</tbody></table>
 
 

--- a/tests/examples/pacer/case_queries/scb_1.html
+++ b/tests/examples/pacer/case_queries/scb_1.html
@@ -1,0 +1,83 @@
+
+<!-- saved from url=(0070)https://ecf.scb.uscourts.gov/cgi-bin/iquery.pl?202319743581335-L_1_0-1 -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><link rel="shortcut icon" href="https://ecf.scb.uscourts.gov/favicon.ico"><title>SC Bankruptcy CM/ECF - LIVE</title>
+<script language="JavaScript">
+							document.cookie="PacerSession=ercNnFCARQ8HPkyMXJCE2ird1GCRZv4hTHJGznZr7gX9J91Rb8QXoWTaFbHYcCqLdmSnmIPQ1ceG9GBJig4SgkG3rEHNnuPjLDAcWYJH6BgSAKdA42Jt7YHlCZQbbw5G; path=/; domain=.uscourts.gov; secure;"
+							</script><script type="text/javascript">document.cookie = "PRTYPE=web; path=/;"</script> <script>var default_base_path = "/"; </script> <link rel="stylesheet" type="text/css" href="./scb_iquer_page_files/default.css"><script type="text/javascript" src="./scb_iquer_page_files/core.js"></script><script type="text/javascript" src="./scb_iquer_page_files/autocomplete.js"></script><script type="text/javascript" src="./scb_iquer_page_files/DisableAJTALinks.js"></script><script type="text/javascript">if (top!=self) {top.location.replace(location.href);}</script><script>var default_base_path = "/"; </script></head><body bgcolor="FFFFF0" text="000000">
+				<div class="noprint">
+				<div id="topmenu" class="yuimenubar"><div class="bd">
+				<img id="cmecfLogo" class="cmecfLogo" src="./scb_iquer_page_files/logo-cmecf-sm.png" alt="CM/ECF" title="">
+				<ul class="first-of-type">
+			
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href="https://ecf.scb.uscourts.gov/cgi-bin/iquery.pl">Query</a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href="https://ecf.scb.uscourts.gov/cgi-bin/DisplayMenu.pl?Reports&amp;id=-1">Reports <div class="spritedownarrow"></div></a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href="https://ecf.scb.uscourts.gov/cgi-bin/DisplayMenu.pl?Utilities&amp;id=-1">Utilities <div class="spritedownarrow"></div></a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" onclick="CMECF.MainMenu.showHelpPage(&#39;&#39;); return false">Help</a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href="https://ecf.scb.uscourts.gov/cgi-bin/login.pl?logout">Log Out</a></li><li class="yuimenubaritem" id="placeholderForAlertsIcon"></li>
+				</ul></div>
+				<hr class="hrmenuseparator"></div></div>
+				
+			<script type="text/javascript">
+callCreateMenu=function(){
+				var fn = "CMECF.MainMenu.renderSimpleMenu";
+				if(typeof CMECF.MainMenu.renderSimpleMenu == 'function') {
+					CMECF.MainMenu.renderSimpleMenu();
+				}
+                        }
+if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout( function(){ callCreateMenu(); }, 1);}else{CMECF.util.Event.addListener(window, "load",  callCreateMenu());}</script> <div id="cmecfMainContent" style="height: 814px;"><input type="hidden" id="cmecfMainContentScroll" value="0"><script language="JavaScript">
+							document.cookie="PacerSession=ercNnFCARQ8HPkyMXJCE2ird1GCRZv4hTHJGznZr7gX9J91Rb8QXoWTaFbHYcCqLdmSnmIPQ1ceG9GBJig4SgkG3rEHNnuPjLDAcWYJH6BgSAKdA42Jt7YHlCZQbbw5G; path=/; domain=.uscourts.gov; secure;"
+							</script><center>
+<b><font size="+1">12-07357-hb</font></b>
+<b></b>Kenneth Edward Walker and Linda Jean Walker                                 
+<br>
+<b>Case type:</b> bk
+<b>Chapter:</b> 13
+<b>Asset:</b> Yes
+<b>Vol: </b> v
+<b>Chief Judge:</b> Helen E. Burris 
+<br>
+<b>Date filed:</b> 11/29/2012
+<b>Date of last filing:</b> 11/02/2017
+<b>Plan confirmed:</b> 01/10/2013
+<br><b>Debtor&nbsp;discharged:</b>&nbsp;09/05/2017
+<b>Joint&nbsp;debtor&nbsp;discharged:</b>&nbsp;09/05/2017
+<br><b>Date terminated:</b> 10/31/2017
+<br>
+</center><br>
+
+<div style="margin: 3px 0 1em 3px"><a href="https://ecf.scb.uscourts.gov/cgi-bin/mobile_query.pl?search=caseInfo&amp;caseid=243953">Mobile Query</a></div><font size="+1"><strong>Query</strong></font><br>
+	<table vspace="0" cellspacing="10" hspace="10" cellpadding="0" align="left" valign="top">
+		<tbody><tr align="left" valign="top">
+		<td align="top">
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/qryAlias.pl?243953">Alias</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/qryAscCases.pl?243953">Associated Cases</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/qryAttorneys.pl?243953">Attorney</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/qrySummary.pl?243953">Case Summary</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/CreditorQry.pl?243953">Creditor</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/SchedQry.pl?243953">Deadline/Schedule</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/DktRpt.pl?243953">Docket Report ...</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/FilerQry.pl?243953">Filers</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/HistDocQry.pl?243953">History/Documents</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/NoticeOfFiling.pl?243953">Notice of Bankruptcy Case Filing</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/qryParties.pl?243953">Party</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/RelTransactQry.pl?243953">Related Transactions</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/StatusQry.pl?243953">Status</a><br>
+		</td>
+		
+		
+		<td>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/qryTrustee.pl?243953">Trustee</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/qryViewDocument.pl?243953">View Document</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/SearchClaims.pl?243953">Claims Register</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.scb.uscourts.gov/cgi-bin/CredMatrixCase.pl?243953">List of Creditors</a><br>
+		</td>
+		</tr>	
+		</tbody></table>
+
+
+<script>
+function clearDesktopCookie(){
+	document.cookie = "uiexperience=dtp;secure;path=/;expires=Thu, 01-Jan-1970 00:00:01 GMT';";
+}
+</script>
+</div></body></html>

--- a/tests/examples/pacer/case_queries/scb_1.json
+++ b/tests/examples/pacer/case_queries/scb_1.json
@@ -1,0 +1,17 @@
+{
+  "asset": "Yes",
+  "assigned_to_str": "Helen E. Burris",
+  "case_name": "Kenneth Edward Walker and Linda Jean Walker",
+  "case_name_raw": "Kenneth Edward Walker and Linda Jean Walker",
+  "case_type": "bk",
+  "chapter": "13",
+  "court_id": "scb",
+  "date_debtor_dismissed": "2017-09-05",
+  "date_filed": "2012-11-29",
+  "date_joint_debtor_dismissed": "2017-09-05",
+  "date_last_filing": "2017-11-02",
+  "date_plan_confirmed": "2013-01-10",
+  "date_terminated": "2017-10-31",
+  "docket_number": "12-07357",
+  "vol": "v"
+}


### PR DESCRIPTION
This PR solves the issue described in https://github.com/freelawproject/courtlistener/issues/2819 regarding the unparsed judge's name in SCB, as well as the issue detailed in  https://github.com/freelawproject/courtlistener/discussions/2820 about the case name not being parsed in INSB.

Both issues were related to iquery pages for these two courts, which had different formats.

- In the case of SCB, the judge's name was indeed parsed, but was added under the key `chief_judge` instead of `assigned_to_str` so it was not being recognized and assigned in Courtlistener. So I changed the key name to `assigned_to_str`.

- In INSB, the case name is within a `font` tag. So I added a new parsing method to properly handle this case.



