### PR TITLE
feat(deps): configure Dependabot for Github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,11 @@ updates:
   - dependency-name: '*'
     update-types: ["version-update:semver-patch"]
 
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: monthly
+  groups:
+    core:
+      patterns:
+        - 'actions/*' # The core actions offered by Github


### PR DESCRIPTION
In theory, this will make updates easier keep up with. Given aggressiveness of deprecation in Github actions - that would break CI/CD - keeping up to date has more than passing importance.