### PR TITLE
chore(tests): clear out unclosed file warnings from tests

### DIFF
--- a/juriscraper/opinions/united_states/administrative_agency/mspb_p.py
+++ b/juriscraper/opinions/united_states/administrative_agency/mspb_p.py
@@ -21,7 +21,8 @@ class Site(OpinionSiteLinear):
 
     def _process_html(self):
         if self.test_mode_enabled():
-            self.html = json.load(open(self.url))
+            with open(self.url) as file:
+                self.html = json.load(file)
         for row in self.html["data"]:
             url = row["FILE_NAME"]
             name = f"{row['APL_FIRST_NAME']} {row['APL_LAST_NAME']} v. {row['AGENCY']}"

--- a/juriscraper/opinions/united_states/federal_appellate/ca4.py
+++ b/juriscraper/opinions/united_states/federal_appellate/ca4.py
@@ -53,7 +53,8 @@ class Site(OpinionSiteLinear):
 
     def _download(self, request_dict={}):
         if self.test_mode_enabled():
-            self.json = json.load(open(self.url))
+            with open(self.url) as file:
+                self.json = json.load(file)
         else:
             self.json = (
                 self.request["session"]

--- a/juriscraper/opinions/united_states/federal_special/tax.py
+++ b/juriscraper/opinions/united_states/federal_special/tax.py
@@ -48,7 +48,8 @@ class Site(OpinionSiteLinear):
                 self.url = f"{self.base}/opinion-search"
             self.set_blue_green = True
         if self.test_mode_enabled():
-            self.json = json.load(open(self.url))
+            with open(self.url) as file:
+                self.json = json.load(file)
         else:
             self.json = (
                 self.request["session"]

--- a/juriscraper/opinions/united_states/state/mdag.py
+++ b/juriscraper/opinions/united_states/state/mdag.py
@@ -32,7 +32,8 @@ class Site(OpinionSiteLinear):
 
     def _download(self, request_dict={}):
         if self.test_mode_enabled():
-            self.json = json.load(open(self.url))
+            with open(self.url) as file:
+                self.json = json.load(file)
         else:
             self.json = (
                 self.request["session"]


### PR DESCRIPTION
When running `tests.local.test_ScraperExampleTest`, a handful of warnings are sent to stderr:

```
./juriscraper/juriscraper/opinions/united_states/administrative_agency/mspb_p.py:24: ResourceWarning: unclosed file <_io.TextIOWrapper name='tests/examples/opinions/united_states/mspb_p_example.html' mode='r' encoding='UTF-8'>
  self.html = json.load(open(self.url))
./juriscraper/juriscraper/opinions/united_states/administrative_agency/mspb_p.py:24: ResourceWarning: unclosed file <_io.TextIOWrapper name='tests/examples/opinions/united_states/mspb_u_example.html' mode='r' encoding='UTF-8'>
  self.html = json.load(open(self.url))
./juriscraper/juriscraper/opinions/united_states/federal_appellate/ca4.py:56: ResourceWarning: unclosed file <_io.TextIOWrapper name='tests/examples/opinions/united_states/ca4_example.json' mode='r' encoding='UTF-8'>
  self.json = json.load(open(self.url))
./juriscraper/juriscraper/opinions/united_states/federal_special/tax.py:51: ResourceWarning: unclosed file <_io.TextIOWrapper name='tests/examples/opinions/united_states/tax_example.html' mode='r' encoding='UTF-8'>
  self.json = json.load(open(self.url))
./juriscraper/juriscraper/opinions/united_states/state/mdag.py:35: ResourceWarning: unclosed file <_io.TextIOWrapper name='tests/examples/opinions/united_states/mdag_example.json' mode='r' encoding='UTF-8'>
  self.json = json.load(open(self.url))
```