### PR TITLE
Try to parse pages with unable to create PDF file error

### DIFF
--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -341,7 +341,6 @@ class DocketReport(BaseDocketReport, BaseReport):
         "Incomplete request. Please try your query again by choosing the "
         "Query or Reports option",
         "To accept charges shown below, click on the 'View Report' button",
-        "Unable to create PDF file.",
         "This case was administratively closed",
         "The start date must be less than or equal to the end date",
         "The starting document number must be less than or equal to the "


### PR DESCRIPTION
This doesn't seem to actually indicate a docket report is invalid.