### PR TITLE
appellate_docket.py: remove .decode() python2ism

### DIFF
--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -781,7 +781,7 @@ def _main():
     filepath = sys.argv[1]
     print(f"Parsing HTML file at {filepath}")
     with open(filepath) as f:
-        text = f.read().decode("utf-8")
+        text = f.read()
     report._parse_text(text)
     pprint.pprint(report.data, indent=2)
 


### PR DESCRIPTION
.decode() not work in python3, whoops.

The problem is such:
```
(juriscraper) jhawk@lrr juriscraper % python3 -m juriscraper.pacer.appellate_docket /dev/null

Warning: No such file or directory: /var/log/juriscraper/debug.log. Have you created the directory for the log?
Juriscraper will continue to run, and all logs will be sent to stderr.
<frozen runpy>:128: RuntimeWarning: 'juriscraper.pacer.appellate_docket' found in sys.modules after import of package 'juriscraper.pacer', but prior to execution of 'juriscraper.pacer.appellate_docket'; this may result in unpredictable behaviour
Parsing HTML file at /dev/null
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/jhawk/src/juriscraper/juriscraper/pacer/appellate_docket.py", line 790, in <module>
    _main()
  File "/Users/jhawk/src/juriscraper/juriscraper/pacer/appellate_docket.py", line 784, in _main
    text = f.read().decode("utf-8")
           ^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```

I suppose maybe we should add a test? Otherwise this code path, which is useful for debugging, tends to bitrot?
hmu