### PR TITLE
setup.cfg: description_file not description-file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 python-tag = py27
 
 [metadata]
-description-file = README.rst
+description_file = README.rst


### PR DESCRIPTION
(juriscraper) jhawk@lrr juriscraper % python3 setup.py test --help /opt/homebrew/lib/python3.11/site-packages/setuptools/dist.py:744: SetuptoolsDeprecationWarning: Invalid dash-separated options !!

        ********************************************************************************
        Usage of dash-separated 'description-file' will not be supported in future
        versions. Please use the underscore name 'description_file' instead.

        This deprecation is overdue, please update your project and remove deprecated
        calls to avoid build errors in the future.

        See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
        ********************************************************************************

!!