### PR TITLE
test_DocketParseText.py: assert_anonymized() cleanup spew

### DIFF
--- a/tests/local/test_DocketParseTest.py
+++ b/tests/local/test_DocketParseTest.py
@@ -145,7 +145,6 @@ class DocketAnonymizeTest(unittest.TestCase):
         report._parse_text(text)
         anon_text = report.get_anonymized_text()
         self.assertNotIn("LOGIN REMOVED", anon_text)
-        print(anon_text)
 
     def test_anonymize_district(self) -> None:
         path = os.path.join(


### PR DESCRIPTION
Don't print `anon_text` to save test output from thousands of lines of HTML that clutters it.