### PR TITLE
test_utils.py/warn_or_crash_slow_parser() significant figures

### DIFF
--- a/juriscraper/lib/test_utils.py
+++ b/juriscraper/lib/test_utils.py
@@ -64,7 +64,7 @@ def warn_or_crash_slow_parser(duration, warn_duration=1, max_duration=15):
             # Only do this if we're not debugging. Debuggers make things slower
             # and breakpoints make things stop.
             raise SlownessException(
-                "This scraper took {duration}s to test, which is more than "
+                "This scraper took {duration:.3f}s to test, which is more than "
                 "the allowed speed of {max_duration}s. Please speed it up for "
                 "tests to pass.".format(
                     duration=duration, max_duration=max_duration


### PR DESCRIPTION
It's not OK to print

juriscraper.lib.exceptions.SlownessException: This scraper took 3.372174024581909s to test, which is more than the allowed speed of 1s. Please speed it up for tests to pass.

Limit to three digits of precision to the right of the decimal point (fixed-point).