### PR TITLE
Refactor regex pattern in coloctapp to get cases from any year 2020-2029

### DIFF
--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -48,21 +48,21 @@ class Site(colo.Site):
                 self.find_element_by_id("next").click()
                 self.html = fromstring(self.webdriver.page_source)
 
-            #pattern = fr"({self.year}COA\d+)\n(.*?)\n(Division \w+)" #self.year fails tests in 2023
-            #pattern = fr"(2022COA\d+|{self.year}COA\d+)\n(.*?)\n(Division \w+)" #hybrid regex satisfies 2022 test examples
-            pattern = r"(202\d{1}COA\d+)\n(.*?)\n(Division \w+)" #regex generalized for this decade (passes tests)
-            #pattern = r"(20\d{2}COA\d+)\n(.*?)\n(Division \w+)" #regex generalized for 21st century (passes tests)
-            '''
+            # pattern = fr"({self.year}COA\d+)\n(.*?)\n(Division \w+)" #self.year fails tests in 2023
+            # pattern = fr"(2022COA\d+|{self.year}COA\d+)\n(.*?)\n(Division \w+)" #hybrid regex satisfies 2022 test examples
+            pattern = r"(202\d{1}COA\d+)\n(.*?)\n(Division \w+)"  # regex generalized for this decade (passes tests)
+            # pattern = r"(20\d{2}COA\d+)\n(.*?)\n(Division \w+)" #regex generalized for 21st century (passes tests)
+            """
             TODO revisit the regex pattern if the state scraper test examples are ever updated.
             A more rigorous test would check 2023 examples, or maybe even examples from different years.
             Potential edgecase: self.year == 2024, but the scraper is getting cases from 2023.
             I've suggested a few regex patterns, but decided on one generalized for this decade 2020-2029.
             The narrow scope limits unintended consequences while still being good for cases until 2029.
             It also lets us fix the scraper without changing the 2022 test examples.
-            This is kind of a hack because the tests no longer certify the 2023 data, 
+            This is kind of a hack because the tests no longer certify the 2023 data,
             so we are relying on the courts to maintain 2022 formatting.
                 -honeykjoule
-            '''
+            """
             urls_to_add = []
             for pg in self.html.xpath(".//div[@class='page']"):
                 if not pg.xpath(".//span[@role='link']/span/@aria-owns"):

--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -47,7 +47,7 @@ class Site(colo.Site):
                 self.find_element_by_id("next").click()
                 self.html = fromstring(self.webdriver.page_source)
 
-            pattern = r"(2022COA\d+)\n(.*?)\n(Division \w+)"
+            pattern = fr"({self.year}COA\d+)\n(.*?)\n(Division \w+)"
             urls_to_add = []
             for pg in self.html.xpath(".//div[@class='page']"):
                 if not pg.xpath(".//span[@role='link']/span/@aria-owns"):

--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -48,21 +48,7 @@ class Site(colo.Site):
                 self.find_element_by_id("next").click()
                 self.html = fromstring(self.webdriver.page_source)
 
-            # pattern = fr"({self.year}COA\d+)\n(.*?)\n(Division \w+)" #self.year fails tests in 2023
-            # pattern = fr"(2022COA\d+|{self.year}COA\d+)\n(.*?)\n(Division \w+)" #hybrid regex satisfies 2022 test examples
-            pattern = r"(202\d{1}COA\d+)\n(.*?)\n(Division \w+)"  # regex generalized for this decade (passes tests)
-            # pattern = r"(20\d{2}COA\d+)\n(.*?)\n(Division \w+)" #regex generalized for 21st century (passes tests)
-            """
-            TODO revisit the regex pattern if the state scraper test examples are ever updated.
-            A more rigorous test would check 2023 examples, or maybe even examples from different years.
-            Potential edgecase: self.year == 2024, but the scraper is getting cases from 2023.
-            I've suggested a few regex patterns, but decided on one generalized for this decade 2020-2029.
-            The narrow scope limits unintended consequences while still being good for cases until 2029.
-            It also lets us fix the scraper without changing the 2022 test examples.
-            This is kind of a hack because the tests no longer certify the 2023 data,
-            so we are relying on the courts to maintain 2022 formatting.
-                -honeykjoule
-            """
+            pattern = r"(202\d{1}COA\d+)\n(.*?)\n(Division \w+)"
             urls_to_add = []
             for pg in self.html.xpath(".//div[@class='page']"):
                 if not pg.xpath(".//span[@role='link']/span/@aria-owns"):

--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -5,6 +5,7 @@ Court Short Name: Colo. Ct. App.
 History:
     - 2022-01-31: Updated by William E. Palin
     - 2023-01-05: Updated by William E. Palin
+    - 2023-11-04: Updated by Honey K. Joule
 """
 
 
@@ -47,7 +48,21 @@ class Site(colo.Site):
                 self.find_element_by_id("next").click()
                 self.html = fromstring(self.webdriver.page_source)
 
-            pattern = fr"({self.year}COA\d+)\n(.*?)\n(Division \w+)"
+            #pattern = fr"({self.year}COA\d+)\n(.*?)\n(Division \w+)" #self.year fails tests in 2023
+            #pattern = fr"(2022COA\d+|{self.year}COA\d+)\n(.*?)\n(Division \w+)" #hybrid regex satisfies 2022 test examples
+            pattern = r"(202\d{1}COA\d+)\n(.*?)\n(Division \w+)" #regex generalized for this decade (passes tests)
+            #pattern = r"(20\d{2}COA\d+)\n(.*?)\n(Division \w+)" #regex generalized for 21st century (passes tests)
+            '''
+            TODO revisit the regex pattern if the state scraper test examples are ever updated.
+            A more rigorous test would check 2023 examples, or maybe even examples from different years.
+            Potential edgecase: self.year == 2024, but the scraper is getting cases from 2023.
+            I've suggested a few regex patterns, but decided on one generalized for this decade 2020-2029.
+            The narrow scope limits unintended consequences while still being good for cases until 2029.
+            It also lets us fix the scraper without changing the 2022 test examples.
+            This is kind of a hack because the tests no longer certify the 2023 data, 
+            so we are relying on the courts to maintain 2022 formatting.
+                -honeykjoule
+            '''
             urls_to_add = []
             for pg in self.html.xpath(".//div[@class='page']"):
                 if not pg.xpath(".//span[@role='link']/span/@aria-owns"):


### PR DESCRIPTION
issue #758 
refactored by changing regex pattern. was hardcoded for 2022, so it didn't pick up any 2023 cases. 
new pattern is `202\d{1}` so it picks up any cases 2020-2029.
some technical debt: will need to be changed in 2030.

This PR does not address the fact that the test examples only have cases from 2022. A more rigorous test would check 2023 examples, or maybe even examples from different years.

I also don't know if this fix completely addresses the issue and fixes the scraper. At the very least it should be able to pick up cases from the announcement PDF on the court website.

I've suggested a few regex patterns, but decided on one generalized for this decade 2020-2029.
* The narrow scope limits unintended consequences while still being good for cases until 2029.
* It also lets us fix the scraper without changing the 2022 test examples.
* This is kind of a hack because the tests no longer certify the 2023 data, so we are relying on the courts to maintain 2022 * formatting.

here is the `site.parse()` on 2023-11-02.

```
[
    {
        "date": "November 02, 2023",
        "name": "Colorado Sun and Tegna, Inc., d/b/a KUSA-TV/9News v. Amanda Brubaker, in her official capacity as the Records Custodian for theColorado Department of Human Services",
        "docket": "21CA1608-PD",
        "status": "Published",
        "url": "http://www.courts.state.co.us/Courts/Court_of_Appeals/Opinion/2023/21CA1608-PD.pdf",
        "citation": "2023COA101"
    },
    {
        "date": "November 02, 2023",
        "name": "The People of the State of Colorado v. Adrian Elijah Salazar",
        "docket": "22CA0331-PD",
        "status": "Published",
        "url": "http://www.courts.state.co.us/Courts/Court_of_Appeals/Opinion/2023/22CA0331-PD.pdf",
        "citation": "2023COA102"
    },
    {
        "date": "November 02, 2023",
        "name": "Alexander Rudnicki; and Francis Rudnicki as parents, guardians, and nextfriends; and Pamela Rudnicki, as parents, guardians, and next friends v. Peter Bianco, D.O.",
        "docket": "22CA1246-PD",
        "status": "Published",
        "url": "http://www.courts.state.co.us/Courts/Court_of_Appeals/Opinion/2023/22CA1246-PD.pdf",
        "citation": "2023COA103"
    }
]
```