### PR TITLE
Avoid populating the case date_filed field with the entry date_filed from NEFS and NDAs.

### DIFF
--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -383,7 +383,7 @@ class NotificationEmail(BaseDocketReport, BaseReport):
             docket = {
                 "case_name": self._get_case_name_plain(),
                 "docket_number": docket_number,
-                "date_filed": self._get_date_filed(),
+                "date_filed": None,
                 "docket_entries": self._get_docket_entries(),
             }
             dockets.append(docket)
@@ -406,7 +406,7 @@ class NotificationEmail(BaseDocketReport, BaseReport):
                 docket = {
                     "case_name": self._get_case_name(docket_table),
                     "docket_number": docket_number,
-                    "date_filed": self._get_date_filed(),
+                    "date_filed": None,
                     "docket_entries": self._get_docket_entries(docket_table),
                 }
                 dockets.append(docket)

--- a/tests/examples/pacer/nda/ca11_1.json
+++ b/tests/examples/pacer/nda/ca11_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Marjorie Taylor Greene v. Secretary of State for the State of Georgia",
-      "date_filed": "2022-08-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-10",

--- a/tests/examples/pacer/nda/ca11_2.json
+++ b/tests/examples/pacer/nda/ca11_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Marjorie Taylor Greene v. Secretary of State for the State of Georgia",
-      "date_filed": "2022-08-22",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-22",

--- a/tests/examples/pacer/nda/ca2_1.json
+++ b/tests/examples/pacer/nda/ca2_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "New York State Telecommunicati v. James",
-      "date_filed": "2022-07-27",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-07-27",

--- a/tests/examples/pacer/nda/ca2_2.json
+++ b/tests/examples/pacer/nda/ca2_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "New York State Telecommunicati v. James",
-      "date_filed": "2022-06-14",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-06-14",

--- a/tests/examples/pacer/nda/ca2_3.json
+++ b/tests/examples/pacer/nda/ca2_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "New York State Telecommunicati v. James",
-      "date_filed": "2022-03-23",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-03-23",

--- a/tests/examples/pacer/nda/ca2_4.json
+++ b/tests/examples/pacer/nda/ca2_4.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "New York State Telecommunicati v. James",
-      "date_filed": "2022-03-03",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-03-03",

--- a/tests/examples/pacer/nda/ca2_5.json
+++ b/tests/examples/pacer/nda/ca2_5.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Elisa W. v. The City of New York",
-      "date_filed": "2022-08-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-10",

--- a/tests/examples/pacer/nda/ca3_1.json
+++ b/tests/examples/pacer/nda/ca3_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Madison Lara v. Commissioner PA State Police",
-      "date_filed": "2022-08-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-08",

--- a/tests/examples/pacer/nda/ca3_2.json
+++ b/tests/examples/pacer/nda/ca3_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Port Hamilton Refining and Transportation LLLP v. EPA",
-      "date_filed": "2023-01-27",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-01-27",

--- a/tests/examples/pacer/nda/ca4_1.json
+++ b/tests/examples/pacer/nda/ca4_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Neuhtah Opiotennione v. Bozzuto Management Company",
-      "date_filed": "2022-08-19",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-19",

--- a/tests/examples/pacer/nda/ca4_2.json
+++ b/tests/examples/pacer/nda/ca4_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Neuhtah Opiotennione v. Bozzuto Management Company",
-      "date_filed": "2022-08-18",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-18",

--- a/tests/examples/pacer/nda/ca5_1.json
+++ b/tests/examples/pacer/nda/ca5_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Certain Underwriters v. Cox Operating",
-      "date_filed": "2022-08-16",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-16",

--- a/tests/examples/pacer/nda/ca5_2.json
+++ b/tests/examples/pacer/nda/ca5_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Kenai Ironclad v. CP Marine Services",
-      "date_filed": "2022-09-26",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-09-26",

--- a/tests/examples/pacer/nda/ca6_1.json
+++ b/tests/examples/pacer/nda/ca6_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Andrea Goldblum v. UC",
-      "date_filed": "2022-08-15",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-15",

--- a/tests/examples/pacer/nda/ca6_2.json
+++ b/tests/examples/pacer/nda/ca6_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Anthony Eid v. Wayne State University",
-      "date_filed": "2022-08-17",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-17",

--- a/tests/examples/pacer/nda/ca9_1.json
+++ b/tests/examples/pacer/nda/ca9_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Rosemarie Vargas v. Facebook, Inc.",
-      "date_filed": "2022-08-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-08",

--- a/tests/examples/pacer/nda/ca9_2.json
+++ b/tests/examples/pacer/nda/ca9_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Mackenzie Brown v. State of Arizona",
-      "date_filed": "2022-08-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-08",

--- a/tests/examples/pacer/nda/ca9_3.json
+++ b/tests/examples/pacer/nda/ca9_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Rosemarie Vargas v. Facebook, Inc.",
-      "date_filed": "2022-08-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-08",

--- a/tests/examples/pacer/nda/ca9_4.json
+++ b/tests/examples/pacer/nda/ca9_4.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Mackenzie Brown v. State of Arizona",
-      "date_filed": "2022-08-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-08",

--- a/tests/examples/pacer/nda/ca9_5.json
+++ b/tests/examples/pacer/nda/ca9_5.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "City of Oakland v. BP PLC",
-      "date_filed": "2022-12-05",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-12-05",

--- a/tests/examples/pacer/nda/cafc_1.json
+++ b/tests/examples/pacer/nda/cafc_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Corephotonics, Ltd. v. Apple Inc.",
-      "date_filed": "2022-08-22",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-22",

--- a/tests/examples/pacer/nda/cafc_2.json
+++ b/tests/examples/pacer/nda/cafc_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Corephotonics, Ltd. v. Apple Inc.",
-      "date_filed": "2022-08-19",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-19",

--- a/tests/examples/pacer/nef/ared_1.json
+++ b/tests/examples/pacer/nef/ared_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Bryson v. Protho Junction LLC",
-      "date_filed": "2021-06-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-10",

--- a/tests/examples/pacer/nef/ared_2.json
+++ b/tests/examples/pacer/nef/ared_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Santiago v. United Parcel Service Inc",
-      "date_filed": "2021-06-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-10",

--- a/tests/examples/pacer/nef/ared_3.json
+++ b/tests/examples/pacer/nef/ared_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Pitts v. Fire Extinguisher Sales & Services of Arkansas LLC",
-      "date_filed": "2021-06-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-10",

--- a/tests/examples/pacer/nef/arwd.json
+++ b/tests/examples/pacer/nef/arwd.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Kizziar v. Zakirali",
-      "date_filed": "2021-06-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-10",

--- a/tests/examples/pacer/nef/cacd.json
+++ b/tests/examples/pacer/nef/cacd.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Kelvin Hernandez Roman v. Chad F. Wolf",
-      "date_filed": "2021-04-19",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-04-19",

--- a/tests/examples/pacer/nef/cand.json
+++ b/tests/examples/pacer/nef/cand.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Epic Games, Inc. v. Apple Inc.",
-      "date_filed": "2021-04-19",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-04-19",

--- a/tests/examples/pacer/nef/ned.json
+++ b/tests/examples/pacer/nef/ned.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Hicks v. Hawkins Construction Company",
-      "date_filed": "2021-06-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-10",

--- a/tests/examples/pacer/nef/s3/almd_1.json
+++ b/tests/examples/pacer/nef/s3/almd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Stapler v. Automatic Food Service, Inc.",
-      "date_filed": "2021-08-09",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-09",

--- a/tests/examples/pacer/nef/s3/almd_2.json
+++ b/tests/examples/pacer/nef/s3/almd_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Stapler v. Automatic Food Service, Inc.",
-      "date_filed": "2021-08-09",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-09",

--- a/tests/examples/pacer/nef/s3/almd_3_plain.json
+++ b/tests/examples/pacer/nef/s3/almd_3_plain.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "United States v. MANAFORT",
-      "date_filed": "2019-03-15",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2019-03-15",

--- a/tests/examples/pacer/nef/s3/almd_4_plain.json
+++ b/tests/examples/pacer/nef/s3/almd_4_plain.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "United States v. MANAFORT",
-      "date_filed": "2019-03-15",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2019-03-15",

--- a/tests/examples/pacer/nef/s3/alsd_1.json
+++ b/tests/examples/pacer/nef/s3/alsd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Troxel v. Gunite Pros, LLC",
-      "date_filed": "2021-06-28",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-28",

--- a/tests/examples/pacer/nef/s3/alsd_2.json
+++ b/tests/examples/pacer/nef/s3/alsd_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Troxel v. Gunite Pros, LLC",
-      "date_filed": "2021-06-28",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-28",

--- a/tests/examples/pacer/nef/s3/alsd_3.json
+++ b/tests/examples/pacer/nef/s3/alsd_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Autrey v. Harrigan Lumber Co., Inc.",
-      "date_filed": "2021-08-11",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-11",

--- a/tests/examples/pacer/nef/s3/ared_1.json
+++ b/tests/examples/pacer/nef/s3/ared_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Fuller v. Singleton Farms LLC",
-      "date_filed": "2021-06-28",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-28",

--- a/tests/examples/pacer/nef/s3/ared_2.json
+++ b/tests/examples/pacer/nef/s3/ared_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Taylor v. Envolve Community Management LLC",
-      "date_filed": "2021-06-28",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-28",

--- a/tests/examples/pacer/nef/s3/ared_3.json
+++ b/tests/examples/pacer/nef/s3/ared_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Santiago v. United Parcel Service Inc",
-      "date_filed": "2021-07-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-07-08",

--- a/tests/examples/pacer/nef/s3/ared_4.json
+++ b/tests/examples/pacer/nef/s3/ared_4.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Huffman v. Associated Management Ltd",
-      "date_filed": "2021-07-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-07-08",

--- a/tests/examples/pacer/nef/s3/ared_5.json
+++ b/tests/examples/pacer/nef/s3/ared_5.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Taylor v. Envolve Community Management LLC",
-      "date_filed": "2021-06-28",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-28",

--- a/tests/examples/pacer/nef/s3/ared_6.json
+++ b/tests/examples/pacer/nef/s3/ared_6.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Huffman v. Associated Management Ltd",
-      "date_filed": "2021-07-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-07-08",

--- a/tests/examples/pacer/nef/s3/ared_7.json
+++ b/tests/examples/pacer/nef/s3/ared_7.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Bailey v. Jefferson County, Arkansas",
-      "date_filed": "2021-08-12",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-12",

--- a/tests/examples/pacer/nef/s3/arwd_1.json
+++ b/tests/examples/pacer/nef/s3/arwd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Greenlee v. Driven Brands, INC.",
-      "date_filed": "2021-06-28",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-28",

--- a/tests/examples/pacer/nef/s3/arwd_2.json
+++ b/tests/examples/pacer/nef/s3/arwd_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Greenlee v. Driven Brands, INC.",
-      "date_filed": "2021-06-28",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-28",

--- a/tests/examples/pacer/nef/s3/arwd_3.json
+++ b/tests/examples/pacer/nef/s3/arwd_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Johnson v. Ozark Mountain Poultry, Inc.",
-      "date_filed": "2021-07-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-07-08",

--- a/tests/examples/pacer/nef/s3/arwd_4.json
+++ b/tests/examples/pacer/nef/s3/arwd_4.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Greenlee v. Driven Brands, INC.",
-      "date_filed": "2021-06-28",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-28",

--- a/tests/examples/pacer/nef/s3/arwd_5.json
+++ b/tests/examples/pacer/nef/s3/arwd_5.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Allen v. K-MAC Enterprises, Inc.",
-      "date_filed": "2021-08-12",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-12",

--- a/tests/examples/pacer/nef/s3/cacb_1.json
+++ b/tests/examples/pacer/nef/s3/cacb_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Matthew Condran",
-      "date_filed": "2022-10-05",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-05",

--- a/tests/examples/pacer/nef/s3/cacb_2.json
+++ b/tests/examples/pacer/nef/s3/cacb_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Matthew Condran",
-      "date_filed": "2022-10-06",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-06",

--- a/tests/examples/pacer/nef/s3/cacb_3.json
+++ b/tests/examples/pacer/nef/s3/cacb_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Maximo Arturo Arriola",
-      "date_filed": "2022-10-04",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-04",

--- a/tests/examples/pacer/nef/s3/cacb_6.json
+++ b/tests/examples/pacer/nef/s3/cacb_6.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Lara Fakhoury",
-      "date_filed": "2023-03-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-03-08",

--- a/tests/examples/pacer/nef/s3/cand_1.json
+++ b/tests/examples/pacer/nef/s3/cand_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Simon v. City and County of San Francisco",
-      "date_filed": "2023-01-13",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-01-13",

--- a/tests/examples/pacer/nef/s3/cand_3.json
+++ b/tests/examples/pacer/nef/s3/cand_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "The People of the State of California v. BP P.L.C.",
-      "date_filed": "2022-09-28",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-09-28",
@@ -23,7 +23,7 @@
     },
     {
       "case_name": "The People of the State of California v. BP P.L.C.",
-      "date_filed": "2022-09-28",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-09-28",

--- a/tests/examples/pacer/nef/s3/ctb_1.json
+++ b/tests/examples/pacer/nef/s3/ctb_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Alan E. Waskowicz",
-      "date_filed": "2023-02-16",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-02-16",

--- a/tests/examples/pacer/nef/s3/ctb_2.json
+++ b/tests/examples/pacer/nef/s3/ctb_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Alan E. Waskowicz",
-      "date_filed": "2023-02-17",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-02-17",

--- a/tests/examples/pacer/nef/s3/ded_1.json
+++ b/tests/examples/pacer/nef/s3/ded_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "CBV, Inc. v. ChanBond, LLC",
-      "date_filed": "2022-08-03",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-03",

--- a/tests/examples/pacer/nef/s3/ded_2.json
+++ b/tests/examples/pacer/nef/s3/ded_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "CBV, Inc. v. ChanBond, LLC",
-      "date_filed": "2022-08-05",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-05",

--- a/tests/examples/pacer/nef/s3/gand_1.json
+++ b/tests/examples/pacer/nef/s3/gand_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Kinder v. Koch Industries, Inc.",
-      "date_filed": "2021-07-30",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-07-30",

--- a/tests/examples/pacer/nef/s3/ilnd_1.json
+++ b/tests/examples/pacer/nef/s3/ilnd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Street v. Footprint Acquisition, LLC",
-      "date_filed": "2021-08-12",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-12",

--- a/tests/examples/pacer/nef/s3/jpml_1.json
+++ b/tests/examples/pacer/nef/s3/jpml_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "IN RE: Clearview AI, Inc., Consumer Privacy Litigation",
-      "date_filed": "2022-10-09",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-09",
@@ -23,7 +23,7 @@
     },
     {
       "case_name": "Hurvitz v. Clearview AI, Inc.",
-      "date_filed": "2022-10-09",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-09",
@@ -41,7 +41,7 @@
     },
     {
       "case_name": "Calderon v. Clearview AI, Inc.",
-      "date_filed": "2022-10-09",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-09",
@@ -59,7 +59,7 @@
     },
     {
       "case_name": "Burke v. Clearview AI, Inc.",
-      "date_filed": "2022-10-09",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-09",

--- a/tests/examples/pacer/nef/s3/laed_1.json
+++ b/tests/examples/pacer/nef/s3/laed_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Lou v. Lopinto",
-      "date_filed": "2022-08-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-10",

--- a/tests/examples/pacer/nef/s3/laed_2.json
+++ b/tests/examples/pacer/nef/s3/laed_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Grant v. Gusman",
-      "date_filed": "2022-08-11",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-11",

--- a/tests/examples/pacer/nef/s3/njb_1.json
+++ b/tests/examples/pacer/nef/s3/njb_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Hollister Construction Services, LLC",
-      "date_filed": "2023-01-19",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-01-19",

--- a/tests/examples/pacer/nef/s3/njb_2.json
+++ b/tests/examples/pacer/nef/s3/njb_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Hollister Construction Services, LLC",
-      "date_filed": "2023-01-27",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-01-27",

--- a/tests/examples/pacer/nef/s3/njd_1.json
+++ b/tests/examples/pacer/nef/s3/njd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "KOONES v. KEHATI",
-      "date_filed": "2023-01-30",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-01-30",

--- a/tests/examples/pacer/nef/s3/nyed_1.json
+++ b/tests/examples/pacer/nef/s3/nyed_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Cunningham v. The City of New York",
-      "date_filed": "2022-08-01",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-01",

--- a/tests/examples/pacer/nef/s3/nyed_2.json
+++ b/tests/examples/pacer/nef/s3/nyed_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Acosta v. City of New York",
-      "date_filed": "2022-08-05",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-05",

--- a/tests/examples/pacer/nef/s3/nysb_1.json
+++ b/tests/examples/pacer/nef/s3/nysb_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Gerasimos Stefanitsis",
-      "date_filed": "2022-12-21",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-12-21",

--- a/tests/examples/pacer/nef/s3/nysb_2.json
+++ b/tests/examples/pacer/nef/s3/nysb_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Gerasimos Stefanitsis",
-      "date_filed": "2023-02-27",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-02-27",

--- a/tests/examples/pacer/nef/s3/nysb_3.json
+++ b/tests/examples/pacer/nef/s3/nysb_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Gerasimos Stefanitsis",
-      "date_filed": "2022-12-07",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-12-07",

--- a/tests/examples/pacer/nef/s3/nysd_1.json
+++ b/tests/examples/pacer/nef/s3/nysd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "IN RE: NEW YORK CITY POLICING DURING SUMMER 2020 DEMONSTRATIONS",
-      "date_filed": "2022-08-04",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-04",

--- a/tests/examples/pacer/nef/s3/nysd_2.json
+++ b/tests/examples/pacer/nef/s3/nysd_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "IN RE: NEW YORK CITY POLICING DURING SUMMER 2020 DEMONSTRATIONS",
-      "date_filed": "2022-08-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-08",

--- a/tests/examples/pacer/nef/s3/nysd_3.json
+++ b/tests/examples/pacer/nef/s3/nysd_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "IN RE: NEW YORK CITY POLICING DURING SUMMER 2020 DEMONSTRATIONS",
-      "date_filed": "2022-09-29",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-09-29",
@@ -23,7 +23,7 @@
     },
     {
       "case_name": "Wood v. De Blasio",
-      "date_filed": "2022-09-29",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-09-29",
@@ -41,7 +41,7 @@
     },
     {
       "case_name": "People of the State of New York v. City Of New York",
-      "date_filed": "2022-09-29",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-09-29",
@@ -59,7 +59,7 @@
     },
     {
       "case_name": "Sierra v. City of New York",
-      "date_filed": "2022-09-29",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-09-29",
@@ -77,7 +77,7 @@
     },
     {
       "case_name": "Gray v. City of New York",
-      "date_filed": "2022-09-29",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-09-29",

--- a/tests/examples/pacer/nef/s3/nysd_4.json
+++ b/tests/examples/pacer/nef/s3/nysd_4.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "IN RE: NEW YORK CITY POLICING DURING SUMMER 2020 DEMONSTRATIONS",
-      "date_filed": "2022-09-12",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-09-12",
@@ -23,7 +23,7 @@
     },
     {
       "case_name": "Wood v. De Blasio",
-      "date_filed": "2022-09-12",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-09-12",

--- a/tests/examples/pacer/nef/s3/nysd_5.json
+++ b/tests/examples/pacer/nef/s3/nysd_5.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "IN RE: NEW YORK CITY POLICING DURING SUMMER 2020 DEMONSTRATIONS",
-      "date_filed": "2022-10-18",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-18",
@@ -23,7 +23,7 @@
     },
     {
       "case_name": "Wood v. De Blasio",
-      "date_filed": "2022-10-18",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-18",

--- a/tests/examples/pacer/nef/s3/ohnd_1.json
+++ b/tests/examples/pacer/nef/s3/ohnd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "In Re: Sonic Corp. Customer Data Security Breach",
-      "date_filed": "2022-08-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-08",

--- a/tests/examples/pacer/nef/s3/ohsd_2.json
+++ b/tests/examples/pacer/nef/s3/ohsd_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Roe v. University Of Cincinnati",
-      "date_filed": "2022-08-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-08",

--- a/tests/examples/pacer/nef/s3/oknd_1.json
+++ b/tests/examples/pacer/nef/s3/oknd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Wilson v. Filtrex Service Group Inc",
-      "date_filed": "2021-08-09",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-09",

--- a/tests/examples/pacer/nef/s3/pawb_2.json
+++ b/tests/examples/pacer/nef/s3/pawb_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "U LOCK INC",
-      "date_filed": "2023-01-24",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-01-24",

--- a/tests/examples/pacer/nef/s3/pawb_3.json
+++ b/tests/examples/pacer/nef/s3/pawb_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Daniel J. Adamson",
-      "date_filed": "2023-02-27",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-02-27",

--- a/tests/examples/pacer/nef/s3/pawb_4.json
+++ b/tests/examples/pacer/nef/s3/pawb_4.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Moses Dolz",
-      "date_filed": "2023-01-24",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2023-01-24",

--- a/tests/examples/pacer/nef/s3/txnd_1.json
+++ b/tests/examples/pacer/nef/s3/txnd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Caulkins v. Ditmore",
-      "date_filed": "2021-08-16",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-16",

--- a/tests/examples/pacer/nef/s3/txsd_1.json
+++ b/tests/examples/pacer/nef/s3/txsd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "United States of America, ex rel v. Merida Health Care Group",
-      "date_filed": "2022-08-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-08-10",

--- a/tests/examples/pacer/nef/s3/txwd_1.json
+++ b/tests/examples/pacer/nef/s3/txwd_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Segovia v. Fuelco Energy LLC",
-      "date_filed": "2021-06-25",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-25",

--- a/tests/examples/pacer/nef/s3/txwd_2.json
+++ b/tests/examples/pacer/nef/s3/txwd_2.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Fenwick v. Amistad Homecare, Inc.",
-      "date_filed": "2021-07-07",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-07-07",

--- a/tests/examples/pacer/nef/s3/txwd_3.json
+++ b/tests/examples/pacer/nef/s3/txwd_3.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Ginger Beeler v. Colonial Management Group, L.P.",
-      "date_filed": "2021-07-08",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-07-08",

--- a/tests/examples/pacer/nef/s3/txwd_4.json
+++ b/tests/examples/pacer/nef/s3/txwd_4.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Didler v. Maofu Home Health Care Services Incorporated",
-      "date_filed": "2021-08-11",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-11",

--- a/tests/examples/pacer/nef/s3/txwd_5.json
+++ b/tests/examples/pacer/nef/s3/txwd_5.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Collins v. Pel-State Bulk Plant, LLC",
-      "date_filed": "2021-08-09",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-09",

--- a/tests/examples/pacer/nef/s3/txwd_6.json
+++ b/tests/examples/pacer/nef/s3/txwd_6.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Tanis v. Austin Private Car Service, Corp.",
-      "date_filed": "2021-08-11",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-08-11",

--- a/tests/examples/pacer/nef/s3/txwd_7.json
+++ b/tests/examples/pacer/nef/s3/txwd_7.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Lionra Technologies Limited v. Apple Inc.",
-      "date_filed": "2022-10-05",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-05",

--- a/tests/examples/pacer/nef/s3/vaed_1.json
+++ b/tests/examples/pacer/nef/s3/vaed_1.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Glover and Pridemore v. Hryniewich",
-      "date_filed": "2022-10-05",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2022-10-05",

--- a/tests/examples/pacer/nef/txed.json
+++ b/tests/examples/pacer/nef/txed.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Alexander v. Clean Shot, LLC",
-      "date_filed": "2021-06-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-10",

--- a/tests/examples/pacer/nef/txnd.json
+++ b/tests/examples/pacer/nef/txnd.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Sanchez v. Palacios",
-      "date_filed": "2021-06-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-10",

--- a/tests/examples/pacer/nef/txwd.json
+++ b/tests/examples/pacer/nef/txwd.json
@@ -5,7 +5,7 @@
   "dockets": [
     {
       "case_name": "Newsome, Jr. v. QES Pressure Control, LLC",
-      "date_filed": "2021-06-10",
+      "date_filed": null,
       "docket_entries": [
         {
           "date_filed": "2021-06-10",


### PR DESCRIPTION
As described in https://github.com/freelawproject/courtlistener/issues/3449

The case's `date_filed` was previously being populated with the entry `date_filed` from emails. 
In this PR the case's `date_filed` is set to None, since it's not available in NEFS or NDAs.