### PR TITLE
fix(cadc_pi): Fixed InvalidURL error

### DIFF
--- a/juriscraper/opinions/united_states/federal_appellate/cadc_pi.py
+++ b/juriscraper/opinions/united_states/federal_appellate/cadc_pi.py
@@ -4,8 +4,9 @@ Court Short Name: Court of Appeals of the District of Columbia
 Author: flooie
 History:
   2021-12-18: Created by flooie
+  2023-01-12: Fixed requests.exceptions.InvalidURL error by grossir
 """
-
+from urllib.parse import urljoin
 
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
@@ -17,7 +18,7 @@ class Site(OpinionSiteLinear):
         self.base = "https://www.cadc.uscourts.gov"
         self.court_id = self.__module__
 
-    def _process_html(self):
+    def _process_html(self) -> None:
         """Iterate over the public interest cases.
 
         :return: None
@@ -32,7 +33,7 @@ class Site(OpinionSiteLinear):
             self.cases.append(
                 {
                     "date": date,
-                    "url": f"https:{url}",
+                    "url": urljoin("https:", url),
                     "docket": docket,
                     "name": name,
                     "status": "Published",


### PR DESCRIPTION
Error was surfacing on Courtlistener when trying to get the download_url of scraped items
Problem was a duplication of https protocol inserted on parsing code `https:https://`
This was useful in the past, causing errors now. Still, code is adapted in case it changes back to the old format

Solves: #817 