### PR TITLE
819 update ssl adapter

### DIFF
--- a/juriscraper/lib/network_utils.py
+++ b/juriscraper/lib/network_utils.py
@@ -1,27 +1,26 @@
 import random
+import ssl
 import time
 
 from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.poolmanager import PoolManager
+from urllib3.util.ssl_ import create_urllib3_context
 
 from juriscraper.AbstractSite import logger
 
 
 class SSLAdapter(HTTPAdapter):
-    """An HTTPS Transport Adapter that uses an arbitrary SSL version."""
-
-    def __init__(self, ssl_version=None, **kwargs):
-        self.ssl_version = ssl_version
-
+    def __init__(
+        self, ssl_version=ssl.PROTOCOL_TLSv1_2, ciphers=None, **kwargs
+    ):
+        self.ssl_version = ssl_version or ssl.PROTOCOL_TLS
+        self.ssl_context = create_urllib3_context(
+            ssl_version=self.ssl_version, ciphers=ciphers
+        )
         super().__init__(**kwargs)
 
-    def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = PoolManager(
-            num_pools=connections,
-            maxsize=maxsize,
-            block=block,
-            ssl_version=self.ssl_version,
-        )
+    def init_poolmanager(self, *args, **kwargs):
+        kwargs["ssl_context"] = self.ssl_context
+        return super().init_poolmanager(*args, **kwargs)
 
 
 def add_delay(delay=0, deviation=0):

--- a/juriscraper/opinions/united_states/state/calag.py
+++ b/juriscraper/opinions/united_states/state/calag.py
@@ -5,6 +5,7 @@ Court Short Name: California Attorney General
 
 import datetime
 
+from juriscraper.lib.network_utils import SSLAdapter
 from juriscraper.lib.string_utils import convert_date_string
 from juriscraper.OpinionSite import OpinionSite
 
@@ -19,6 +20,16 @@ class Site(OpinionSite):
         self.back_scrape_iterable = list(range(1985, self.year + 1))
         self.rows_path = '//tbody/tr[contains(./td[1]//a/@href, ".pdf")]'
         self.cell_path = f"{self.rows_path}/td[%d]"
+        self._mount_ssl_adapter()
+
+    def _mount_ssl_adapter(self):
+        """Configures and mounts an SSL adapter to a given session
+
+        :return: None
+        """
+        self.request["session"].mount(
+            "https://", SSLAdapter(ciphers="ECDHE-RSA-AES128-GCM-SHA256")
+        )
 
     def _get_case_names(self):
         """No case names available"""

--- a/juriscraper/opinions/united_states/state/conn.py
+++ b/juriscraper/opinions/united_states/state/conn.py
@@ -16,6 +16,7 @@ History:
 import re
 from datetime import date
 
+from juriscraper.lib.network_utils import SSLAdapter
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
@@ -26,27 +27,75 @@ class Site(OpinionSiteLinear):
         self.year = date.today().strftime("%y")
         self.url = f"http://www.jud.ct.gov/external/supapp/archiveAROsup{self.year}.htm"
         self.status = "Published"
+        self._mount_ssl_adapter()
+
+    def _mount_ssl_adapter(self):
+        """Configures and mounts an SSL adapter to a given session
+
+        :return: None
+        """
+        self.request["session"].mount(
+            "https://", SSLAdapter(ciphers="AES256-SHA256")
+        )
+
+    def fetch_docket_numbers(self, text):
+        """Find docket numbers in row
+
+        :param text: the row text
+        :return: return a list of docket numbers matches
+        """
+        matches = re.findall(r"SC\d+", text)
+        return matches
+
+    def make_case_name(self, cleaned_text, url):
+        """Generate the case name identifying opinion type
+
+        :param cleaned_text: the row text without excess whitespace
+        :param url: the url of the document
+        :return: Update case name
+        """
+        name = cleaned_text.split("-", 1)[1].strip()
+        if url[-5].upper() == "A":
+            name = f"{name} (Concurrence)"
+        elif url[-5].upper() == "B":
+            name = f"{name} (Second Concurrence)"
+        elif url[-5].upper() == "E":
+            name = f"{name} (Dissent)"
+        return name.strip()
 
     def _process_html(self) -> None:
         """Process the html and extract out the opinions
 
         :return: None
         """
-        for row in self.html.xpath("//ul/preceding-sibling::p"):
-            if "Published in the Law Journal" not in row.text_content():
+        begin = False
+        date = None
+        for row in self.html.xpath(
+            "//table[@id='AutoNumber1']//*[text() and not(./*[text()])]"
+        ):
+            if "Published" in row.text_content():
+                begin = True
+            if not begin:
                 continue
-            date = row.text_content().split(" ")[-1][:-1]
-            for document in row.xpath("following-sibling::ul[1]/li"):
-                output_string = re.sub(
-                    r"\s{2,}", " ", document.text_content()
-                ).strip()
-                name = output_string.split("-")[-1].strip()
-                docket = document.xpath(".//a")[0].text_content().split()[0]
+            if "Published" in row.text_content():
+                date = row.text_content().split("of")[-1][:-1].strip()
+                continue
+            if row.text_content().strip() == "Return to Top":
+                return
+            if row.tag == "a":
+                url = row.get("href")
+                text = row.getparent().text_content().strip()
+                cleaned_text = re.sub(r"\s+", " ", text)
+                name = self.make_case_name(cleaned_text, url)
+                docket = self.fetch_docket_numbers(cleaned_text)
+
+                if not date:
+                    continue
                 self.cases.append(
                     {
                         "date": date,
-                        "url": document.xpath(".//a")[0].get("href"),
-                        "docket": docket,
+                        "url": url,
+                        "docket": ",".join(docket),
                         "name": name,
                     }
                 )

--- a/juriscraper/opinions/united_states/state/connappct.py
+++ b/juriscraper/opinions/united_states/state/connappct.py
@@ -10,6 +10,7 @@ History:
 
 from datetime import date
 
+from juriscraper.lib.network_utils import SSLAdapter
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
@@ -20,6 +21,16 @@ class Site(OpinionSiteLinear):
         self.year = date.today().strftime("%y")
         self.url = f"http://www.jud.ct.gov/external/supapp/archiveAROap{self.year}.htm"
         self.status = "Published"
+        self._mount_ssl_adapter()
+
+    def _mount_ssl_adapter(self):
+        """Configures and mounts an SSL adapter to a given session
+
+        :return: None
+        """
+        self.request["session"].mount(
+            "https://", SSLAdapter(ciphers="AES256-SHA256")
+        )
 
     def _process_html(self) -> None:
         """Process the html and extract out the opinions

--- a/juriscraper/opinions/united_states/state/lactapp_1.py
+++ b/juriscraper/opinions/united_states/state/lactapp_1.py
@@ -8,11 +8,13 @@ History:
 
 import math
 import re
+import ssl
 
 from juriscraper.lib.html_utils import (
     get_row_column_links,
     get_row_column_text,
 )
+from juriscraper.lib.network_utils import SSLAdapter
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
@@ -30,6 +32,16 @@ class Site(OpinionSiteLinear):
         # (Unpublished cases have "Not Designated For Publication" on
         # the cover page.)
         self.status = "Unknown"
+        self._mount_ssl_adapter()
+
+    def _mount_ssl_adapter(self):
+        """Configures and mounts an SSL adapter to a given session
+
+        :return: None
+        """
+        self.request["session"].mount(
+            "https://", SSLAdapter(ciphers="AES128-SHA")
+        )
 
     def _process_html(self):
         for row in self.html.cssselect("#opinion_contentTable tbody tr"):

--- a/juriscraper/opinions/united_states_backscrapers/federal_appellate/cadc.py
+++ b/juriscraper/opinions/united_states_backscrapers/federal_appellate/cadc.py
@@ -1,10 +1,8 @@
-import ssl
 import time
 from datetime import date
 
 from dateutil.rrule import MONTHLY, rrule
 
-from juriscraper.lib.network_utils import SSLAdapter
 from juriscraper.OpinionSite import OpinionSite
 
 
@@ -21,14 +19,6 @@ class Site(OpinionSite):
                 until=date(2015, 1, 1),
             )
         ]
-
-    def _get_adapter_instance(self):
-        """Unfortunately this court doesn't support modern crypto, so you have
-        to manually downgrade the crypto it uses.
-
-        See: http://stackoverflow.com/questions/14102416/
-        """
-        return SSLAdapter(ssl_version=ssl.PROTOCOL_TLSv1)
 
     def _get_case_names(self):
         return [

--- a/tests/examples/opinions/united_states/conn_example.compare.json
+++ b/tests/examples/opinions/united_states/conn_example.compare.json
@@ -11,7 +11,7 @@
   },
   {
     "case_dates": "2023-10-17",
-    "case_names": "Ahmed v. Oak Management Corp.",
+    "case_names": "Ahmed v. Oak Management Corp. (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR348/348CR40E.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -41,7 +41,7 @@
   },
   {
     "case_dates": "2023-09-26",
-    "case_names": "Salce v. Cardello",
+    "case_names": "Salce v. Cardello (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR348/348CR67E.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -61,23 +61,23 @@
   },
   {
     "case_dates": "2023-09-19",
-    "case_names": "State v. Robles",
+    "case_names": "State v. Robles (Second Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR348/348CR46B.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "SC20452",
-    "case_name_shorts": "Robles"
+    "case_name_shorts": ""
   },
   {
     "case_dates": "2023-09-19",
-    "case_names": "State v. Robles",
+    "case_names": "State v. Robles (Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR348/348CR46A.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "SC20452",
-    "case_name_shorts": "Robles"
+    "case_name_shorts": ""
   },
   {
     "case_dates": "2023-09-19",
@@ -91,7 +91,7 @@
   },
   {
     "case_dates": "2023-09-19",
-    "case_names": "State v. Butler",
+    "case_names": "State v. Butler (Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR348/348CR54A.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -111,13 +111,13 @@
   },
   {
     "case_dates": "2023-09-12",
-    "case_names": "Mattos",
+    "case_names": "State v. Velasquez-Mattos",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR347/347CR53.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "SC20683",
-    "case_name_shorts": "Mattos"
+    "case_name_shorts": "Velasquez-Mattos"
   },
   {
     "case_dates": "2023-09-05",
@@ -141,7 +141,7 @@
   },
   {
     "case_dates": "2023-08-29",
-    "case_names": "Commissioner of Mental Health & Addiction Services v. Freedom of Information Commission",
+    "case_names": "Commissioner of Mental Health & Addiction Services v. Freedom of Information Commission (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR347/347CR48E.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -151,7 +151,7 @@
   },
   {
     "case_dates": "2023-08-29",
-    "case_names": "Commissioner of Mental Health & Addiction Services v. Freedom of Information Commission",
+    "case_names": "Commissioner of Mental Health & Addiction Services v. Freedom of Information Commission (Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR347/347CR48A.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -181,23 +181,23 @@
   },
   {
     "case_dates": "2023-08-22",
-    "case_names": "Santana v. State",
+    "case_names": "Escobar-Santana v. State (Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR347/347CR60A.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "SC20772",
-    "case_name_shorts": "Santana"
+    "case_name_shorts": "Escobar-Santana"
   },
   {
     "case_dates": "2023-08-22",
-    "case_names": "Santana v. State",
+    "case_names": "Escobar-Santana v. State",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR347/347CR60.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "SC20772",
-    "case_name_shorts": "Santana"
+    "case_name_shorts": "Escobar-Santana"
   },
   {
     "case_dates": "2023-08-15",
@@ -206,7 +206,7 @@
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "SC20763",
+    "docket_numbers": "SC20763,SC20764,SC20765",
     "case_name_shorts": "Mills"
   },
   {
@@ -216,12 +216,12 @@
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "SC20767",
+    "docket_numbers": "SC20767,SC20768",
     "case_name_shorts": "Manginelli"
   },
   {
     "case_dates": "2023-08-08",
-    "case_names": "Schoenhorn v. Moss",
+    "case_names": "Schoenhorn v. Moss (Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR347/347CR55A.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -311,7 +311,7 @@
   },
   {
     "case_dates": "2023-07-25",
-    "case_names": "Bosque v. Commissioner of Correction",
+    "case_names": "Bosque v. Commissioner of Correction (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR347/347CR42E.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -331,7 +331,7 @@
   },
   {
     "case_dates": "2023-07-25",
-    "case_names": "Banks v. Commissioner of Correction",
+    "case_names": "Banks v. Commissioner of Correction (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR347/347CR41E.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -376,7 +376,7 @@
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "SC20669",
+    "docket_numbers": "SC20669,SC20674",
     "case_name_shorts": ""
   },
   {
@@ -431,13 +431,13 @@
   },
   {
     "case_dates": "2023-06-27",
-    "case_names": "Commission on Human Rights & Opportunities v. Cantillon",
+    "case_names": "Commission on Human Rights & Opportunities v. Cantillon (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR347/347CR34E.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "SC20655",
-    "case_name_shorts": "Cantillon"
+    "case_name_shorts": ""
   },
   {
     "case_dates": "2023-06-27",
@@ -461,7 +461,7 @@
   },
   {
     "case_dates": "2023-06-20",
-    "case_names": "Cohen v. Rossi",
+    "case_names": "Cohen v. Rossi (Second Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR346/346CR31B.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -471,7 +471,7 @@
   },
   {
     "case_dates": "2023-06-20",
-    "case_names": "Cohen v. Rossi",
+    "case_names": "Cohen v. Rossi (Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR346/346CR31A.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -491,7 +491,7 @@
   },
   {
     "case_dates": "2023-06-20",
-    "case_names": "Clark v. Waterford, Cohanzie Fire Dept.",
+    "case_names": "Clark v. Waterford, Cohanzie Fire Dept. (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR346/346CR33E.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -561,13 +561,13 @@
   },
   {
     "case_dates": "2023-05-09",
-    "case_names": "Smith v. Supple",
+    "case_names": "Smith v. Supple (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR346/ord346_13e.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "SC20730",
-    "case_name_shorts": "Supple"
+    "case_name_shorts": ""
   },
   {
     "case_dates": "2023-05-09",
@@ -581,7 +581,7 @@
   },
   {
     "case_dates": "2023-05-09",
-    "case_names": "Robinson v. V. D.",
+    "case_names": "Robinson v. V. D. (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR346/ord346_14e.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -601,12 +601,12 @@
   },
   {
     "case_dates": "2023-05-09",
-    "case_names": "Pryor v. Brignole",
+    "case_names": "Pryor v. Brignole (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR346/346CR25E.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "SC20581",
+    "docket_numbers": "SC20581,SC20583",
     "case_name_shorts": "Pryor"
   },
   {
@@ -616,7 +616,7 @@
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "SC20581",
+    "docket_numbers": "SC20581,SC20583",
     "case_name_shorts": "Pryor"
   },
   {
@@ -676,12 +676,12 @@
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "SC20635",
+    "docket_numbers": "SC20635,SC20637,SC20636",
     "case_name_shorts": ""
   },
   {
     "case_dates": "2023-03-21",
-    "case_names": "Dunn v. Northeast Helicopters Flight Services, LLC",
+    "case_names": "Dunn v. Northeast Helicopters Flight Services, LLC (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR346/346CR19E.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -781,13 +781,13 @@
   },
   {
     "case_dates": "2023-02-14",
-    "case_names": "P.",
+    "case_names": "State v. Juan A. G.-P.",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR346/346CR10.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "SC20164",
-    "case_name_shorts": "P."
+    "case_name_shorts": ""
   },
   {
     "case_dates": "2023-02-14",
@@ -841,23 +841,23 @@
   },
   {
     "case_dates": "2023-01-24",
-    "case_names": "State v. Brandon",
+    "case_names": "State v. Brandon (Dissent)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR345/345CR63E.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "SC20371",
-    "case_name_shorts": "Brandon"
+    "case_name_shorts": ""
   },
   {
     "case_dates": "2023-01-24",
-    "case_names": "State v. Brandon",
+    "case_names": "State v. Brandon (Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR345/345CR63A.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "SC20371",
-    "case_name_shorts": "Brandon"
+    "case_name_shorts": ""
   },
   {
     "case_dates": "2023-01-24",
@@ -891,7 +891,7 @@
   },
   {
     "case_dates": "2023-01-17",
-    "case_names": "State v. James A.",
+    "case_names": "State v. James A. (Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR345/345CR75A.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -921,7 +921,7 @@
   },
   {
     "case_dates": "2023-01-10",
-    "case_names": "State v. Joseph V.",
+    "case_names": "State v. Joseph V. (Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR345/345CR54A.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
@@ -941,7 +941,7 @@
   },
   {
     "case_dates": "2023-01-10",
-    "case_names": "State v. Douglas C.",
+    "case_names": "State v. Douglas C. (Concurrence)",
     "download_urls": "tests/examples/opinions/united_states/Cases/AROcr/CR345/345CR55A.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,


### PR DESCRIPTION
This update address issue #819 

We had an SSL adapter method that was not being used by anything so I updated it 
to be used by `lactapp_1`, `conn`, `connctapp`, and `calag`.

I also updated Connecticut Supreme to work for the random changes to the 2024 page they made.