### PR TITLE
feat(opinion_types): Add support for opinion types

### DIFF
--- a/juriscraper/OpinionSite.py
+++ b/juriscraper/OpinionSite.py
@@ -31,6 +31,7 @@ class OpinionSite(AbstractSite):
             "summaries",
             "case_name_shorts",
             "child_courts",
+            "opinion_types",
         ]
         self._req_attrs = [
             "case_dates",
@@ -110,6 +111,9 @@ class OpinionSite(AbstractSite):
         return None
 
     def _get_child_courts(self):
+        return None
+
+    def _get_opinion_types(self):
         return None
 
     def extract_from_text(self, scraped_text):

--- a/juriscraper/lib/models.py
+++ b/juriscraper/lib/models.py
@@ -8,3 +8,18 @@ citation_types = {
     "WEST": 7,
     "NEUTRAL": 8,
 }
+
+
+class OpinionType:
+    COMBINED = "010combined"
+    UNANIMOUS = "015unamimous"
+    LEAD = "020lead"
+    PLURALITY = "025plurality"
+    CONCURRENCE = "030concurrence"
+    CONCUR_IN_PART = "035concurrenceinpart"
+    DISSENT = "040dissent"
+    ADDENDUM = "050addendum"
+    REMITTUR = "060remittitur"
+    REHEARING = "070rehearing"
+    ON_THE_MERITS = "080onthemerits"
+    ON_MOTION_TO_STRIKE = "090onmotiontostrike"


### PR DESCRIPTION
Modeling the types we have in Courtlistener, we should be able to add opinion types if not default Combined Opinions

This should allow us to caputre multiple opinion types and let courtlistener group them together when it occurs in the handful of courts we know about.

