### PR TITLE
fix(pacer.email): _parse_bankruptcy_short_description

### DIFF
--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -542,7 +542,7 @@ class NotificationEmail(BaseDocketReport, BaseReport):
             # Remove docket number traces "-AAA"
             regex = r"^-.*?\s"
             short_description = re.sub(regex, "", short_description)
-        elif self.court_id in ["njb", "dcb", "vaeb","paeb"]:
+        elif self.court_id in ["njb", "dcb", "vaeb", "paeb"]:
             # In: Ch-11 19-27439-MBK Determination of Adjournment Request - Hollister Construc
             # Out: Determination of Adjournment Request
             short_description = subject.split(docket_number)[-1]
@@ -550,8 +550,8 @@ class NotificationEmail(BaseDocketReport, BaseReport):
             # Remove CH after docket and BK after short description for dcb
             regex = r"^-.*?\s|C[Hh][\s\d]+|[ (]?B[Kk]( Other)?[) ]?"
             short_description = re.sub(regex, "", short_description)
-            short_description = short_description.rsplit("-", 1)[0]            
-        elif self.court_id  == "nysb":
+            short_description = short_description.rsplit("-", 1)[0]
+        elif self.court_id == "nysb":
             # In: 22-22507-cgm Ch13 Affidavit Re: Gerasimos Stefanitsis
             # Out: Affidavit
             short_description = subject.split(case_name)[0]

--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -516,10 +516,9 @@ class NotificationEmail(BaseDocketReport, BaseReport):
         :param subject: The email subject string.
         :return: The parsed short description.
         """
-
         if len(self.docket_numbers) > 1:
-            # Since we don't have examples for bankruptcy multi docket NEF.
-            # No short_description parsing support yet.
+            # We haven't implemented short_description parsing for bankruptcy multi docket NEF.
+            # See paeb_3.txt for a test of multi docket NEF
             logger.error(
                 "Not parsing description for Bankruptcy Multi Docket NEF for court '%s'",
                 self.court_id,
@@ -535,7 +534,7 @@ class NotificationEmail(BaseDocketReport, BaseReport):
         docket_number = self.docket_numbers[0]
         case_name = self.case_names[0]
 
-        if self.court_id in ["cacb", "ctb", "cob"]:
+        if self.court_id in ["cacb", "ctb", "cob", "ianb"]:
             # In: 6:22-bk-13643-SY Request for courtesy Notice of Electronic Filing (NEF)
             # Out: Request for courtesy Notice of Electronic Filing (NEF)
             short_description = subject.split(docket_number)[-1]
@@ -543,18 +542,16 @@ class NotificationEmail(BaseDocketReport, BaseReport):
             # Remove docket number traces "-AAA"
             regex = r"^-.*?\s"
             short_description = re.sub(regex, "", short_description)
-
-        elif self.court_id == "njb":
+        elif self.court_id in ["njb", "dcb", "vaeb","paeb"]:
             # In: Ch-11 19-27439-MBK Determination of Adjournment Request - Hollister Construc
             # Out: Determination of Adjournment Request
             short_description = subject.split(docket_number)[-1]
-            short_description = short_description.rsplit("-", 1)[0]
-
             # Remove docket number traces "-AAA"
-            regex = r"^-.*?\s"
+            # Remove CH after docket and BK after short description for dcb
+            regex = r"^-.*?\s|C[Hh][\s\d]+|[ (]?B[Kk]( Other)?[) ]?"
             short_description = re.sub(regex, "", short_description)
-
-        elif self.court_id == "nysb":
+            short_description = short_description.rsplit("-", 1)[0]            
+        elif self.court_id  == "nysb":
             # In: 22-22507-cgm Ch13 Affidavit Re: Gerasimos Stefanitsis
             # Out: Affidavit
             short_description = subject.split(case_name)[0]
@@ -568,12 +565,10 @@ class NotificationEmail(BaseDocketReport, BaseReport):
             # Remove docket number traces "-AAA"
             regex = r"^-.*?\s"
             short_description = re.sub(regex, "", short_description)
-
-        elif self.court_id == "pawb":
+        elif self.court_id in ["pawb", "ndb"]:
             # In: Ch-7 22-20823-GLT U LOCK INC Reply
             # Out: Reply
             short_description = subject.split(case_name)[-1]
-
         else:
             logger.error(
                 "Short description has no parsing for bankruptcy court '%s'",

--- a/tests/examples/pacer/nef/s3/dcb_1.json
+++ b/tests/examples/pacer/nef/s3/dcb_1.json
@@ -1,0 +1,43 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "dcb",
+  "dockets": [
+    {
+      "case_name": "Avamere NPS Carpenters LLC",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-02-01",
+          "description": "PDF with attached Audio File. Court Date & Time [ 1/31/2024 10:31:49 AM ]. File Size [ 3128 KB ]. Run Time [ 00:06:31 ]. (Audio Duplicate Docket.). (admin).",
+          "document_number": "45",
+          "document_url": "https://ecf.dcb.uscourts.gov/doc1/04402826049?pdf_header=&magic_num=3652693&de_seq_num=130&caseid=49636",
+          "pacer_case_id": "49636",
+          "pacer_doc_id": "04402826049",
+          "pacer_magic_num": "3652693",
+          "pacer_seq_no": "130",
+          "short_description": ""
+        }
+      ],
+      "docket_number": "23-00286"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "Kristen.S.Eustis@usdoj.gov",
+        "Robert.W.Ours@usdoj.gov",
+        "example@domain.com",
+        "example@domain.com;example@domain.com;x.example@domain.com",
+        "sara.kathryn.mayson@usdoj.gov",
+        "Robert.W.Ours@usdoj.gov",
+        "example@domain.com",
+        "example@domain.com;example@domain.com;example@domain.com;example@domain.com;x.example@domain.com",
+        "USTPRegion04.DC.ECF@USDOJ.GOV",
+        "example@domain.com",
+        "example@domain.com;example@domain.com;x.example@domain.com;x@recap.email"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/dcb_1.txt
+++ b/tests/examples/pacer/nef/s3/dcb_1.txt
@@ -1,0 +1,125 @@
+Return-Path: <ecf_dcb@dcb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 6nid5ninai5dc7kqu95qksl1ee927hh98jumsk01
+ for example@domain.com;
+ Fri, 02 Feb 2024 14:06:32 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of dcb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecf_dcb@dcb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of dcb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecf_dcb@dcb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=dcb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFGYkExU2paODBFS2V4WTF1c3p0ckFvUncwWTMrUjZWQ09pZEZwc2ZFWS9JU0xjajFRTjF3SDlERTVia3pQQjFYR0JGRG9FckhnYzNxZ0t2VHZjR0lsaW1SRE80MURqckVjZE13YS9YUllIMm5jeVFlR0V1L2RtVVI3TWdTVit4c0ZRbkFFTDZteE9YSnJaZENabHhPb3o4M01JbUs3eFJveHE0cUFWUlp1UHowL1l1REIyWm9zSEVEYzVtQk1SdmhsY3g4NkpURWgwOGdldWZvdDlHSzdFZzdXWE5FQmMvdnZUNVd4VjhpemNmbHg1aUdGR2hEWG8zYUlqNjg0blY3UkVhcENGTm1EeFo3Z0JrYmF5dDVkb05tMjlVTWRtZjViOWhLTlU1OVJBd1E9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=mNPqgfvh+kAppz8qUtezLtpXIHkyp/Ag7Oe+b+f/qjEJCsjXv6EC1vV77S3RtTJKckppwa/fzSCFrxrxXTxv43IN9lJ2KiZmZSd5mmqZKWEcak+5TVihrZx1YJsKKRTHzseaIWkuTDP8j+4G+uM5Ju4feMQgbe6kNRVqKYxej7k=; c=relaxed/simple; s=hsbnp7p3ensaochzwyq5wwmceodymuwv; d=amazonses.com; t=1706882794; v=1; bh=re1ptExT3cySftvqN3rhnCMD4oa5HCHo8vFtRhJhDkk=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.113
+Received: from dcbdb.dcb.gtwy.dcn ([156.119.190.113])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 02 Feb 2024 09:06:32 -0500
+Received: from dcbdb.dcb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+        by dcbdb.dcb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 412E5jox025787;
+        Fri, 2 Feb 2024 09:05:50 -0500
+Received: (from ecf_web@localhost)
+        by dcbdb.dcb.gtwy.dcn (8.14.7/8.14.4/Submit) id 412E56vw024511;
+        Fri, 2 Feb 2024 09:05:06 -0500
+Date: Fri, 2 Feb 2024 09:05:06 -0500
+X-Authentication-Warning: dcbdb.dcb.gtwy.dcn: ecf_web set sender to ecf_dcb@dcb.uscourts.gov using -f
+MIME-Version:1.0
+From:ecf_dcb@dcb.uscourts.gov
+To:courtmail@dcb.uscourts.gov
+Message-Id:<2731415@dcb.uscourts.gov>
+Subject:23-00286-ELG CH11  - Avamere NPS Carpenters LLC
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>United States Bankruptcy Court for the District of Columbia</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from admin entered on 02/02/2024  at 00:30 AM  EST and filed on 02/01/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Avamere NPS Carpenters LLC                        </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.dcb.uscourts.gov/cgi-bin/DktRpt.pl?49636>23-00286-ELG</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.dcb.uscourts.gov/doc1/04402826049?pdf_header=&magic_num=3652693&de_seq_num=130&caseid=49636'>45</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+PDF with attached Audio File. Court Date & Time [ 1/31/2024 10:31:49 AM ]. File Size [ 3128 KB ]. Run Time [ 00:06:31 ]. (Audio Duplicate Docket.). (admin).
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document
+<BR><STRONG>Original filename:</STRONG>/data/docs0/ECF/ADI/dcb_live/batch/documents/1bk2023-00286_20240131-103149-MP3.pdf
+<BR><STRONG>Electronic document Stamp:</STRONG>
+<BR>[STAMP bkecfStamp_ID=1011211900 [Date=02/02/2024] [FileNumber=2731369-0] [31eb9fcf5d43a65e85abcf1f5f43988876d6ab8b52c3660edd063d5f7beb234904d68bb7fe6e40634543a4dbcca4710a805d7cdd6c8ec75b3956016ac7617076]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+23-00286-ELG Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">Kristen S. Eustis on behalf of U.S. Trustee   U. S. Trustee for Region Four</span>
+<br>Kristen.S.Eustis@usdoj.gov,  Robert.W.Ours@usdoj.gov
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Debtor In Possession   Avamere NPS Carpenters LLC</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;x.example@domain.com
+<BR>
+<BR><span class="personName">Sara Kathryn  Mayson on behalf of U.S. Trustee   U. S. Trustee for Region Four</span>
+<br>sara.kathryn.mayson@usdoj.gov,  Robert.W.Ours@usdoj.gov
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Debtor In Possession   Avamere NPS Carpenters LLC</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;example@domain.com;example@domain.com;x.example@domain.com
+<BR>
+<BR><span class="personName">  U. S. Trustee for Region Four</span>
+<br>USTPRegion04.DC.ECF@USDOJ.GOV
+<BR>
+<BR><span class="personName">Firstnane Lastname on behalf of Creditor   WCP Fund I LLC</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;x.example@domain.com;x@recap.email
+<BR>
+
+<BR>
+<B>
+23-00286-ELG Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR>
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/dcb_2.json
+++ b/tests/examples/pacer/nef/s3/dcb_2.json
@@ -1,0 +1,43 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "dcb",
+  "dockets": [
+    {
+      "case_name": "Avamere NPS Stables LLC",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-01-31",
+          "description": "Minute Entry RE: Hearing Held (BK) (RE: related document(s)[49] Motion to Approve) Appearances: FirstName LastName, FirstName LastName, FirstName LastName. Motion Granted, Order to be Submitted. Hearing on Approval of Disclosure Statement and Confirmation of Plan Set for 3/13/2024 at 1:00 PM. (FirstName LastName)",
+          "document_number": "56",
+          "document_url": null,
+          "pacer_case_id": "49635",
+          "pacer_doc_id": null,
+          "pacer_magic_num": null,
+          "pacer_seq_no": null,
+          "short_description": "Hearing Held"
+        }
+      ],
+      "docket_number": "23-00285"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "Kristen.S.Eustis@usdoj.gov",
+        "Robert.W.Ours@usdoj.gov",
+        "example@domain.com",
+        "example@domain.com;example@domain.com;example@domain.com",
+        "sara.kathryn.mayson@usdoj.gov",
+        "Robert.W.Ours@usdoj.gov",
+        "example@domain.com",
+        "example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com",
+        "USTPRegion04.DC.ECF@USDOJ.GOV",
+        "example@domain.com",
+        "example@domain.com;example@domain.com;example@domain.com;c@recap.email"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/dcb_2.txt
+++ b/tests/examples/pacer/nef/s3/dcb_2.txt
@@ -1,0 +1,120 @@
+Return-Path: <ecf_dcb@dcb.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id qeihvdi4sjibug8fnhbarm8jfieiphc880gr5301
+ for example@domain.com;
+ Thu, 01 Feb 2024 21:15:29 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of dcb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=ecf_dcb@dcb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of dcb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=ecf_dcb@dcb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=dcb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFUklMM0xUUUNKbmthcXVCZnM3Qk0rSWZ0bXBjVmxsQmVzTWhjVWlESThzSEhjWXlyUUpjKytoQmxaVWhZdGJMQVlpMzJpWFNEdVpXQittcFgwOC9OaFNMSEpQOXBxSGl5S2wzbkJsRm1qMVhwOFJHeHcyckJ5S2Q5dGhDQTFZZHdVQ0dldXRYaFQ3TU8rRlFHRkZlNUZqeit6QnJHTzI4VHB5U1lySlYyTkZxQWlhbGhNZVQxNnh0WVM3Ky9ac0prQlNscy9ZMlNrM0JhWkdhSHJNdjVPbnB3RW5RajRndEtCVTVnV2xkVUhKVWdheUZaci9UbGNvcjRkZkZQeWdvZ0V1Y0xITzRaUzBVUjk2UW1Edk1qWVRwSjJWUmVueXlRUEhhN1FFSzVtR3c9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=OoHr3CMz78YBMWx5FNZGJ6iYNvxV8vj9+R//KOgpmwWEwpzRh6zhI7JQT/cAriCffdJN/LUjmd91uDqFBiFq1GZRkoYXCHNjajpZ5UG5VxRcEH2EBzWRFLwLVxNb5JgSO1kMSXl+HYgHtxjUtjL8cMpJHgvTSEgfPrEYbYdgTy4=; c=relaxed/simple; s=hsbnp7p3ensaochzwyq5wwmceodymuwv; d=amazonses.com; t=1706822130; v=1; bh=5B9UPv+HsO8o5ByrK5/3gZ81Q0yGpBqdUo5nYk2F1v0=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.113
+Received: from dcbdb.dcb.gtwy.dcn ([156.119.190.113])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 01 Feb 2024 16:15:29 -0500
+Received: from dcbdb.dcb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+        by dcbdb.dcb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 411LEibh102749;
+        Thu, 1 Feb 2024 16:14:44 -0500
+Received: (from ecf_web@localhost)
+        by dcbdb.dcb.gtwy.dcn (8.14.7/8.14.4/Submit) id 411LE4Gf102139;
+        Thu, 1 Feb 2024 16:14:04 -0500
+Date: Thu, 1 Feb 2024 16:14:04 -0500
+X-Authentication-Warning: dcbdb.dcb.gtwy.dcn: ecf_web set sender to ecf_dcb@dcb.uscourts.gov using -f
+MIME-Version:1.0
+From:ecf_dcb@dcb.uscourts.gov
+To:courtmail@dcb.uscourts.gov
+Message-Id:<2731273@dcb.uscourts.gov>
+Subject:23-00285-ELG CH11 Hearing Held (BK) - Avamere NPS Stables LLC
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>United States Bankruptcy Court for the District of Columbia</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Mathewes, Aimee entered on 2/1/2024 at 4:14 PM EST and filed on 1/31/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Avamere NPS Stables LLC                           </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.dcb.uscourts.gov/cgi-bin/DktRpt.pl?49635>23-00285-ELG</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+56
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Minute Entry RE: Hearing Held (BK) (RE: related document(s)[49] Motion to Approve)  Appearances: FirstName LastName, FirstName LastName, FirstName LastName. Motion Granted, Order to be Submitted. Hearing on Approval of Disclosure Statement and Confirmation of Plan Set for 3/13/2024 at 1:00 PM. (FirstName LastName)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+23-00285-ELG Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">Kristen S. Eustis on behalf of U.S. Trustee   U. S. Trustee for Region Four</span>
+<br>Kristen.S.Eustis@usdoj.gov,  Robert.W.Ours@usdoj.gov
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Debtor In Possession   Avamere NPS Stables LLC</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;example@domain.com
+<BR>
+<BR><span class="personName">Sara Kathryn  Mayson on behalf of U.S. Trustee   U. S. Trustee for Region Four</span>
+<br>sara.kathryn.mayson@usdoj.gov,  Robert.W.Ours@usdoj.gov
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Debtor In Possession   Avamere NPS Stables LLC</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com
+<BR>
+<BR><span class="personName">  U. S. Trustee for Region Four</span>
+<br>USTPRegion04.DC.ECF@USDOJ.GOV
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Creditor   WCP Fund I LLC</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;example@domain.com;c@recap.email
+<BR>
+
+<BR>
+<B>
+23-00285-ELG Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR>
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/ianb.json
+++ b/tests/examples/pacer/nef/s3/ianb.json
@@ -1,0 +1,37 @@
+{
+  "appellate": false,
+  "contains_attachments": true,
+  "court_id": "ianb",
+  "dockets": [
+    {
+      "case_name": "Mercy Hospital, Iowa City, Iowa",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-02-01",
+          "description": "Motion for Relief from Stay . Fee Amount $199. Filed by Corporation (Attachments: (1) Proposed Order (2) Ex. A - Account Statement (3) Ex. B - Exposure Statement (4) Ex. C - Credit App.(Redacted)) (FirstName LastName)",
+          "document_number": "701",
+          "document_url": "https://ecf.ianb.uscourts.gov/doc1/07404369078?pdf_header=&magic_num=82978176&de_seq_num=2927&caseid=108151",
+          "pacer_case_id": "108151",
+          "pacer_doc_id": "07404369078",
+          "pacer_magic_num": "82978176",
+          "pacer_seq_no": "2927",
+          "short_description": "Motion for Relief From Stay (Fee)"
+        }
+      ],
+      "docket_number": "23-00623"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "example@domain.com",
+        "example@domain.com;example@domain.com",
+        "example@domain.com",
+        "example@domain.com",
+        "example@domain.com"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/ianb.txt
+++ b/tests/examples/pacer/nef/s3/ianb.txt
@@ -1,0 +1,158 @@
+Return-Path: <cmecf@ianb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 1tmqk3g6ndpmjqadf44bqog0eub2fjnqlckbn181
+ for c@recap.email;
+ Thu, 01 Feb 2024 23:27:01 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ianb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=cmecf@ianb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ianb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=cmecf@ianb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ianb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFIVFF4TnN1d2F0djZjRHl1aW1yK1dKVlpZaVR0WVpyMEZycC92a1ZlTGN0V1pkRlpKREFYdDZRdmh0akt1NDIvdklDa2crZWxZUkdUOFRlMzdMOHJIT0s0d3lLcS9OWDNqSS9hQVN1WkY0Q2l1QkM5TFFVRTQxc0FyZklKMlQ5OWZWd3JKNEMyQU9rTXFaWjl2VEtxTmJHWk1yZ0ZxR1o2bGsrRE82czBBeUJsUEhqeGt4U1lieUVmOTdrbmxEWEFNYVZ6VVBXN1lPdGVsbjhxdU0rbHBhMTU5OGQ5MkxMN3RnSlh3K2pockZsWElmcjNRT1ZBLzVBT1htMGxwWmE3MkFWYWxXaUxFRmd1bnlmdkh6MVJ5V2FDV1FYUXVPbGxkNTNENkg3U0NORlE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=Qppdb3D73icpIXvE6NyDjUdpHje8yYVJsTj8+uTqi4mybZEFK9iTKrZjRVp6S8RchG5oK2FEO8GPcM3I7HijQsDRstfdujlNdd/iO3meCnS/TWg32w51DMz83EdjugxCWk72gM86n6JXi2Y+bLAOT6zZwa5jLFaYnyKImZu+N+k=; c=relaxed/simple; s=hsbnp7p3ensaochzwyq5wwmceodymuwv; d=amazonses.com; t=1706830022; v=1; bh=gEzNZ6L3Hw1Ba5D1lLWDBu4bj17bUlN3Wxp94ShZhnc=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.193.116
+Received: from ianbdb-rep.ianb.gtwy.dcn ([156.119.193.116])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 01 Feb 2024 18:27:00 -0500
+Received: from ianbdb-rep.ianb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+        by ianbdb-rep.ianb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 411NQDxf102231;
+        Thu, 1 Feb 2024 17:26:24 -0600
+Received: (from ecf_web@localhost)
+        by ianbdb-rep.ianb.gtwy.dcn (8.14.7/8.14.4/Submit) id 411NQ61V101387;
+        Thu, 1 Feb 2024 17:26:06 -0600
+Date: Thu, 1 Feb 2024 17:26:06 -0600
+X-Authentication-Warning: ianbdb-rep.ianb.gtwy.dcn: ecf_web set sender to cmecf@ianb.uscourts.gov using -f
+MIME-Version:1.0
+From:cmecf@ianb.uscourts.gov
+To:courtmail@ianb.uscourts.gov
+Message-Id:<4477685@ianb.uscourts.gov>
+Subject:23-00623 Motion for Relief From Stay (Fee)
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>United States Bankruptcy Court</strong></p>
+
+<p align=center><strong>Northern District of Iowa</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from FirstName LastName entered on 2/1/2024 at 5:25 PM CST and filed on 2/1/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Mercy Hospital, Iowa City, Iowa                   </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.ianb.uscourts.gov/cgi-bin/DktRpt.pl?108151>23-00623</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.ianb.uscourts.gov/doc1/07404369078?pdf_header=&magic_num=82978176&de_seq_num=2927&caseid=108151'>701</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+  Motion for Relief from Stay <i>and for Order Authorizing and Directing the Distribution of Proceeds from the Sale of the Debtors' Assets</i>. Fee Amount $199. Filed by    Corporation     (Attachments: # (1) Proposed Order  # (2)  Ex. A - Account Statement # (3)  Ex. B - Exposure Statement # (4)  Ex. C - Credit App.(Redacted)) (FirstName LastName)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>2024 02 01 Mercy - Motion for Order Directing Sale Proceeds Allocation.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=993675052 [Date=2/1/2024] [FileNumber=4477683-0] 
+<BR><TAB>[55d576de494ba53085658d2a68c569ed36b3f818236bb4a9a71ee55092fc50c20590a
+<BR><TAB>8e8bc9d32b918bc0b928706d4a5ef194753d20afc1f96c91d7e2334e193]]
+<BR>
+<STRONG>Document description:</STRONG>Proposed Order 
+<BR><STRONG>Original filename:</STRONG>C:\fakepath\2024 02 01 Mercy - Proposed Order Granting Motion for Sale Proceeds Allocation.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=993675052 [Date=2/1/2024] [FileNumber=4477683-1] 
+<BR><TAB>[3771ba384e880c379613e4dd02c04fae7478bf5338a1e77bee43e9bf622de63526890
+<BR><TAB>50acc17ed9be31da74374a3c4107120d051da72c2d2d969be8c43198035]]
+<BR>
+<STRONG>Document description:</STRONG> Ex. A - Account Statement
+<BR><STRONG>Original filename:</STRONG>C:\fakepath\Ex A Mercy Statement.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=993675052 [Date=2/1/2024] [FileNumber=4477683-2] 
+<BR><TAB>[a832f8eb7d5a660b3abc6898d4f938da7c379ffbb56d435ada1c95d68c17744cebd0f
+<BR><TAB>216b2e8b98e9ae0cf122dff936e373eeb9cbe86397afa3f46cb5a15814b]]
+<BR>
+<STRONG>Document description:</STRONG> Ex. B - Exposure Statement
+<BR><STRONG>Original filename:</STRONG>C:\fakepath\Ex B Copy of Med Surg Mercy Exposure.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=993675052 [Date=2/1/2024] [FileNumber=4477683-3] 
+<BR><TAB>[46348447392c941e3e940dba24deb26996adaabfbb36cfc91d7d68210ce365242e372
+<BR><TAB>65bfe8ec04282c34d10a27e0b13ec91852d598540ed94047e2582ae50e9]]
+<BR>
+<STRONG>Document description:</STRONG> Ex. C - Credit App.(Redacted)
+<BR><STRONG>Original filename:</STRONG>C:\fakepath\Ex C Specialty Mercy Credit App UCC_Redacted1.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=993675052 [Date=2/1/2024] [FileNumber=4477683-4] 
+<BR><TAB>[df3e41da02575f58cc68f67e3a9dcc3af68c3eef00255d838d0acb7c3c334be8e6972
+<BR><TAB>2ba0c9df5aae9053e0844e4189624eee301fa709ee62f797f76ce2b7f51]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+23-00623 Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName on behalf of Creditor   UnitedHealth Group</span>
+<br>example@domain.com,  example@domain.com;example@domain.com
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Creditor   LiquidAgents Healthcare, LLC</span>
+<br>example@domain.com
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Interested Party   State University of Iowa</span>
+<br>example@domain.com,  example@domain.com
+<BR>
+
+<BR>
+<B>
+23-00623 Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">  CompanyMedical Staffing</span>
+<BR>c/o FirstName LastName
+<BR>Becker LLC 
+<BR>Livingston, NJ 07039
+<BR>
+<BR><span class="personName">  Altera Digital Health, Inc.</span>
+<BR>c/o FirstName LastName, Corporate Counsel 
+<BR>Chicago, IL 60654
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/ndb_1.json
+++ b/tests/examples/pacer/nef/s3/ndb_1.json
@@ -1,0 +1,34 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "ndb",
+  "dockets": [
+    {
+      "case_name": "Drain Services Inc. v. Houdyshell",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-02-02",
+          "description": "Clerk's Entry of Default (RE: related document(s)[1] Complaint filed by Plaintiff Drain Services Inc.) (vck, Court)",
+          "document_number": "5",
+          "document_url": "https://ecf.ndb.uscourts.gov/doc1/13601595078?pdf_header=&magic_num=63506631&de_seq_num=22&caseid=45339",
+          "pacer_case_id": "45339",
+          "pacer_doc_id": "13601595078",
+          "pacer_magic_num": "63506631",
+          "pacer_seq_no": "22",
+          "short_description": "Clerk's Entry of Default"
+        }
+      ],
+      "docket_number": "23-07017"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "example@domain.com",
+        "example@domain.com;example@domain.com;c@recap.email"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/ndb_1.txt
+++ b/tests/examples/pacer/nef/s3/ndb_1.txt
@@ -1,0 +1,121 @@
+Return-Path: <ecf@ndb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id glmo25n50fd84qdufgc8o3uekt3fe4nfi5nfrgo1
+ for example@domain.com;
+ Fri, 02 Feb 2024 14:26:08 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of ndb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecf@ndb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of ndb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=ecf@ndb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=ndb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFIbUhjbWdGS2daQVc5MnpOdHBXZ0tLRmpMWkd6ejJBOHVRUmxzUHhnaWtTZFZYY3Aya1hOVlY1TEMvSHlzaG41UXJrU0tDVWFWRngvdUJMME1TOWgrOVduQ3FWNEpOa3grRFB0TUt4TjhaOFpaL01xa1M4L20yOEJocmhEYlNzeUtYVUVRZDIyUUZzdHBiWmpGb0VsaVZ0cWZRRVd3dm5nVG5kVjZDc1dad2l1VFBRNGsyYVczeDJNdW5FSWsxN0hJQUlUQkkxQ1NrYXBjVzJOeStwRkFnS2ZnQU5zdUlnMmVabFNwQWlEOXRxZCtuSFhNTU1LZngrMm5xNzYxTDAyYUZzVjJCeTcxQ2diNEx0ektUdVNhREdKR1hybUk5Q09pbWxJa2xSYmxlU1E9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=mhPpoySeDvZtQt6jEeD460/pxkbUe+koqlGb5TiZQx+T9dpprvyfT2MD3pl+zLwC0WyU7W0QlLHSPKET9S6Ij1ucBRqqGaPtLbVSk8GYnj6oNA2ADWXeTCrI2KXrDTsDtIlce3Pad8dlrnJ8xwA5ziWIC5uwkrrUuf4xfznXRK4=; c=relaxed/simple; s=hsbnp7p3ensaochzwyq5wwmceodymuwv; d=amazonses.com; t=1706883969; v=1; bh=N8AZnwlrG8xPV+3InvyNp+w17kX5aKRHp7LS0Vh0G2s=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.193.242
+Received: from ndbdb-rep.ndb.gtwy.dcn ([156.119.193.242])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 02 Feb 2024 09:26:08 -0500
+Received: from ndbdb-rep.ndb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+        by ndbdb-rep.ndb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 412EPNFN052971;
+        Fri, 2 Feb 2024 08:25:23 -0600
+Received: (from ecf_web@localhost)
+        by ndbdb-rep.ndb.gtwy.dcn (8.14.7/8.14.4/Submit) id 412EOlPR051566;
+        Fri, 2 Feb 2024 08:24:47 -0600
+Date: Fri, 2 Feb 2024 08:24:47 -0600
+X-Authentication-Warning: ndbdb-rep.ndb.gtwy.dcn: ecf_web set sender to ecf@ndb.uscourts.gov using -f
+MIME-Version:1.0
+From:ecf@ndb.uscourts.gov
+To:nate_olson@ndb.uscourts.gov
+Message-Id:<1604226@ndb.uscourts.gov>
+Subject:23-07017 Drain Services Inc. v. Houdyshell et al Clerk's Entry of Default
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of North Dakota</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from vck, Court entered on 2/2/2024 at 8:24 AM CST and filed on 2/2/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Drain Services Inc. v. Houdyshell et al                                  </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.ndb.uscourts.gov/cgi-bin/DktRpt.pl?45339>23-07017</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.ndb.uscourts.gov/doc1/13601595078?pdf_header=&magic_num=63506631&de_seq_num=22&caseid=45339'>5</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Clerk's Entry of Default  (RE: related document(s)[1] Complaint filed by Plaintiff Drain Services Inc.)    (vck, Court)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>23-7017 Drain Services v SD Clerks Notice of Default.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1065028669 [Date=2/2/2024] [FileNumber=1604224-0]
+<BR><TAB> [6784c7c8eafb1d97e2229f42651772cd9c720d0e92a789333b5d01bfe4b6126f0d69
+<BR><TAB>7adfa5dbfbd3be634412fd00491935cf062172ccf1452d993c6135af5f53]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+23-07017 Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName on behalf of Plaintiff   Drain Services Inc.</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;c@recap.email
+<BR>
+
+<BR>
+<B>
+23-07017 Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">Michael  Houdyshell</span>
+<BR>South Dakota Department of Revenue
+<BR>445 E Capitol Avenue 
+<BR>Pierre, SD 57501
+<BR>
+<BR><span class="personName">  The State of South Dakota</span>
+<BR>c/o Kristi Noem, Governor
+<BR>500 East Capitol Avenue 
+<BR>Pierre, SD 57501
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/paeb_1.json
+++ b/tests/examples/pacer/nef/s3/paeb_1.json
@@ -1,0 +1,37 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "paeb",
+  "dockets": [
+    {
+      "case_name": "Br Cun",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-01-31",
+          "description": "BNC Certificate of Mailing - Financial Management Course Certificate. Number of Notices Mailed: (related document(s) (Related Doc [13])). No. of Notices: 1. Notice Date 01/31/2024. (Admin.)",
+          "document_number": "15",
+          "document_url": "https://ecf.paeb.uscourts.gov/doc1/152032522337?pdf_header=&magic_num=26909320&de_seq_num=47&caseid=510078",
+          "pacer_case_id": "510078",
+          "pacer_doc_id": "152032522337",
+          "pacer_magic_num": "26909320",
+          "pacer_seq_no": "47",
+          "short_description": "BNC Certificate of Mailing - Financial Management Course Certificate"
+        }
+      ],
+      "docket_number": "23-13129"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "example@domain.com",
+        "example@domain.com;c@recap.email;example@domain.com;example@domain.com;example@domain.com",
+        "example@domain.com",
+        "example@domain.com",
+        "USTPRegion03.PH.ECF@usdoj.gov"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/paeb_1.txt
+++ b/tests/examples/pacer/nef/s3/paeb_1.txt
@@ -1,0 +1,116 @@
+Return-Path: <BKECF_LiveDB@paeb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id gr7j927cksekb3r57t82qqn7n9duk1n7767ho8g1
+ for c@recap.email;
+ Thu, 01 Feb 2024 05:36:06 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of paeb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=BKECF_LiveDB@paeb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of paeb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=BKECF_LiveDB@paeb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=paeb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFUVVUWEU0ZTk2K2hpL3F0RXBuNGlPSW5SUGdKRmdHZlNQMmJPeTVmaWZjVVdKWTlDTXBRRENCc29qczhvckV1NXpsVU9qNlpnMWlaV0pybDJBYk1nT3U1RllBS3I2Sk92T1NqYzM2OTZhNThzY2tLa2plM0YrZlNUT2ZJVmFDQi9aU1VoUnhSQTFoTVJqcFpPbWJHSjl0WEY1YUdzcUlVU1dxYXZpa2VrZXhyT0ljSjFEdjg2RjFPeUxUbHFSUGpZdlRBRnVnbGpPVkxYV0ZEelE1R1JuQXBDQ2Q5NXZMcVE0Z0RzZEE3WVdUTUh5ZFlVYUNsOTEzOWNNM3RwTUtOa2V3ejEvZGNDRkp1cFVSSTRBaTFmMU4zUENzSkdmckJjRTlKUCtxUmg0Y0RWbm5iOWM3WERCdjBndG16WG1sbHc9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=qCWaR494cPqH6G7VWrbwbjCnWeFEUog6BmGIS3VWy6lGUaFen2UO3xmubql28IQfKNpVk+e7d6VKuHTPSVnN77+jx8N3l4K2Xf9a4RtsJgMhHBlQPbxtM7dSxB8oOg9MA4zMEghnzaqeslAeBo3FuWxZucYv1eLmBg4fhVocE2Q=; c=relaxed/simple; s=hsbnp7p3ensaochzwyq5wwmceodymuwv; d=amazonses.com; t=1706765767; v=1; bh=/cgupJQnS9lMXPGcmG71IvLQH9pHc4nrz3/NUCuQ7OE=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.80
+Received: from paebdb.paeb.gtwy.dcn ([156.119.190.80])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 01 Feb 2024 00:36:06 -0500
+Received: from paebdb.paeb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+        by paebdb.paeb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 4115ZDu4021851;
+        Thu, 1 Feb 2024 00:35:24 -0500
+Received: (from ecf_web@localhost)
+        by paebdb.paeb.gtwy.dcn (8.14.7/8.14.4/Submit) id 4115YrRU019823;
+        Thu, 1 Feb 2024 00:34:53 -0500
+Date: Thu, 1 Feb 2024 00:34:53 -0500
+X-Authentication-Warning: paebdb.paeb.gtwy.dcn: ecf_web set sender to BKECF_LiveDB@paeb.uscourts.gov using -f
+MIME-Version:1.0
+From:BKECF_LiveDB@paeb.uscourts.gov
+To:Courtmail@paeb.uscourts.gov
+Message-Id:<31788189@paeb.uscourts.gov>
+Subject:Ch-7 23-13129-amc BNC Certificate of Mailing - Financial Management Course Certificate - FirstName LastName
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>Eastern District of Pennsylvania</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Admin entered on 02/01/2024  at 00:34 AM EST and filed on 01/31/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Br Cun</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.paeb.uscourts.gov/cgi-bin/DktRpt.pl?510078>23-13129-amc</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.paeb.uscourts.gov/doc1/152032522337?pdf_header=&magic_num=26909320&de_seq_num=47&caseid=510078'>15</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+BNC Certificate of Mailing - Financial Management Course Certificate. Number of Notices Mailed: (related document(s) (Related Doc [13])). No. of Notices: 1. Notice Date 01/31/2024. (Admin.)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Imaged Certificate of Notice
+<BR><STRONG>Original filename:</STRONG>P223131292110042.pdf
+<BR><STRONG>Electronic document Stamp:</STRONG>
+<BR>[STAMP bkecfStamp_ID=1008166204 [Date=2/1/2024] [FileNumber=31788077-0] [a2c0fc1682ead43f8689775d728ce63f2576f2f20aab77085a0c40952e821c6f266d3d3a65357d4a9d7addee8f09035d5bf17001fe3b7da85dbcfa2d95a65e59]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+23-13129-amc Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">MICHAEL A. CIBIK on behalf of Debtor Brittany  Cunningham</span>
+<br>example@domain.com,  example@domain.com;c@recap.email;example@domain.com;example@domain.com;example@domain.com
+<BR>
+<BR><span class="personName">CHRISTINE C. SHUBERT</span>
+<br>example@domain.com,  example@domain.com
+<BR>
+<BR><span class="personName">  United States Trustee</span>
+<br>USTPRegion03.PH.ECF@usdoj.gov
+<BR>
+
+<BR>
+<B>
+23-13129-amc Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR>
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/paeb_2.json
+++ b/tests/examples/pacer/nef/s3/paeb_2.json
@@ -1,0 +1,40 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "paeb",
+  "dockets": [
+    {
+      "case_name": "Alexander Michael Brader-Sims",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-02-01",
+          "description": "Hearing Continued on Confirmation. Hearing scheduled 03/14/2024 at 10:00 AM at Zoom. For Zoom link, see the current Hearing Calendar for the Judge on the Court website. (Roman, Sara)",
+          "document_number": "36",
+          "document_url": null,
+          "pacer_case_id": "508646",
+          "pacer_doc_id": null,
+          "pacer_magic_num": null,
+          "pacer_seq_no": null,
+          "short_description": "CHAP - Hearing Continued"
+        }
+      ],
+      "docket_number": "23-11723"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "example@domain.com",
+        "example@domain.com;c@recap.email;example@domain.com;example@domain.com;example@domain.com",
+        "example@domain.com",
+        "example@domain.com",
+        "example@domain.com",
+        "example@domain.com",
+        "example@domain.com",
+        "example@domain.com"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/paeb_2.txt
+++ b/tests/examples/pacer/nef/s3/paeb_2.txt
@@ -1,0 +1,118 @@
+Return-Path: <BKECF_LiveDB@paeb.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id gp1i24vfmj6jirm7m83kqnrsf6c2jgpkpmt2i5o1
+ for c@recap.email;
+ Thu, 01 Feb 2024 15:15:07 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of paeb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=BKECF_LiveDB@paeb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of paeb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=BKECF_LiveDB@paeb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=paeb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFVkNDUEdVMTNTYStZbE1DK3Jrc0U1eVZMT2VSRVVDTDV6SVVlQjhDdDgyN1BTcTV4Z21RMXdITWk5MjZuSkI2bDVwcVdURlFMQ3dGaGZhaXg3YmQ4aWZlTVF3Q1FjQ3psOENhSzBUcDFHTEVXUHROd3BEaUEzTG55c2NsYjRwUjlEUW1KM2FORHAzcjFLNW0yNUswaWJxT0hDSDdwdVpIanRKdjFzOTE0b201Tlgxd2FZMkhLemtKaU56a0YvNFV4U2FhRThLYlExd1VmM1FtNU4wZXN5aWJacldkTjA3K003Smo1L0V6WEtZT0t1Smc1c29yTms3aERiYVhwdE1GaWFlVDRmSVA4TWdNT1k2VGFMOUlxV0hkMDc1Y2drRzJ2aUpxVlllTzJFRG1Gc1UwcktzdU5VUmJiS0lBbTZCdUU9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=hbcJD9rF6sLPIqO8YB1dSEmbhetxTl+RTX82YBtS79ktszWPnWsfNpTNWZE8BSBE6zqhBImudIn//xP/nk+QJj2zLBWFb+c1NY9kd+HYfh/xbfgf6j7P+IGC1MD2d6WjUGs4j6Cta6eraeBPuIgipSBFGlvaY4JSYi8wc4Dsmos=; c=relaxed/simple; s=hsbnp7p3ensaochzwyq5wwmceodymuwv; d=amazonses.com; t=1706800508; v=1; bh=VKaG7T1hC8/0kuo/yDOb+Z/OIOh71910ZoGVZf2jG7s=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.80
+Received: from paebdb.paeb.gtwy.dcn ([156.119.190.80])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 01 Feb 2024 10:15:06 -0500
+Received: from paebdb.paeb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+        by paebdb.paeb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 411FEE0v117057;
+        Thu, 1 Feb 2024 10:14:30 -0500
+Received: (from ecf_web@localhost)
+        by paebdb.paeb.gtwy.dcn (8.14.7/8.14.4/Submit) id 411FDqKk115530;
+        Thu, 1 Feb 2024 10:13:52 -0500
+Date: Thu, 1 Feb 2024 10:13:52 -0500
+X-Authentication-Warning: paebdb.paeb.gtwy.dcn: ecf_web set sender to BKECF_LiveDB@paeb.uscourts.gov using -f
+MIME-Version:1.0
+From:BKECF_LiveDB@paeb.uscourts.gov
+To:Courtmail@paeb.uscourts.gov
+Message-Id:<31788748@paeb.uscourts.gov>
+Subject:Ch-13 23-11723-pmm CHAP - Hearing Continued (Bk Other) - Alexander Michael
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>Eastern District of Pennsylvania</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Roman, Sara entered on 02/01/2024  at 10:13 AM  EST and filed on 02/01/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Alexander Michael Brader-Sims</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.paeb.uscourts.gov/cgi-bin/DktRpt.pl?508646>23-11723-pmm</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+36
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Hearing Continued on Confirmation. Hearing scheduled 03/14/2024 at 10:00 AM  at Zoom. For Zoom link, see the current Hearing Calendar for the Judge on the Court website.   (Roman, Sara)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+23-11723-pmm Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName on behalf of Debtor A M S</span>
+<br>example@domain.com,  example@domain.com;c@recap.email;example@domain.com;example@domain.com;example@domain.com
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Creditor   x Financial Services</span>
+<br>example@domain.com,  example@domain.com
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Creditor   XXXX Financial Services</span>
+<br>example@domain.com,  example@domain.com
+<BR>
+<BR><span class="personName">  United States Trustee</span>
+<br>example@domain.com
+<BR>
+<BR><span class="personName">SCOTT F. WATERMAN [Chapter 13]</span>
+<br>example@domain.com
+<BR>
+
+<BR>
+<B>
+23-11723-pmm Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">  Wilmington Savings Fund Society, FSB, d/b/a Ch Trust, not in its individual capacity, but solely as indenture trustee of Citigroup Mortgage Loan Trust 2015-RP2</span>
+<BR>c/o FirstName LastName, LLC 
+<BR>Bankruptcy Department
+<BR>1544 Old Alabama Rd
+<BR>Roswell, GA 30076
+<BR>
+
+<BR>
+<B>
+
+</B>

--- a/tests/examples/pacer/nef/s3/paeb_3.json
+++ b/tests/examples/pacer/nef/s3/paeb_3.json
@@ -1,0 +1,63 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "paeb",
+  "dockets": [
+    {
+      "case_name": "Tri-State Paper, Inc. v. Foodarama Caterers Inc.",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-02-01",
+          "description": "Adversary Case 2:23-ap-75 Terminated for Statistical Purposes. (R., LastName)",
+          "document_number": null,
+          "document_url": null,
+          "pacer_case_id": "510318",
+          "pacer_doc_id": null,
+          "pacer_magic_num": null,
+          "pacer_seq_no": null,
+          "short_description": ""
+        }
+      ],
+      "docket_number": "23-00075"
+    },
+    {
+      "case_name": "Tri-State Paper, Inc.",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-02-01",
+          "description": "Adversary Case 2:23-ap-75 Terminated for Statistical Purposes. (R., LastName)",
+          "document_number": null,
+          "document_url": null,
+          "pacer_case_id": "510187",
+          "pacer_doc_id": null,
+          "pacer_magic_num": null,
+          "pacer_seq_no": null,
+          "short_description": ""
+        }
+      ],
+      "docket_number": "23-13237"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "example@domain.com",
+        "example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com",
+        "example@domain.com",
+        "example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com"
+      ],
+      "name": ""
+    },
+    {
+      "email_addresses": [
+        "example@domain.com",
+        "example@domain.com",
+        "example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com",
+        "USTPRegion03.PH.ECF@usdoj.gov"
+      ],
+      "name": "4510A Adams Circle Bensalem, PA 19020"
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/paeb_3.txt
+++ b/tests/examples/pacer/nef/s3/paeb_3.txt
@@ -1,0 +1,177 @@
+Return-Path: <BKECF_LiveDB@paeb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id clofkr5crceoju0ek1t6jh162fp47ah3bmr2a6o1
+ for c@recap.email;
+ Thu, 01 Feb 2024 20:00:46 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of paeb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=BKECF_LiveDB@paeb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of paeb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=BKECF_LiveDB@paeb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=paeb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFNzh4QzY2VDFGTllHc3o4MzJpSyswcE9TYlJwVHF1RDZFbmczV1YzdTVLTDZHeHZiVUlIVHI2WXZLd0RjSkJjY2drL3VNYnpLQzlVeFpoRTZSUUVoTmxEMDMzd0JWbllJRFp4Wml4NkZiQzVXdktobFE2RS80VlhrSmVQb2llUVh1bGtVTjVDR2pMVE5JcXl6ZDNmak1ueGNKeGNiSmRrQWRPWWZvdDRaVDJ5bTZ4bjhlUlhPYTBCdHpGdkwxamF0Y0I1bTVWQ3VKaVRmSmxMRXJ2MEhtMFgxcW9jWlM0R3FtL0Q2UDBhRWRHbmMyeGR3ajhPbGJadE9PMWlseERnWTU2QW9rSzdJTHpyRjY2ZXE0SzEyck1wcjBZcDd1TUwyY3lWSWY5Ym4rUTc3d09SSWswNkxTU2s5aXFnYW1FVVk9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=fVGG8ZUQJv0zsk8KeQIXbAewV5oXtxOQdxNeMKyLHuUYVvNI+zGOl0hlHfQjAfw0ue+VI6xuhggrQT+Nu5EfE4GDkGCvrKkdR5gwzIOIeK8+aR9aXl4PVkJLeeJRPM6dKffdAJy0NB3nHfhhSGdU1XuXlEjTm0/ePofnyRP9B0Q=; c=relaxed/simple; s=hsbnp7p3ensaochzwyq5wwmceodymuwv; d=amazonses.com; t=1706817647; v=1; bh=oRdaJ5s9YC1C5Ty8XUuD4CaI4EMuOD2LlxsEcEfY2Uw=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.80
+Received: from paebdb.paeb.gtwy.dcn ([156.119.190.80])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 01 Feb 2024 15:00:45 -0500
+Received: from paebdb.paeb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+        by paebdb.paeb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 411K0iKA075435;
+        Thu, 1 Feb 2024 15:00:45 -0500
+Received: (from ecf_web@localhost)
+        by paebdb.paeb.gtwy.dcn (8.14.7/8.14.4/Submit) id 411K0RBC075196;
+        Thu, 1 Feb 2024 15:00:27 -0500
+Date: Thu, 1 Feb 2024 15:00:27 -0500
+X-Authentication-Warning: paebdb.paeb.gtwy.dcn: ecf_web set sender to BKECF_LiveDB@paeb.uscourts.gov using -f
+MIME-Version:1.0
+From:BKECF_LiveDB@paeb.uscourts.gov
+To:Courtmail@paeb.uscourts.gov
+Message-Id:<31790064@paeb.uscourts.gov>
+Subject:Ch-11 23-13237-pmm Close Adversary Case - Tri-State Paper, I
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>Eastern District of Pennsylvania</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from R., Yvette entered on 2/1/2024 at 3:00 PM EST and filed on 2/1/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Tri-State Paper, Inc. v. Foodarama Caterers Inc.</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.paeb.uscourts.gov/cgi-bin/DktRpt.pl?510318>23-00075-pmm</A></td></tr>
+<tr><td colspan=2><strong>WARNING: CASE CLOSED on 02/01/2024</strong></td></tr>
+<tr><td><strong>Document Number:</strong></td>
+<td>
+
+</td></tr>
+</table>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Tri-State Paper, Inc.</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.paeb.uscourts.gov/cgi-bin/DktRpt.pl?510187>23-13237-pmm</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Adversary Case 2:23-ap-75 Terminated for Statistical Purposes.    (R., LastName)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+23-00075-pmm Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FIRSTNAME LASTNAME on behalf of Plaintiff   Company, Inc.</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com
+<BR>
+<BR><span class="personName">FIRSTNAME LASTNAME on behalf of Plaintiff   Company, Inc.</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com
+<BR>
+
+<BR>
+<B>
+23-00075-pmm Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">  Foodarama Caterers Inc.</span>
+<BR>4510A Adams Circle 
+<BR>Bensalem, PA 19020
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>
+
+
+
+
+<BR><B>
+23-13237-pmm Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">DAVE P. ADAMS on behalf of U.S. Trustee   United States Trustee</span>
+<br>example@domain.com
+<BR>
+<BR><span class="personName">MICHAEL I. ASSAD on behalf of Creditor   Citizens Bank, N.A., successor by merger to Citizens Bank of Pennsylvania</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com;example@domain.com
+<BR>
+
+<BR><span class="personName">  United States Trustee</span>
+<br>USTPRegion03.PH.ECF@usdoj.gov
+<BR>
+
+<BR>
+<B>
+23-13237-pmm Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">  Law Company, P.C.</span>
+<BR>Deleted
+<BR>Suite 900
+<BR>Philadelphia, PA 19102
+<BR>
+<BR><span class="personName">First Name</span>
+<BR>Deleted
+<BR>Philadelphia, PA 19116-3850
+<BR>
+<BR><span class="personName"> Realty Associates, Inc.</span>
+<BR>Deleted
+<BR>Ardmore, PA 19003
+<BR>
+<BR><span class="personName">  Adjustment Company, Inc.</span>
+<BR>c/o FirstNane LastName
+<BR>Deleted
+<BR>Blue Bell, PA 19422
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/vaeb_1.json
+++ b/tests/examples/pacer/nef/s3/vaeb_1.json
@@ -1,0 +1,44 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "vaeb",
+  "dockets": [
+    {
+      "case_name": "Tanese Renee Newton-Love",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-02-01",
+          "description": "Notice of Dismissal (Re: related document(s)[32] Order on Motion to Dismiss Case by Trustee (Batch)) (Admin.)",
+          "document_number": "33",
+          "document_url": "https://ecf.vaeb.uscourts.gov/doc1/188040985133?pdf_header=&magic_num=49963627&de_seq_num=101&caseid=752725",
+          "pacer_case_id": "752725",
+          "pacer_doc_id": "188040985133",
+          "pacer_magic_num": "49963627",
+          "pacer_seq_no": "101",
+          "short_description": "Notice of Dismissal"
+        }
+      ],
+      "docket_number": "23-31747"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "example@domain.com",
+        "example@domain.com",
+        "example@domain.com",
+        "example@domain.com;example@domain.com",
+        "example@domain.com",
+        "example@domain.com",
+        "example@domain.com;example@domain.com;example@domain.com",
+        "USTPRegion04.RH.ECF@usdoj.gov",
+        "example@domain.com",
+        "example@domain.com;example@domain.com",
+        "example@domain.com",
+        "example@domain.com"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/vaeb_1.txt
+++ b/tests/examples/pacer/nef/s3/vaeb_1.txt
@@ -1,0 +1,130 @@
+Return-Path: <live_ecf@vaeb.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id dmqt97lgfc7eu5tu4090otni6na6b0gedsc8nd81
+ for c@recap.email;
+ Fri, 02 Feb 2024 05:25:29 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of vaeb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=live_ecf@vaeb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of vaeb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=live_ecf@vaeb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=vaeb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFIdysvdkM5TEdaRlBKUnFObkN2MEZUbGZzM2Nad1lBVzRmd0kwQXcvckl1T25uV3lNR21vYnRLZFA3b0tEWGRmMzRUV2FxUk1zMnBYVVRvM1RpTmoyaFd2ZjhJVDZEczVSakhpSGhOY3RzbXhjanhBSjJ0aFk4M0pQZjl5ajVXZWlOeW44RnF3OGFJd3VWdlc3ejNBU0ZmUm4xQU45TXpHVG1acU1rbE9lZGRrYW9RN2EyZTRvSEFsVXNrclZWclR0NmN4VkU4WE12a2VFZU5NTGduc2dSVy9IN3lUdk51RzByUm51Y244RUx5UmZBWFJkbUlsUTJxTU1xa1NEQnpjOXpZTzNKRlB2OU92UWFhQ1cweUN3c1p0SVBiYi9HVWNRQzNMbDhPa0xKTVE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=G2ZOPs7mc4GAXgafzFhAjrzqau4UgITz1m9CkiJbscl12As7ttqKymNjuWEnYNV6hCKbawyoZ4fCMeoRAy5VomhZFYm49xm91dcVhKlH9tzxOv3jlJ+j5+6UukxuViryldHJr1mir/vAqYnClpmfhWalgTKRHRyWS97nd3Q6LAk=; c=relaxed/simple; s=hsbnp7p3ensaochzwyq5wwmceodymuwv; d=amazonses.com; t=1706851529; v=1; bh=tk5TSRqVZL5aHklIZOSFCyGIWGE5P9Z6DaENB8HGV4I=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.191.40
+Received: from vaebdb.vaeb.gtwy.dcn ([156.119.191.40])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 02 Feb 2024 00:25:28 -0500
+Received: from vaebdb.vaeb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+        by vaebdb.vaeb.gtwy.dcn (8.14.4/8.14.4) with ESMTP id 4125OOO4128637;
+        Fri, 2 Feb 2024 00:24:57 -0500
+Received: (from ecf_web@localhost)
+        by vaebdb.vaeb.gtwy.dcn (8.14.4/8.14.4/Submit) id 4125NlNC126083;
+        Fri, 2 Feb 2024 00:23:47 -0500
+Date: Fri, 2 Feb 2024 00:23:47 -0500
+X-Authentication-Warning: vaebdb.vaeb.gtwy.dcn: ecf_web set sender to live_ecf@vaeb.uscourts.gov using -f
+MIME-Version:1.0
+From:live_ecf@vaeb.uscourts.gov
+To:Courtmail@vaeb.uscourts.gov
+Message-Id:<40573088@vaeb.uscourts.gov>
+Subject:Tanese Renee Newton-Love 23-31747-KLP Ch 13  Notice of Dismissal - CerDocTyp
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>Eastern District of Virginia</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Admin entered on 02/02/2024  at 00:20 AM EST and filed on 02/01/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Tanese Renee Newton-Love                          </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.vaeb.uscourts.gov/cgi-bin/DktRpt.pl?752725>23-31747-KLP</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.vaeb.uscourts.gov/doc1/188040985133?pdf_header=&magic_num=49963627&de_seq_num=101&caseid=752725'>33</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Notice of Dismissal (Re: related document(s)[32] Order on Motion to Dismiss Case by Trustee (Batch)) (Admin.)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Imaged Certificate of Notice
+<BR><STRONG>Original filename:</STRONG>P72331747VAN0150094.pdf
+<BR><STRONG>Electronic document Stamp:</STRONG>
+<BR>[STAMP VAEBStamp_ID=875559604 [Date=2/2/2024] [FileNumber=40572492-0] [5e1098c1773080ccd0396aeb2c4a1656fea377eb4276143dc7760dbd62661d37d764ec31e4897c2525195b9d3f7518eaa6aa933a8ffe1d910daa424dbc4efd1b]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+23-31747-KLP Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName on behalf of FirstName LastName</span>
+<br>example@domain.com,  example@domain.com
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of FirstName LastName</span>
+<br>example@domain.com,  example@domain.com;example@domain.com
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Creditor   Santander Consumer USA Inc.</span>
+<br>example@domain.com
+<BR>
+<BR><span class="personName">JFirstName LastName on behalf of Creditor   XXX, LLC</span>
+<br>example@domain.com,  example@domain.com;example@domain.com;example@domain.com
+<BR>
+<BR><span class="personName">Gerard R. Vetter</span>
+<br>USTPRegion04.RH.ECF@usdoj.gov
+<BR>
+<BR><span class="personName">FirstName LastName</span>
+<br>example@domain.com,  example@domain.com;example@domain.com
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of FirstName LastName</span>
+<br>example@domain.com,  example@domain.com
+<BR>
+
+<BR>
+<B>
+23-31747-KLP Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">  Atlas Acquisitions LLC</span>
+<BR>492C Cedar Lane, Ste 442 
+<BR>Teaneck, NJ 07666
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>


### PR DESCRIPTION
Solves #912

Add parsing clauses and test cases for:

- dcb
- ndb
- ianb
- paeb
- vaeb

Note that some tests will have no short description

- dcb_1: no short description available
- paeb_3: is multidocket NEF, currently unsupported

Fixes COURTLISTENER-6HH
Fixes COURTLISTENER-6HH
Fixes COURTLISTENER-6HR
Fixes COURTLISTENER-6HS
Fixes COURTLISTENER-6J7