### PR TITLE
feat(base report): Adds a method for checking sealed status on a entry

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Releases are also tagged in git, if that's helpful.
 Features:
 
 - The GET method of the PacerSession class now supports custom timeouts for flexible request management.
+- Adds a method to check if a district court docket entry is sealed..
 
 Changes:
 

--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -382,7 +382,10 @@ class BaseReport:
         return sealed in r.content
 
     def is_entry_sealed(
-        self, pacer_case_id, pacer_doc_id, pacer_magic_num=None
+        self,
+        pacer_case_id: str,
+        pacer_doc_id: str,
+        pacer_magic_num: Optional[str] = None,
     ):
         """Check if a docket entry is sealed without trying to actually download
         it.

--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -380,3 +380,14 @@ class BaseReport:
         )
         sealed = "You do not have permission to view this document."
         return sealed in r.content
+
+    def is_entry_sealed(
+        self, pacer_case_id, pacer_doc_id, pacer_magic_num=None
+    ):
+        """Check if a docket entry is sealed without trying to actually download
+        it.
+        """
+        r, url = self._query_pdf_download(
+            pacer_case_id, pacer_doc_id, pacer_magic_num, got_receipt="0"
+        )
+        return b"could not retrieve dktentry for dlsid" in r.content


### PR DESCRIPTION
This PR adds a new method to the `BaseReport` class. This helper uses the content of the receipt page to flag potentially sealed docket entries.