### PR TITLE
feat(pacer): Tweak the DownloadConfirmationPage class to set smaller timeout

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,13 @@ Releases are also tagged in git, if that's helpful.
 
 ## Coming up
 
- - N/A
+Features:
+
+- The GET method of the PacerSession class now supports custom timeouts for flexible request management.
+
+Changes:
+
+- Update the DownloadConfirmationPage class to reduce the read timeout of the GET request within the query method.
 
 ## Current
 

--- a/juriscraper/pacer/download_confirmation_page.py
+++ b/juriscraper/pacer/download_confirmation_page.py
@@ -45,7 +45,7 @@ class DownloadConfirmationPage(BaseReport):
             url = make_doc1_url(self.court_id, pacer_doc_id, True)
 
         logger.info("Querying the confirmation page endpoint at URL: %s", url)
-        self.response = self.session.get(url)
+        self.response = self.session.get(url, timeout=60)
         if is_pdf(self.response):
             # Sometimes the PDF document is returned without showing the
             # download confirmation page, not a valid page to parse.

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -132,7 +132,8 @@ class PacerSession(requests.Session):
         :param auto_login: Whether the auto-login procedure should happen.
         :return: requests.Response
         """
-        kwargs.setdefault("timeout", 300)
+        if "timeout" not in kwargs:
+            kwargs.setdefault("timeout", 300)
 
         r = super().get(url, **kwargs)
 


### PR DESCRIPTION
This PR updates the `DownloadConfirmationPage` class to reduce the read timeout of the `GET` request within the `query` method. These changes align with the retry strategy improvements(exponential task retries with relatively fast timeouts) discussed in [courtlistener#3766](https://github.com/freelawproject/courtlistener/issues/3766) for `process_recap_email` task.