### PR TITLE
fix(texag): correct content type and link xpath

### DIFF
--- a/juriscraper/opinions/united_states/state/texag.py
+++ b/juriscraper/opinions/united_states/state/texag.py
@@ -15,14 +15,14 @@ class Site(OpinionSiteLinear):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
         self.url = "https://texasattorneygeneral.gov/opinions"
-        self.expected_content_types = ["text/html"]
+        self.expected_content_types = ["application/pdf"]
 
     def _process_html(self):
         cases = self.html.xpath("//div[@class='sidebar-ag-opinion-content']")
         for case in cases:
             docket = case.xpath(".//h4")[0].text_content().strip()
             summary = case.xpath(".//p")[0].text_content().strip()
-            url = case.xpath(".//h4/a/@href")[0]
+            url = case.xpath(".//a[contains(@href, '.pdf')]/@href")[0]
             name = f"Untitled Texas Attorney General Opinion: {docket}"
             date = case.xpath(
                 ".//div[@class='sidebar-ag-opinion-casedate']/text()"

--- a/tests/examples/opinions/united_states/texag_example.compare.json
+++ b/tests/examples/opinions/united_states/texag_example.compare.json
@@ -2,7 +2,7 @@
   {
     "case_dates": "2022-12-15",
     "case_names": "Untitled Texas Attorney General Opinion: KP-0423",
-    "download_urls": "/opinions/ken-paxton/kp-0423",
+    "download_urls": "/sites/default/files/opinion-files/opinion/2022/kp-0423.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
@@ -13,7 +13,7 @@
   {
     "case_dates": "2022-12-15",
     "case_names": "Untitled Texas Attorney General Opinion: KP-0422",
-    "download_urls": "/opinions/ken-paxton/kp-0422",
+    "download_urls": "/sites/default/files/opinion-files/opinion/2022/kp-0422_1.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
@@ -24,7 +24,7 @@
   {
     "case_dates": "2022-10-25",
     "case_names": "Untitled Texas Attorney General Opinion: KP-0421",
-    "download_urls": "/opinions/ken-paxton/kp-0421",
+    "download_urls": "/sites/default/files/opinion-files/opinion/2022/kp-0421.pdf",
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,


### PR DESCRIPTION
download_url xpath was picking an HTML page instead of the PDF link, causing incorrect downloads and duplicates. To correct past corrupt data a backscraper will be needed

Solves #940