### PR TITLE
feat(backscrape): support dynamic backscraping ranges

### DIFF
--- a/juriscraper/AbstractSite.py
+++ b/juriscraper/AbstractSite.py
@@ -34,7 +34,7 @@ class AbstractSite:
     Should not contain lists that can't be sorted by the _date_sort function.
     """
 
-    def __init__(self, cnt=None):
+    def __init__(self, cnt=None, **kwargs):
         super().__init__()
 
         # Computed metadata

--- a/juriscraper/opinions/united_states/state/tex.py
+++ b/juriscraper/opinions/united_states/state/tex.py
@@ -15,10 +15,9 @@
 #  - 2015-08-19: Updated by Andrei Chelaru to add backwards scraping support.
 #  - 2015-08-27: Updated by Andrei Chelaru to add explicit waits
 #  - 2021-12-28: Updated by flooie to remove selenium.
-#  - 2024-02-21; Updated by grossir: handle dynamic backscrapes
 
-from datetime import date, datetime, timedelta
-from typing import Dict, Optional, Tuple
+from datetime import date, timedelta
+from typing import Optional
 
 from juriscraper.AbstractSite import logger
 from juriscraper.DeferringList import DeferringList
@@ -30,11 +29,6 @@ class Site(OpinionSiteLinear):
     rows_xpath = (
         "//table[@class='rgMasterTable']/tbody/tr[not(@class='rgNoRecords')]"
     )
-    param_date_format = "%-m/%-d/%Y"
-    first_opinion_date = datetime(2002, 1, 24, 0, 0, 0)
-    next_page_xpath = (
-        "//input[@title='Next Page' and not(@onclick='return false;')]"
-    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -42,13 +36,11 @@ class Site(OpinionSiteLinear):
         self.checkbox = 0
         self.status = "Published"
         self.url = "https://search.txcourts.gov/CaseSearch.aspx?coa=cossup"
-        self.make_backscrape_iterable(kwargs)
-        self.next_page = None
-        # Default scrape range if not doing a backscrape
-        self.end_date = date.today()
-        self.start_date = self.end_date - timedelta(days=30)
 
-    def _set_parameters(self) -> None:
+    def _set_parameters(
+        self,
+        view_state: str,
+    ) -> None:
         """Set ASPX post parameters
 
         This method - chooses the court and date parameters.
@@ -60,62 +52,45 @@ class Site(OpinionSiteLinear):
          3: 2nd District Court of Appeals
          ...etc
 
+        :param view_state: view state of the page
         :return: None
         """
-        start_date_str = self.start_date.strftime(self.param_date_format)
-        end_date_str = self.end_date.strftime(self.param_date_format)
+        today = date.today()
+        last_month = today - timedelta(days=30)
+        last_month_str = last_month.strftime("%m/%d/%Y")
+        today_str = today.strftime("%m/%d/%Y")
 
-        from_date_param = self.make_date_param(self.start_date, start_date_str)
-        to_date_param = self.make_date_param(self.end_date, end_date_str)
-
-        self.parameters = {}
-        for hidden in self.html.xpath("//input[@type='hidden']"):
-            value = hidden.xpath("@value")[0] if hidden.xpath("@value") else ""
-            self.parameters[hidden.xpath("@name")[0]] = value
-
-        self.parameters.update(
-            {
-                "ctl00$ContentPlaceHolder1$SearchType": "rbSearchByDocument",  # "Document Search" radio button
-                "ctl00$ContentPlaceHolder1$dtDocumentFrom": str(
-                    self.start_date
-                ),
-                "ctl00$ContentPlaceHolder1$dtDocumentFrom$dateInput": start_date_str,
-                "ctl00$ContentPlaceHolder1$dtDocumentTo": str(self.end_date),
-                "ctl00$ContentPlaceHolder1$dtDocumentTo$dateInput": end_date_str,
-                "ctl00_ContentPlaceHolder1_dtDocumentFrom_dateInput_ClientState": from_date_param,
-                "ctl00_ContentPlaceHolder1_dtDocumentTo_dateInput_ClientState": to_date_param,
-                "ctl00$ContentPlaceHolder1$btnSearchText": "Search",
-                "ctl00$ContentPlaceHolder1$chkListDocTypes$0": "on",  # "Opinion" checkbox
-                f"ctl00$ContentPlaceHolder1$chkListCourts${self.checkbox}": "on",  # Court checkbox
-                "ctl00$ContentPlaceHolder1$txtSearchText": "",
-                "ctl00_ContentPlaceHolder1_dtDocumentFrom_ClientState": '{"minDateStr":"1900-01-01-00-00-00","maxDateStr":"2099-12-31-00-00-00"}',
-                "ctl00_ContentPlaceHolder1_dtDocumentTo_ClientState": '{"minDateStr":"1900-01-01-00-00-00","maxDateStr":"2099-12-31-00-00-00"}',
-                "ctl00$ContentPlaceHolder1$Stemming": "on",
-                "ctl00$ContentPlaceHolder1$Fuzziness": "0",
-            }
+        date_param = (
+            '{"enabled":true,"emptyMessage":"",'
+            f'"validationText":"{last_month}-00-00-00",'
+            f'"valueAsString":"{last_month}-00-00-00",'
+            '"minDateStr":"1900-01-01-00-00-00",'
+            '"maxDateStr":"2099-12-31-00-00-00",'
+            f'"lastSetTextBoxValue":"{last_month_str}"'
+            "}"
         )
 
-        # "Next page" arrow button has a name
-        # "ctl00$ContentPlaceHolder1$grdDocuments$ctl00$ctl02$ctl00$ctl18"
-        # Couldn't get pagination working when using the numbered page anchors,
-        # whose id goes into __EVENTTARGET
-        if self.next_page:
-            self.parameters[self.next_page[0].xpath("@name")[0]] = ""
-            self.parameters["__EVENTTARGET"] = ""
-            self.parameters["__SCROLLPOSITIONX"] = "0"
-            self.parameters["__SCROLLPOSITIONY"] = "345"
-            self.parameters["__EVENTARGUMENT"] = ""
-            self.parameters["__LASTFOCUS"] = ""
+        self.parameters = {
+            "ctl00$ContentPlaceHolder1$SearchType": "rbSearchByDocument",  # "Document Search" radio button
+            "ctl00$ContentPlaceHolder1$dtDocumentFrom": str(last_month),
+            "ctl00$ContentPlaceHolder1$dtDocumentFrom$dateInput": last_month_str,
+            "ctl00_ContentPlaceHolder1_dtDocumentFrom_dateInput_ClientState": date_param,
+            "ctl00$ContentPlaceHolder1$dtDocumentTo": str(today),
+            "ctl00$ContentPlaceHolder1$dtDocumentTo$dateInput": today_str,
+            "ctl00$ContentPlaceHolder1$chkListDocTypes$0": "on",  # "Opinion" checkbox
+            "ctl00$ContentPlaceHolder1$btnSearchText": "Search",
+            "__VIEWSTATE": view_state,
+            f"ctl00$ContentPlaceHolder1$chkListCourts${self.checkbox}": "on",  # Court checkbox
+        }
 
     def _process_html(self) -> None:
-        """Process HTML and paginates if needed
-
-        :return: None
-        """
         if not self.test_mode_enabled():
             # Make our post request to get our data
             self.method = "POST"
-            self._set_parameters()
+            view_state = self.html.xpath("//input[@id='__VIEWSTATE']")[0].get(
+                "value"
+            )
+            self._set_parameters(view_state)
             self.html = super()._download()
 
         for row in self.html.xpath(self.rows_xpath):
@@ -128,10 +103,6 @@ class Site(OpinionSiteLinear):
                     "url": row.xpath(".//a")[1].get("href"),
                 }
             )
-
-        self.next_page = self.html.xpath(self.next_page_xpath)
-        if self.next_page and not self.test_mode_enabled():
-            self._process_html()
 
     def _get_case_names(self) -> DeferringList:
         """Get case names using a deferring list."""
@@ -168,51 +139,3 @@ class Site(OpinionSiteLinear):
                 return None
 
         return DeferringList(seed=seeds, fetcher=get_name)
-
-    def make_backscrape_iterable(self, kwargs: Dict) -> None:
-        """Checks if backscrape start and end arguments have been passed
-        by caller, and parses them accordinly
-
-        :return None
-        """
-        start = kwargs.get("backscrape_start")
-        end = kwargs.get("backscrape_end")
-
-        if start:
-            start = datetime.strptime(start, "%m/%d/%Y")
-        else:
-            start = self.first_opinion_date
-        if end:
-            end = datetime.strptime(end, "%m/%d/%Y")
-        else:
-            end = datetime.now() - timedelta(days=30)
-
-        self.back_scrape_iterable = [(start, end)]
-
-    def _download_backwards(self, dates: Tuple[date]) -> None:
-        """Overrides present scraper start_date and end_date
-
-        :param dates: (start_date, end_date) tuple
-        :return None
-        """
-        self.start_date = dates[0].date()
-        self.end_date = dates[1].date()
-
-    @staticmethod
-    def make_date_param(date_obj: date, date_str: str) -> str:
-        """Make JSON encoded string with dates as expected by formdata
-
-        :param date_obj: a date object
-        :param date_str: string representation of the date in expected format
-
-        :return: JSON encoded string
-        """
-        return (
-            '{"enabled":true,"emptyMessage":"",'
-            f'"validationText":"{date_obj}-00-00-00",'
-            f'"valueAsString":"{date_obj}-00-00-00",'
-            '"minDateStr":"1900-01-01-00-00-00",'
-            '"maxDateStr":"2099-12-31-00-00-00",'
-            f'"lastSetTextBoxValue":"{date_str}"'
-            "}"
-        )

--- a/juriscraper/opinions/united_states/state/tex.py
+++ b/juriscraper/opinions/united_states/state/tex.py
@@ -15,9 +15,10 @@
 #  - 2015-08-19: Updated by Andrei Chelaru to add backwards scraping support.
 #  - 2015-08-27: Updated by Andrei Chelaru to add explicit waits
 #  - 2021-12-28: Updated by flooie to remove selenium.
+#  - 2024-02-21; Updated by grossir: handle dynamic backscrapes
 
-from datetime import date, timedelta
-from typing import Optional
+from datetime import date, datetime, timedelta
+from typing import Dict, Optional, Tuple
 
 from juriscraper.AbstractSite import logger
 from juriscraper.DeferringList import DeferringList
@@ -29,6 +30,11 @@ class Site(OpinionSiteLinear):
     rows_xpath = (
         "//table[@class='rgMasterTable']/tbody/tr[not(@class='rgNoRecords')]"
     )
+    param_date_format = "%-m/%-d/%Y"
+    first_opinion_date = datetime(2002, 1, 24, 0, 0, 0)
+    next_page_xpath = (
+        "//input[@title='Next Page' and not(@onclick='return false;')]"
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -36,11 +42,13 @@ class Site(OpinionSiteLinear):
         self.checkbox = 0
         self.status = "Published"
         self.url = "https://search.txcourts.gov/CaseSearch.aspx?coa=cossup"
+        self.make_backscrape_iterable(kwargs)
+        self.next_page = None
+        # Default scrape range if not doing a backscrape
+        self.end_date = date.today()
+        self.start_date = self.end_date - timedelta(days=30)
 
-    def _set_parameters(
-        self,
-        view_state: str,
-    ) -> None:
+    def _set_parameters(self) -> None:
         """Set ASPX post parameters
 
         This method - chooses the court and date parameters.
@@ -52,45 +60,62 @@ class Site(OpinionSiteLinear):
          3: 2nd District Court of Appeals
          ...etc
 
-        :param view_state: view state of the page
         :return: None
         """
-        today = date.today()
-        last_month = today - timedelta(days=30)
-        last_month_str = last_month.strftime("%m/%d/%Y")
-        today_str = today.strftime("%m/%d/%Y")
+        start_date_str = self.start_date.strftime(self.param_date_format)
+        end_date_str = self.end_date.strftime(self.param_date_format)
 
-        date_param = (
-            '{"enabled":true,"emptyMessage":"",'
-            f'"validationText":"{last_month}-00-00-00",'
-            f'"valueAsString":"{last_month}-00-00-00",'
-            '"minDateStr":"1900-01-01-00-00-00",'
-            '"maxDateStr":"2099-12-31-00-00-00",'
-            f'"lastSetTextBoxValue":"{last_month_str}"'
-            "}"
+        from_date_param = self.make_date_param(self.start_date, start_date_str)
+        to_date_param = self.make_date_param(self.end_date, end_date_str)
+
+        self.parameters = {}
+        for hidden in self.html.xpath("//input[@type='hidden']"):
+            value = hidden.xpath("@value")[0] if hidden.xpath("@value") else ""
+            self.parameters[hidden.xpath("@name")[0]] = value
+
+        self.parameters.update(
+            {
+                "ctl00$ContentPlaceHolder1$SearchType": "rbSearchByDocument",  # "Document Search" radio button
+                "ctl00$ContentPlaceHolder1$dtDocumentFrom": str(
+                    self.start_date
+                ),
+                "ctl00$ContentPlaceHolder1$dtDocumentFrom$dateInput": start_date_str,
+                "ctl00$ContentPlaceHolder1$dtDocumentTo": str(self.end_date),
+                "ctl00$ContentPlaceHolder1$dtDocumentTo$dateInput": end_date_str,
+                "ctl00_ContentPlaceHolder1_dtDocumentFrom_dateInput_ClientState": from_date_param,
+                "ctl00_ContentPlaceHolder1_dtDocumentTo_dateInput_ClientState": to_date_param,
+                "ctl00$ContentPlaceHolder1$btnSearchText": "Search",
+                "ctl00$ContentPlaceHolder1$chkListDocTypes$0": "on",  # "Opinion" checkbox
+                f"ctl00$ContentPlaceHolder1$chkListCourts${self.checkbox}": "on",  # Court checkbox
+                "ctl00$ContentPlaceHolder1$txtSearchText": "",
+                "ctl00_ContentPlaceHolder1_dtDocumentFrom_ClientState": '{"minDateStr":"1900-01-01-00-00-00","maxDateStr":"2099-12-31-00-00-00"}',
+                "ctl00_ContentPlaceHolder1_dtDocumentTo_ClientState": '{"minDateStr":"1900-01-01-00-00-00","maxDateStr":"2099-12-31-00-00-00"}',
+                "ctl00$ContentPlaceHolder1$Stemming": "on",
+                "ctl00$ContentPlaceHolder1$Fuzziness": "0",
+            }
         )
 
-        self.parameters = {
-            "ctl00$ContentPlaceHolder1$SearchType": "rbSearchByDocument",  # "Document Search" radio button
-            "ctl00$ContentPlaceHolder1$dtDocumentFrom": str(last_month),
-            "ctl00$ContentPlaceHolder1$dtDocumentFrom$dateInput": last_month_str,
-            "ctl00_ContentPlaceHolder1_dtDocumentFrom_dateInput_ClientState": date_param,
-            "ctl00$ContentPlaceHolder1$dtDocumentTo": str(today),
-            "ctl00$ContentPlaceHolder1$dtDocumentTo$dateInput": today_str,
-            "ctl00$ContentPlaceHolder1$chkListDocTypes$0": "on",  # "Opinion" checkbox
-            "ctl00$ContentPlaceHolder1$btnSearchText": "Search",
-            "__VIEWSTATE": view_state,
-            f"ctl00$ContentPlaceHolder1$chkListCourts${self.checkbox}": "on",  # Court checkbox
-        }
+        # "Next page" arrow button has a name
+        # "ctl00$ContentPlaceHolder1$grdDocuments$ctl00$ctl02$ctl00$ctl18"
+        # Couldn't get pagination working when using the numbered page anchors,
+        # whose id goes into __EVENTTARGET
+        if self.next_page:
+            self.parameters[self.next_page[0].xpath("@name")[0]] = ""
+            self.parameters["__EVENTTARGET"] = ""
+            self.parameters["__SCROLLPOSITIONX"] = "0"
+            self.parameters["__SCROLLPOSITIONY"] = "345"
+            self.parameters["__EVENTARGUMENT"] = ""
+            self.parameters["__LASTFOCUS"] = ""
 
     def _process_html(self) -> None:
+        """Process HTML and paginates if needed
+
+        :return: None
+        """
         if not self.test_mode_enabled():
             # Make our post request to get our data
             self.method = "POST"
-            view_state = self.html.xpath("//input[@id='__VIEWSTATE']")[0].get(
-                "value"
-            )
-            self._set_parameters(view_state)
+            self._set_parameters()
             self.html = super()._download()
 
         for row in self.html.xpath(self.rows_xpath):
@@ -103,6 +128,10 @@ class Site(OpinionSiteLinear):
                     "url": row.xpath(".//a")[1].get("href"),
                 }
             )
+
+        self.next_page = self.html.xpath(self.next_page_xpath)
+        if self.next_page and not self.test_mode_enabled():
+            self._process_html()
 
     def _get_case_names(self) -> DeferringList:
         """Get case names using a deferring list."""
@@ -139,3 +168,51 @@ class Site(OpinionSiteLinear):
                 return None
 
         return DeferringList(seed=seeds, fetcher=get_name)
+
+    def make_backscrape_iterable(self, kwargs: Dict) -> None:
+        """Checks if backscrape start and end arguments have been passed
+        by caller, and parses them accordinly
+
+        :return None
+        """
+        start = kwargs.get("backscrape_start")
+        end = kwargs.get("backscrape_end")
+
+        if start:
+            start = datetime.strptime(start, "%m/%d/%Y")
+        else:
+            start = self.first_opinion_date
+        if end:
+            end = datetime.strptime(end, "%m/%d/%Y")
+        else:
+            end = datetime.now() - timedelta(days=30)
+
+        self.back_scrape_iterable = [(start, end)]
+
+    def _download_backwards(self, dates: Tuple[date]) -> None:
+        """Overrides present scraper start_date and end_date
+
+        :param dates: (start_date, end_date) tuple
+        :return None
+        """
+        self.start_date = dates[0].date()
+        self.end_date = dates[1].date()
+
+    @staticmethod
+    def make_date_param(date_obj: date, date_str: str) -> str:
+        """Make JSON encoded string with dates as expected by formdata
+
+        :param date_obj: a date object
+        :param date_str: string representation of the date in expected format
+
+        :return: JSON encoded string
+        """
+        return (
+            '{"enabled":true,"emptyMessage":"",'
+            f'"validationText":"{date_obj}-00-00-00",'
+            f'"valueAsString":"{date_obj}-00-00-00",'
+            '"minDateStr":"1900-01-01-00-00-00",'
+            '"maxDateStr":"2099-12-31-00-00-00",'
+            f'"lastSetTextBoxValue":"{date_str}"'
+            "}"
+        )

--- a/sample_caller.py
+++ b/sample_caller.py
@@ -174,6 +174,16 @@ def main():
         help="Download the historical corpus using the _download_backwards method.",
     )
     parser.add_option(
+        "--backscrape-start",
+        dest="backscrape_start",
+        help="Starting value for backscraper iterable creation",
+    )
+    parser.add_option(
+        "--backscrape-end",
+        dest="backscrape_end",
+        help="End value for backscraper iterable creation",
+    )
+    parser.add_option(
         "-r",
         "--report",
         action="store_true",
@@ -187,6 +197,8 @@ def main():
     binaries = options.binaries
     court_id = options.court_id
     backscrape = options.backscrape
+    backscrape_start = options.backscrape_start
+    backscrape_end = options.backscrape_end
     generate_report = options.report
 
     # Set up the print function
@@ -232,7 +244,11 @@ def main():
             try:
                 if backscrape:
                     for site in site_yielder(
-                        mod.Site().back_scrape_iterable, mod
+                        mod.Site(
+                            backscrape_start=backscrape_start,
+                            backscrape_end=backscrape_end,
+                        ).back_scrape_iterable,
+                        mod,
                     ):
                         site.parse()
                         scrape_court(site, binaries)


### PR DESCRIPTION
feat(backscrape): support dynamic backscraping ranges
feat(tex): support dynamic backscraping in tex

Support passing optional start and end backscraping values.
This will help localize backscrapes without having to change
harcoded values. However, it will have to be implemented
on a source by source basis, since the ranges are created
with full dates, years, indexes, etc.

This PR also implements the dynamic backscraper for `tex`
which is one of the sources where we have the biggest gaps

Solves #942: dynamic backscraping
Solves #944: implement `tex` backscraping

but will need a complimentary PR in courtlistener to deploy

Test with:
```
    python sample_caller.py -c juriscraper.opinions.united_states.state.tex --backscrape --backscrape-start=01/01/2018 --backscrape-end=01/01/2019
    
    python sample_caller.py -c juriscraper.opinions.united_states.state.tex --backscrape --backscrape-start=01/01/2017 --backscrape-end=01/01/2018
```

