### PR TITLE
fix(miss): Fix Mississippi scraper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,6 @@ tests/fixtures/cassettes/
 # Swap files
 *.swp
 *~
+
+# Ignoring devcontainer folder from vscode
+.devcontainer

--- a/juriscraper/opinions/united_states/state/miss.py
+++ b/juriscraper/opinions/united_states/state/miss.py
@@ -15,7 +15,7 @@ class Site(OpinionSiteLinear):
         self.method = "POST"
         self.number_of_dates_to_process = 5
         self.pages = {}
-        self.parameters = {"crt": self.get_court_parameter()}
+        self.parameters = {"court": self.get_court_parameter()}
         self.status = "Published"
         self.url = f"{self.domain}/appellatecourts/docket/gethddates.php"
 


### PR DESCRIPTION
Small modification to repair Mississippi court scraper. The parameter passed to do a POST was changed from `{crt: 'SCT'}`  to  `{court: 'SCT'}`