### PR TITLE
fix(pacer.email): parse short description for `deb` and `mdb`

### DIFF
--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -542,7 +542,7 @@ class NotificationEmail(BaseDocketReport, BaseReport):
             # Remove docket number traces "-AAA"
             regex = r"^-.*?\s"
             short_description = re.sub(regex, "", short_description)
-        elif self.court_id in ["njb", "dcb", "vaeb", "paeb"]:
+        elif self.court_id in ["njb", "dcb", "vaeb", "paeb", "mdb"]:
             # In: Ch-11 19-27439-MBK Determination of Adjournment Request - Hollister Construc
             # Out: Determination of Adjournment Request
             short_description = subject.split(docket_number)[-1]
@@ -565,10 +565,12 @@ class NotificationEmail(BaseDocketReport, BaseReport):
             # Remove docket number traces "-AAA"
             regex = r"^-.*?\s"
             short_description = re.sub(regex, "", short_description)
-        elif self.court_id in ["pawb", "ndb"]:
+        elif self.court_id in ["pawb", "ndb", "deb"]:
             # In: Ch-7 22-20823-GLT U LOCK INC Reply
             # Out: Reply
-            short_description = subject.split(case_name)[-1]
+            if case_name in subject:
+                # See deb_2.txt for need of this check
+                short_description = subject.split(case_name)[-1]
         else:
             logger.error(
                 "Short description has no parsing for bankruptcy court '%s'",

--- a/tests/examples/pacer/nef/s3/deb_1.json
+++ b/tests/examples/pacer/nef/s3/deb_1.json
@@ -1,0 +1,36 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "deb",
+  "dockets": [
+    {
+      "case_name": "JOANN Inc.",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-04-23",
+          "description": "Declaration (related document(s)[226]) Filed by JOANN Inc.. (LastName, FirstName)",
+          "document_number": "297",
+          "document_url": "https://ecf.deb.uscourts.gov/doc1/042021533455?pdf_header=&magic_num=47456538&de_seq_num=1312&caseid=192329",
+          "pacer_case_id": "192329",
+          "pacer_doc_id": "042021533455",
+          "pacer_magic_num": "47456538",
+          "pacer_seq_no": "1312",
+          "short_description": "Declaration"
+        }
+      ],
+      "docket_number": "24-10418"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "xx@bb.org",
+        "xx@bb.org",
+        "yy@zz.com",
+        "yy@zz.com"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/deb_1.txt
+++ b/tests/examples/pacer/nef/s3/deb_1.txt
@@ -1,0 +1,112 @@
+Return-Path: <DEBdb_ECF_Reply@deb.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id rv8bbs6984ubijncfifmaoi4f6c2na6pdse8vc81
+ for user@recap.email;
+ Tue, 23 Apr 2024 20:51:49 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of deb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=DEBdb_ECF_Reply@deb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of deb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=DEBdb_ECF_Reply@deb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=pass header.from=deb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHNVpFY3hEK253S29lbEhlWjY4VndRUVdRblZFS21QWVl3aTVFYkxzMlFmUGNUNC9WMVFvTU9vcnlrd2ZFWExSQ3J0R3hnZjBjb3hiRFdHL2xoa1lWNDBST01sRTVhSlYrdkc3V1hYTnpiSnBXTU9iVDRWZ2VoUnFvR1JBV3lKL3lQSFlrU1hxNTFiTTEvNU56Zm5JN1hqM05Cb3lzTVBtdmJBTEdiRjlvQTVnb2JYZjQxZDYrZXBTTjFaNVNMUkFuUW1NUTlOVGlGNnJ2ay9laFFYVStqUnJJS0Z6b3U2anBDTHZBSkZJdzIwSms3Q0x2SkdqdkZJaFljamNkRzAwQXJsRk5EVWVUUzhMVzhxYzl3ZS9rTVBHY1FIYTZaUnNjYUtKRElHSytHYmRIL3F1QVBqaFFSYjNWM1EvZkhOeGM9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=oMW9mRChuJUAr3ZqeH4esHNmFMRmY1re9Nczl9mrXix6OKx0aSFN4is9q/EnxSVEAB1AxaP1JEt7ePglyCfuG3qi5QgSxtDigKgWqUit8hgGUu9MsnvvYWO+YzlxxxZLE+7gIIBOcTUJZL9WViaUlwMzMFBUlHX5oWPv8zUPRaQ=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1713905511; v=1; bh=2t42oGnyedk34f7Dux9GaXWEeKC4z1dog7QKMeXE+8w=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.33
+Received: from debdb.deb.gtwy.dcn ([156.119.190.33])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 23 Apr 2024 16:51:49 -0400
+Received: from debdb.deb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by debdb.deb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 43NKp2sc108959;
+	Tue, 23 Apr 2024 16:51:05 -0400
+Received: (from ecf_web@localhost)
+	by debdb.deb.gtwy.dcn (8.14.7/8.14.4/Submit) id 43NKoPLl107903;
+	Tue, 23 Apr 2024 16:50:25 -0400
+Date: Tue, 23 Apr 2024 16:50:25 -0400
+X-Authentication-Warning: debdb.deb.gtwy.dcn: ecf_web set sender to DEBdb_ECF_Reply@deb.uscourts.gov using -f
+MIME-Version:1.0
+From:DEBdb_ECF_Reply@deb.uscourts.gov
+To:dummail@deb.uscourts.gov
+Message-Id:<18536834@deb.uscourts.gov>
+Subject:Ch-11 24-10418-CTG JOANN Inc. Declaration
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of Delaware</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Rebecca L Lamb entered on 4/23/2024 at 4:50 PM EDT and filed on 4/23/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>JOANN Inc.</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.deb.uscourts.gov/cgi-bin/DktRpt.pl?192329>24-10418-CTG</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.deb.uscourts.gov/doc1/042021533455?pdf_header=&magic_num=47456538&de_seq_num=1312&caseid=192329'>297</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+   Declaration <i>of Ordinary Course Professional Dickinson Wright PLLC</i>  (related document(s)[226]) Filed by    JOANN Inc..    (LastName, FirstName)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>N:\Bankruptcy\Joann Fabrics - 103513.1001\To Be Filed\NOT Dickinson Wright OCP Declaration.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=983460418 [Date=4/23/2024] [FileNumber=18536832-0
+<BR><TAB>] [a4bc9c188e60f81dff29720bdb2b184215cca147e1606ea064da8109b0f9188763f
+<BR><TAB>8190b47adca4db486d71cd2b16c655de9f32b96f63e97e1a312814ed6b143]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+24-10418-CTG Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName  LastName on behalf of Creditor   Broward County</span>
+<br>xx@bb.org,  xx@bb.org
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Creditor   Bank of America, N.A.</span>
+<br>yy@zz.com,  yy@zz.com
+<BR>
+<BR><span class="personName">FirstName  LastName on behalf of Interested Party   Win Properties, Inc.</span>
+<BR>AA BB & CC LLP
+<BR>1 World Trade Center 
+<BR>170 Greenwich Street
+<BR>New York, NY 60001
+<BR>
+
+<BR>
+<B>
+
+</B>
+
+<BR>
+<BR>

--- a/tests/examples/pacer/nef/s3/deb_2.json
+++ b/tests/examples/pacer/nef/s3/deb_2.json
@@ -1,0 +1,37 @@
+{
+  "appellate": false,
+  "contains_attachments": true,
+  "court_id": "deb",
+  "dockets": [
+    {
+      "case_name": "Akorn Holding Company LLC",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-04-23",
+          "description": "Order Approving Confidentiality and Non-Disclosure Agreement Between Chapter 7 Trustee and Thea Pharma Inc. (related document(s)[794]) Order Signed on 4/23/2024. (Attachments: (1) Exhibit 1) (Mml)",
+          "document_number": "795",
+          "document_url": "https://ecf.deb.uscourts.gov/doc1/042021533640?pdf_header=&magic_num=39159314&de_seq_num=2728&caseid=189188",
+          "pacer_case_id": "189188",
+          "pacer_doc_id": "042021533640",
+          "pacer_magic_num": "39159314",
+          "pacer_seq_no": "2728",
+          "short_description": ""
+        }
+      ],
+      "docket_number": "23-10253"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "xx@gg.com",
+        "yy@gg.com",
+        "zz@gg.com",
+        "cc@dd.com",
+        "aa@bb.com"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/deb_2.txt
+++ b/tests/examples/pacer/nef/s3/deb_2.txt
@@ -1,0 +1,114 @@
+Return-Path: <DEBdb_ECF_Reply@deb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 9ifv6rb3p2dhtn5oclbtfsummpbu8pq08ip227o1
+ for user@recap.email;
+ Tue, 23 Apr 2024 21:45:49 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of deb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=DEBdb_ECF_Reply@deb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of deb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=DEBdb_ECF_Reply@deb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=pass header.from=deb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFGeFNWdWxycGppb2JkTmw5Zmpsa0xtUDNZalpoSTFNWHZXWFhvREU0MTJTZ1VaOXp1OVIvOWkzcU5KZkJzWC9QSHVrbzYxZ2tRSHJTMzNUUllQd1ZHWW5idGRNMnhRQXhWbHFmQWx2TlVjeWRpYzd0ZytiWkI1c0dHKzlkOWlpWXpSRXJ6bXk5RnpQM2s5QWlmSCt2elVHUmJUMzNZdStyK2JrSnp4QVpIUHNmL0tUNG1LU3FxNGhoTXI4TEpFMDVyaGg1QlQ4WHNuZndPekF3U0VDSnp6aUtjenZkZk9ldmlWUVFxSFhDRTQ2djNETW5DTWpXOUovcCszTXc4RjJib1RiWkJLUzUvSzlWN3ZqZ2NaNmRudXJ2YmlRZGNQVjFTZVY2QnU5cDdOZjNoYzBLOHRqdXg3dktnMERXOThnYjQ9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=fr+iwDe/s12sS2qubWxo7LBY57GoZej3lRMJEzb1GS7dqxZgcuOBw9B4vzasxC5pQuhZ/2S9y7pwKrKNSDQUQh9vq4Ey4E2RPwUFq72F9vLD9F6fMgVVdaSBTFn6/vaa4J6Wijd0WGDu4cq3XodgUqb/nU0rLgY0Suy6VcRXztQ=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1713908750; v=1; bh=bdnPdkBHkGTrcEeLKzBHorW0n7g+YnQLApFYRKwGUfM=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.33
+Received: from debdb.deb.gtwy.dcn ([156.119.190.33])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 23 Apr 2024 17:45:49 -0400
+Received: from debdb.deb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by debdb.deb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 43NLj2lx113046;
+	Tue, 23 Apr 2024 17:45:05 -0400
+Received: (from ecf_web@localhost)
+	by debdb.deb.gtwy.dcn (8.14.7/8.14.4/Submit) id 43NLiLVD111354;
+	Tue, 23 Apr 2024 17:44:21 -0400
+Date: Tue, 23 Apr 2024 17:44:21 -0400
+X-Authentication-Warning: debdb.deb.gtwy.dcn: ecf_web set sender to DEBdb_ECF_Reply@deb.uscourts.gov using -f
+MIME-Version:1.0
+From:DEBdb_ECF_Reply@deb.uscourts.gov
+To:dummail@deb.uscourts.gov
+Message-Id:<18536996@deb.uscourts.gov>
+Subject:Ch-7 23-10253-KBO Akorn Holding Comp Order
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of Delaware</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Mml entered on 4/23/2024 at 5:44 PM EDT and filed on 4/23/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Akorn Holding Company LLC</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.deb.uscourts.gov/cgi-bin/DktRpt.pl?189188>23-10253-KBO</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.deb.uscourts.gov/doc1/042021533640?pdf_header=&magic_num=39159314&de_seq_num=2728&caseid=189188'>795</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Order Approving Confidentiality and Non-Disclosure Agreement Between Chapter 7 Trustee and Thea Pharma Inc. (related document(s)[794]) Order   Signed on 4/23/2024.  (Attachments: # (1) Exhibit 1) (Mml)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>Akorn_-_Order_to_Upload.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=983460418 [Date=4/23/2024] [FileNumber=18536994-0
+<BR><TAB>] [41bdc1718287547878a190d76ffbeb97e17665bca02f30a185e8f45bf5f282e1504
+<BR><TAB>0b457e214c9c672d0849064b8e5192865096f9b6443b4dfdd588954ecbee3]]
+<BR>
+<STRONG>Document description:</STRONG>Exhibit 1
+<BR><STRONG>Original filename:</STRONG>Akorn_-_Order_to_Upload_ex_1.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=983460418 [Date=4/23/2024] [FileNumber=18536994-1
+<BR><TAB>] [975a753649dd4fbf7b341f9aab4a98e214adf409c1cd7800022bdbec6c912ccaec7
+<BR><TAB>e420b6f8b002f939e1f5f1baaca091c7378949ce4322da889e22a90945876]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+23-10253-KBO Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FistName LastName on behalf of Creditor Stira Pharmaceuticals, LLC</span>
+<br>xx@gg.com
+<BR>
+<BR>
+<BR><span class="personName">FistName LastName on behalf of Interested Party   AmerisourceBergen Drug Corporation</span>
+<br>yy@gg.com,  zz@gg.com
+<BR>
+<BR><span class="personName">FistName LastName on behalf of Creditor Weldon  Chin</span>
+<br>cc@dd.com
+<BR>
+<BR><span class="personName">FistName LastName on behalf of Creditor   HYG Financial Service, Inc.</span>
+<br>aa@bb.com
+<BR>
+<

--- a/tests/examples/pacer/nef/s3/mdb_1.json
+++ b/tests/examples/pacer/nef/s3/mdb_1.json
@@ -1,0 +1,45 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "mdb",
+  "dockets": [
+    {
+      "case_name": "Charles Martin",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-04-16",
+          "description": "Response on behalf of Charles Martin Filed by Charles Martin (related document(s)[522] Motion to Sell and Notice of Motion filed by Trustee Cheryl E. Rose). Hearing scheduled for 5/8/2024 at 02:00 PM by videoconference or teleconference. For hearing access information see www.mdb.uscourts.gov/hearings or call 410-962-2688. (FirstName LastName)",
+          "document_number": "525",
+          "document_url": "https://ecf.mdb.uscourts.gov/doc1/092051699384?pdf_header=&magic_num=63947579&de_seq_num=1997&caseid=751901",
+          "pacer_case_id": "751901",
+          "pacer_doc_id": "092051699384",
+          "pacer_magic_num": "63947579",
+          "pacer_seq_no": "1997",
+          "short_description": "Response"
+        }
+      ],
+      "docket_number": "20-18680"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "ab@maryland.gov",
+        "USTPRegion04.GB.ECF@USDOJ.GOV",
+        "uyy@zzz.com",
+        "aa@bb.com",
+        "aa@xx.com",
+        "cc@yy.com",
+        "user@notify.bestcase.com",
+        "user@recap.email",
+        "aa@bb.com",
+        "aa@bb.com",
+        "AA@BB.net",
+        "A@kk.com",
+        "b@kk.com"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/mdb_1.txt
+++ b/tests/examples/pacer/nef/s3/mdb_1.txt
@@ -1,0 +1,121 @@
+Return-Path: <BKECF_LiveDB@mdb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id n6hfeb3o73btqoftedndlt6abmu0sqdbadhf3jo1
+ for user@recap.email;
+ Tue, 16 Apr 2024 17:52:27 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of mdb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=BKECF_LiveDB@mdb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of mdb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=BKECF_LiveDB@mdb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=mdb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFGU1d5Q2ZHRS9DY1NxZHRtVUF6S2RtcEh3b0s1TjM0KytqeldGd3Y2VlV5OCtFRTI1MkNvOEpGWStHUzZtMFlQMkRqcUYyNERKbll3VldpcHp5UWhRdTNadUVLdzVWT2dFaWZyQ0N4U0ZoSTVTdmQ4WEFZSFBaOE52SmxaUXVabDhYOFUzREYzZjBaRStLRGduQ0NxelloQ2dzUlY5ZHNZRW9sUlJmV0lrdWF5Q1YxVEN5aE0wUjVYMERNTk9TcTR2V0pLUXIzTjZpNXZIbURwZTgwMnF6ODlFb3ZEQldTMXJ0Q1l3L3cwb0kxaXRvK0dMWE8rOFFISlpsQ0U1anMwQjNQc3hRaVQ1SWczYnM2N2pwTXFRZ0h1L2F2T2JGaTlvZmc2Tm1YdTJWeVE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=BldOWgD0OWt1th0rR6mIgfdJqjD5wajF7tky7/P4qphQMSj5FYgzRMnO5TvdUnWWdQiYeEa89oiDCqCtHYBgTdT+rOXDSkY4RsgSzIpZjKyIuhLO5np51uwVRWhh+dnhWMzdpJrca5JICd9ml8uOso8qC2jc/AI+wuzBx0nohgw=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1713289948; v=1; bh=4T/d7yF86JogPUD1CKlXC/2mFQE5lzy1klpv0NB9mlU=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.184
+Received: from mdbdb.mdb.gtwy.dcn ([156.119.190.184])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 16 Apr 2024 13:52:26 -0400
+Received: from mdbdb.mdb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by mdbdb.mdb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 43GHqKLU071293;
+	Tue, 16 Apr 2024 13:52:23 -0400
+Received: (from ecf_web@localhost)
+	by mdbdb.mdb.gtwy.dcn (8.14.7/8.14.4/Submit) id 43GHplkQ070736;
+	Tue, 16 Apr 2024 13:51:47 -0400
+Date: Tue, 16 Apr 2024 13:51:47 -0400
+MIME-Version:1.0
+From:BKECF_LiveDB@mdb.uscourts.gov
+To:courtmail@mdb.uscourts.gov
+Message-Id:<47751327@mdb.uscourts.gov>
+Subject:20-18680 Response - CH7 - Charles Martin
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of Maryland</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Oliver, Yvette  entered on 4/16/2024 at 1:51 PM EDT and filed on 4/16/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Charles Martin                                    </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.mdb.uscourts.gov/cgi-bin/DktRpt.pl?751901>20-18680</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.mdb.uscourts.gov/doc1/092051699384?pdf_header=&magic_num=63947579&de_seq_num=1997&caseid=751901'>525</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Response on behalf of  Charles  Martin  Filed by  Charles  Martin  (related document(s)[522] Motion to Sell and Notice of Motion filed by Trustee Cheryl E. Rose). Hearing scheduled for 5/8/2024 at 02:00 PM by videoconference or teleconference. For hearing access information see www.mdb.uscourts.gov/hearings or call 410-962-2688.  (FirstName LastName)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>20-18680 ba-001.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1013806484 [Date=4/16/2024] [FileNumber=47751325-
+<BR><TAB>0] [1b706080f9378f5d3324a1654a3d9655187e264097d3ed1e58752ebee03cced8b2
+<BR><TAB>c6763291f8a71ed56f7c14982ebd19284a65d5002b9a9b75c6e7b7ba93734e]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+20-18680 Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName</span> ab@maryland.gov
+<BR>
+<BR><span class="personName">  US Trustee - Greenbelt</span> USTPRegion04.GB.ECF@USDOJ.GOV
+<BR>
+<BR><span class="personName">FirstName LastName</span> uyy@zzz.com,
+<br>  aa@bb.com,
+<br>aa@xx.com,
+<br>cc@yy.com,
+<br>user@notify.bestcase.com,
+<br>user@recap.email
+<BR>
+<BR><span class="personName">FirstName LastName</span> aa@bb.com,
+<br>  aa@bb.com,
+<br>AA@BB.net,
+<br>A@kk.com,
+<br>b@kk.com
+<BR>
+
+<BR>
+<B>
+20-18680 Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR>Debtor(s): FirstName LastName; FirstName LastName; FirstName LastName
+<BR><span class="personName">FirstName LastName</span>
+<BR>11111 Atown Road 
+<BR>Atown, MD 20810
+<BR>

--- a/tests/examples/pacer/nef/s3/mdb_2.json
+++ b/tests/examples/pacer/nef/s3/mdb_2.json
@@ -1,0 +1,33 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "mdb",
+  "dockets": [
+    {
+      "case_name": "Jefferson v. Alter",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-04-19",
+          "description": "Order Denying Motion To Quash (related document(s):[97] Motion for Protective Order filed by 3rd Party Plaintiff Jennifer L. Alter, Defendant Jennifer L. Alter, 3rd Party Plaintiff Eagle Premier Title Group, LLC, Defendant Eagle Premier Title Group, LLC, Motion to Quash). (LastName, FirstName)",
+          "document_number": "99",
+          "document_url": "https://ecf.mdb.uscourts.gov/doc1/092051714783?pdf_header=&magic_num=11582823&de_seq_num=409&caseid=768557",
+          "pacer_case_id": "768557",
+          "pacer_doc_id": "092051714783",
+          "pacer_magic_num": "11582823",
+          "pacer_seq_no": "409",
+          "short_description": "Order on Motion To Quash"
+        }
+      ],
+      "docket_number": "22-00193"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "a@b.com"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/mdb_2.txt
+++ b/tests/examples/pacer/nef/s3/mdb_2.txt
@@ -1,0 +1,106 @@
+Return-Path: <BKECF_LiveDB@mdb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id ibr3vk7f6t482tr3kn5ercbot85rjg38tjumsk01
+ for user@recap.email;
+ Fri, 19 Apr 2024 12:45:04 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of mdb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=BKECF_LiveDB@mdb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of mdb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=BKECF_LiveDB@mdb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=mdb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFb0FJb014VHdjM0xTQ20yTlVZbGNIdmF1Y0JRNWxNN2I3MzMydjY5b3M2MTBlVFg3cVVsU3RVNW5XVzV2aDJiL1RBdit4NkxrQnBjdkJ1VVkwUjlzMlFOUTJ5THV5WmV0SGRETHRmcVlIZGdUdGhJMXZSZXdDcWVHUm1hUVk1NHNDc2ltNTZKSzNHQkxQb1g2aDkrRnFNN1NUN3FvTlFiUzZBdGpSc2RSQTNKQmVDSmJXUktBY0lHNGZ5dnRuRUtPMDZ6RHZNQWZUY3hycjd1U3pJQ0lMOGdhM2hKalFRN1VxdFU1VVNNdHd6b3c2S29uVUJYdWtmWTlTSTRGb3NtYzc4V2FsemFyNXJzeG9xQmF1SFpHdVhBbEJxK0JyM3dScDhxU3dacjBsY0E9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=isoxmxwKm31yKkH3VRCk/bg0HDb33JxwYynkTlme1eg90DWsLvz8N4Q0gm58NPS3szvxybsDVrjMrFFGYSgBSlbu6uxxaZyYphJOL7KPOVVEcugC1Gq02aVH+BwRqpstb+7YvX7YhkCta6sxiyFLFmlodXLxJcUq9DOD2rG0YjA=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1713530706; v=1; bh=Mljc8QSweEMHvfMI2fKWARVLs4HQK51lhFLdETJcJJk=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.184
+Received: from mdbdb.mdb.gtwy.dcn ([156.119.190.184])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 19 Apr 2024 08:45:04 -0400
+Received: from mdbdb.mdb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by mdbdb.mdb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 43JCiwho075911;
+	Fri, 19 Apr 2024 08:44:59 -0400
+Received: (from ecf_web@localhost)
+	by mdbdb.mdb.gtwy.dcn (8.14.7/8.14.4/Submit) id 43JCinki075611;
+	Fri, 19 Apr 2024 08:44:49 -0400
+Date: Fri, 19 Apr 2024 08:44:49 -0400
+MIME-Version:1.0
+From:BKECF_LiveDB@mdb.uscourts.gov
+To:courtmail@mdb.uscourts.gov
+Message-Id:<47764967@mdb.uscourts.gov>
+Subject:22-00193 Order on Motion To Quash - CH - Jefferson v. Alter et al
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of Maryland</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from LastName, FirstName entered on 4/19/2024 at 8:44 AM EDT and filed on 4/19/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Jefferson v. Alter et al</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.mdb.uscourts.gov/cgi-bin/DktRpt.pl?768557>22-00193</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.mdb.uscourts.gov/doc1/092051714783?pdf_header=&magic_num=11582823&de_seq_num=409&caseid=768557'>99</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Order Denying Motion To Quash (related document(s):[97] Motion for Protective Order filed by 3rd Party Plaintiff Jennifer L. Alter, Defendant Jennifer L. Alter, 3rd Party Plaintiff   Eagle Premier Title Group, LLC, Defendant   Eagle Premier Title Group, LLC, Motion to Quash).     (LastName, FirstName)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>/opt/BKECF/live/web/eorderDocs/poStampedDocs/lss/1309252-signed.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1013806484 [Date=4/19/2024] [FileNumber=47764965-
+<BR><TAB>0] [08e29cea0e33c7dafb5a4002663cdd825fdf4d72e8c69b2c94b595fa74c7d83949
+<BR><TAB>3f99e7ebbcad9ae4b7cae5f93de45b5ec1cac099a0bee7a20d7b3a258469c7]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+22-00193 Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName</span> a@b.com
+<BR>
+
+<BR>
+<B>
+22-00193 Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName</span>
+<BR>c/o Company Group, LLC
+<BR>234 Street, Suite C 
+<BR>Baltimore, MD 11111
+<BR>

--- a/tests/examples/pacer/nef/s3/mdb_3.json
+++ b/tests/examples/pacer/nef/s3/mdb_3.json
@@ -1,0 +1,36 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "mdb",
+  "dockets": [
+    {
+      "case_name": "Aligned Development LLC",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-03-27",
+          "description": "BNC Certificate of Mailing - PDF Document. (related document(s)[35] Order Dissolving Show Cause Order). No. of Notices: 1. Notice Date 03/27/2024. (Admin.)",
+          "document_number": "37",
+          "document_url": "https://ecf.mdb.uscourts.gov/doc1/092051619029?pdf_header=&magic_num=44278661&de_seq_num=160&caseid=782151",
+          "pacer_case_id": "782151",
+          "pacer_doc_id": "092051619029",
+          "pacer_magic_num": "44278661",
+          "pacer_seq_no": "160",
+          "short_description": "BNC Certificate of Mailing - PDF Document"
+        }
+      ],
+      "docket_number": "24-11929"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "USTPRegion04.GB.ECF@USDOJ.GOV",
+        "b@dcbankruptcy.com",
+        "aa@notify.bestcase.com",
+        "user@recap.email"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/mdb_3.txt
+++ b/tests/examples/pacer/nef/s3/mdb_3.txt
@@ -1,0 +1,100 @@
+Return-Path: <BKECF_LiveDB@mdb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id 2tv22b5fcb7g0quqg84c5p176jameqvfeklrh1g1
+ for user@recap.email;
+ Thu, 28 Mar 2024 04:26:51 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of mdb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=BKECF_LiveDB@mdb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of mdb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=BKECF_LiveDB@mdb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=mdb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHZkhhdnpYY0NHYXI0RWFzVnk1TGdFQTJVZ1M3MEZnaVMyTEZSMGs0V2R0N2hKZU14TVdqZEM2SE53enJOMFo2a3J1Tmw3dWRMYnNUVlRsMElwNnZ4bUlwaXZRalEzWEFrbC82SUgvQjRUZkZ1Q21yTTh3aU9sbXJXK2YzTDdOT0szNGY3d3ppUUdhNzF4NzVjL3ovQjAwOG54N2xlUEdIS2F0bjkvMEtMdkY2RDJDRVU4YkFiRE80N0I0WS9KTHM3aG5WYTZNc20rcFlWQmVJZ2xUcmFxaDcyYm5EWW9VYXNNNDBSQWNZc0g0dFdydjR2UVdkSHhqcm5oU2dCQkFJRmJwRDlINnY0dnAvVnpmY01qQlJhUmQ1SmZEc2NwQnAwNU80M2pjWmV4bWc9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=G+CAYhZMWS3a4KwkOzxmaW3kOkXrI/xn2ia07Gh0b34Y0BLuBOrHY2OhYD0yKtouthogW0XEowq0eAlcmqpvjowKHpiNT1Yu0iuKAFlr7+58QfTsdAtGMM8Zyz9wuEKkn+nFbPB58ljJlMaZimhEvgQciBsTOiBcdi254xm1k84=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1711600012; v=1; bh=t2WyDf+yBRTmg1IJKl7V9rj6G5VAp67j9Yhe7UmM/HE=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.184
+Received: from mdbdb.mdb.gtwy.dcn ([156.119.190.184])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 28 Mar 2024 00:26:51 -0400
+Received: from mdbdb.mdb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by mdbdb.mdb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 42S4Psal097523;
+	Thu, 28 Mar 2024 00:26:18 -0400
+Received: (from ecf_web@localhost)
+	by mdbdb.mdb.gtwy.dcn (8.14.7/8.14.4/Submit) id 42S4PaBS096602;
+	Thu, 28 Mar 2024 00:25:36 -0400
+Date: Thu, 28 Mar 2024 00:25:36 -0400
+MIME-Version:1.0
+From:BKECF_LiveDB@mdb.uscourts.gov
+To:courtmail@mdb.uscourts.gov
+Message-Id:<47679670@mdb.uscourts.gov>
+Subject:24-11929 BNC Certificate of Mailing - PDF Document - CH11 - Aligned Development LLC
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of Maryland</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Admin entered on 03/28/2024  at 00:23 AM EDT and filed on 03/27/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Aligned Development LLC</td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.mdb.uscourts.gov/cgi-bin/DktRpt.pl?782151>24-11929</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.mdb.uscourts.gov/doc1/092051619029?pdf_header=&magic_num=44278661&de_seq_num=160&caseid=782151'>37</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+BNC Certificate of Mailing - PDF Document. (related document(s)[35] Order Dissolving Show Cause Order). No. of Notices: 1. Notice Date 03/27/2024. (Admin.)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Imaged Certificate of Notice
+<BR><STRONG>Original filename:</STRONG>P02411929pdfparty0150.pdf
+<BR><STRONG>Electronic document Stamp:</STRONG>
+<BR>[STAMP bkecfStamp_ID=1013806484 [Date=3/28/2024] [FileNumber=47679287-0] [97850691e041c77126a3840387ce0edb446824f6994f23f6e0035713c5a4edee6c5878cdcdd0fe732e4687b1de60585e8fe428620278735bdf395b80226b11e3]]
+<BR>
+
+</table>
+</div>
+
+<BR><B>
+24-11929 Notice will be electronically mailed to:
+</B>
+
+<BR>
+<BR><span class="personName">  US Trustee - Greenbelt</span> USTPRegion04.GB.ECF@USDOJ.GOV
+<BR>
+<BR><span class="personName">FirstName LastName</span>
+<br>b@dcbankruptcy.com,
+<br>aa@notify.bestcase.com,
+<br>user@recap.email
+<BR>
+
+<BR>
+<B>
+24-11929 Notice will not be electronically mailed to:
+</B>
+
+<BR>
+<BR>Debtor(s): Company LLC
+<BR><span class="personName">For Internal Use Only</span>
+<BR>,  
+<BR>
+


### PR DESCRIPTION
Solves #912

Add `deb` and `mdb` to if clauses on `_parse_bankruptcy_short_description` method

Also, add 2 test cases for `deb` and 3 for `mdb`