### PR TITLE
fix(pacer.email): parse short description for `pamb`

### DIFF
--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -575,12 +575,21 @@ class NotificationEmail(BaseDocketReport, BaseReport):
             # Remove docket number traces "-AAA"
             regex = r"^-.*?\s"
             short_description = re.sub(regex, "", short_description)
-        elif self.court_id in ["pawb", "ndb", "deb"]:
+        elif self.court_id in ["pawb", "ndb", "deb", "pamb"]:
             # In: Ch-7 22-20823-GLT U LOCK INC Reply
             # Out: Reply
             if case_name in subject:
-                # See deb_2.txt for need of this check
                 short_description = subject.split(case_name)[-1]
+            elif case_name[:18] in subject:
+                # See deb_2.txt, pamb_1 and pamb_3 for examples
+                short_description = subject.split(case_name[:18])[-1]
+            elif (
+                " and " in case_name and case_name.split(" and ")[0] in subject
+            ):
+                # See pamb_2.txt
+                short_description = subject.split(case_name.split(" and ")[0])[
+                    -1
+                ]
         else:
             logger.error(
                 "Short description has no parsing for bankruptcy court '%s'",

--- a/tests/examples/pacer/nef/s3/deb_2.json
+++ b/tests/examples/pacer/nef/s3/deb_2.json
@@ -16,7 +16,7 @@
           "pacer_doc_id": "042021533640",
           "pacer_magic_num": "39159314",
           "pacer_seq_no": "2728",
-          "short_description": ""
+          "short_description": "Order"
         }
       ],
       "docket_number": "23-10253"

--- a/tests/examples/pacer/nef/s3/pamb_1.json
+++ b/tests/examples/pacer/nef/s3/pamb_1.json
@@ -1,0 +1,36 @@
+{
+  "appellate": false,
+  "contains_attachments": true,
+  "court_id": "pamb",
+  "dockets": [
+    {
+      "case_name": "Maria Victoria Diri",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-05-03",
+          "description": "Motion to Reopen Chapter 7 Case. Filing Fee due in the amount of $260.00. Filed by FirstName LastName of firm, P.C. on behalf of Maria Victoria Diri (RE: related document(s)[64]). (Attachments: (1) Proposed Order (2) Certificate of Service) (FirstName LastName)",
+          "document_number": "78",
+          "document_url": "https://ecf.pamb.uscourts.gov/doc1/154018337184?pdf_header=&magic_num=83584343&de_seq_num=341&caseid=270840",
+          "pacer_case_id": "270840",
+          "pacer_doc_id": "154018337184",
+          "pacer_magic_num": "83584343",
+          "pacer_seq_no": "341",
+          "short_description": "Motion to Reopen Case"
+        }
+      ],
+      "docket_number": "5:21-bk-00329"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "help@lawfirm.com",
+        "a@lawfirm.com;b@lawfirm.com;c@lawfirm.com;noreply04@lawfirm.com;noreply05@lawfirm.com;lawfirmpc@domain.net;lawfirm@recap.email;ecf@casedriver.com",
+        "a@b.com",
+        "c@b.com"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/pamb_1.txt
+++ b/tests/examples/pacer/nef/s3/pamb_1.txt
@@ -1,0 +1,113 @@
+Return-Path: <PAMB_LiveDB@pamb.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id t76hahcikcvql0a6qetq4ha0m18u4kkuvvk7mh81
+ for user@recap.email;
+ Fri, 03 May 2024 15:16:43 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of pamb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=PAMB_LiveDB@pamb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of pamb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=PAMB_LiveDB@pamb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=pamb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFRUE1bE5DU3lXbGpaZTY0d0NPck5STm1PL1MrclJtNGxFUm0valhlanZPeGU4VUw3TTBmZVppSHp1cE1JQXhudTA0aHhDSEs5UGNFS0E5TEh0dmhieVBmUWxCQ2wvbzdkMkdRZW5EVEJqUllKbXFmZmxTeVZxMEQ0djJVdXdFTE52a1hGRUJ0ZkRrZ29wK3lnb3hvd2Vsc1BKZFZwenZyMnkrYWI0b1Z5R2JQd3B4dTlISmRnbEhJUmplYnZKNnE4V0pubGczSW9MVjY5NDg1TVo0RXRiem9xOE5pL3lQcnBGVEMrbXNMb0prNkR4dXF5QlhaaWVyU2tBbHd6MDFJa1Rmc2FmQXpkcG9BWnQydXdnV3BoT2pDSVpsb2hZanhPYTg1VGVGWVhpYlE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=TH0BntyzMqxIIgacH5cnxvF46N7jJ/ExsHwnonIVO7oB2ElMeiDO296AsS8zU+/H6H+pahNdjWb16rr6xsW4QdwJXoi/aWdxs+2WCC80qddYs12hp109DXaWYfhT+9iQjnZ4vHCE3ywkdywbJJAb70YXM/ndCvgd9Tzq6yFGYs4=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1714749404; v=1; bh=Qrkt0OUBDUUrxDuUFv2A4PQ8jdpWQJhuiQ/HPJ2eQ/8=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.181
+Received: from pambdb.pamb.gtwy.dcn ([156.119.190.181])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 03 May 2024 11:16:43 -0400
+Received: from pambdb.pamb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by pambdb.pamb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 443FFvTL094209;
+	Fri, 3 May 2024 11:15:58 -0400
+Received: (from ecf_web@localhost)
+	by pambdb.pamb.gtwy.dcn (8.14.7/8.14.4/Submit) id 443FFtbm094077;
+	Fri, 3 May 2024 11:15:55 -0400
+Date: Fri, 3 May 2024 11:15:55 -0400
+MIME-Version:1.0
+From:PAMB_LiveDB@pamb.uscourts.gov
+To:Courtmail@pamb.uscourts.gov
+Reply-To: pambecf_helpdesk@pamb.uscourts.gov
+Message-Id:<18007556@pamb.uscourts.gov>
+Subject:Ch-7 5:21-bk-00329-MJC -Maria Victoria Dir Motion to Reopen Case
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>Middle District of Pennsylvania</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from FirstName LastName entered on 5/3/2024 at 11:15 AM EDT and filed on 5/3/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Maria Victoria Diri                               </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.pamb.uscourts.gov/cgi-bin/DktRpt.pl?270840>5:21-bk-00329-MJC</A></td></tr>
+<tr><td colspan=2><strong>WARNING: CASE CLOSED on 10/19/2022</strong></td></tr>
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.pamb.uscourts.gov/doc1/154018337184?pdf_header=&magic_num=83584343&de_seq_num=341&caseid=270840'>78</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+ Motion to Reopen Chapter 7 Case. Filing Fee due in the amount of $260.00. Filed by  FirstName LastName  of firm, P.C. on behalf of  Maria Victoria Diri  (RE: related document(s)[64]).   (Attachments: # (1) Proposed Order  # (2) Certificate of Service) (FirstName LastName)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>motion
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1009835235 [Date=5/3/2024] [FileNumber=18007554-0
+<BR><TAB>] [3c447d21210e95e1f528e3c7dde4106b82265e1be1815516981a4bc9cf17e5458f1
+<BR><TAB>cc5d141a755e5fd180afa7fea116f64463bcf3668e25a632afd9bf72ae01f]]
+<BR>
+<STRONG>Document description:</STRONG>Proposed Order 
+<BR><STRONG>Original filename:</STRONG>C:\fakepath\Order
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1009835235 [Date=5/3/2024] [FileNumber=18007554-1
+<BR><TAB>] [c439a1eb44b249359c8bf859c081bc652de2e937249e9f6539a0ae1be6ec196731b
+<BR><TAB>7dd199c44169bee33b5dd3119576f59e0db1e97f3392ce6ab2eaf6fdbb671]]
+<BR>
+<STRONG>Document description:</STRONG>Certificate of Service 
+<BR><STRONG>Original filename:</STRONG>C:\fakepath\Certificate of Service
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1009835235 [Date=5/3/2024] [FileNumber=18007554-2
+<BR><TAB>] [5a53a0e4e0a3a308714ef056933b29ccdc96a86b84353a6933df77cb935efadc497
+<BR><TAB>5717ed443e16e0ca39a1f4aa53c72ce3338658fc8d9046f5eb7213cba9780]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+5:21-bk-00329-MJC Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName on behalf of Debtor 1 Maria Victoria Diri</span>
+<br>help@lawfirm.com,  a@lawfirm.com;b@lawfirm.com;c@lawfirm.com;noreply04@lawfirm.com;noreply05@lawfirm.com;lawfirmpc@domain.net;lawfirm@recap.email;ecf@casedriver.com
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Creditor   Andrews Federal Credit Union</span>
+<br>a@b.com,  c@b.com

--- a/tests/examples/pacer/nef/s3/pamb_2.json
+++ b/tests/examples/pacer/nef/s3/pamb_2.json
@@ -1,0 +1,34 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "pamb",
+  "dockets": [
+    {
+      "case_name": "Sandra Sattof and David Sattof",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-05-21",
+          "description": "Motion for Relief from Automatic Stay (2635 Blytheburn Road Rd, Mountain Top, PA) ([35]) filed by NewRez, LLC dba Shellpoint Mortgage Servicing Objection by the Debtors ([36]) Jill E. Durkin, Esq. (by remote appearance) Hearing held and continued. The automatic stay shall remain in effect through the conclusion of the continued hearing. IT IS SO ORDERED /s/ Mark J. Conway. Record made. (FirstName LastName)",
+          "document_number": "38",
+          "document_url": null,
+          "pacer_case_id": "276698",
+          "pacer_doc_id": null,
+          "pacer_magic_num": null,
+          "pacer_seq_no": null,
+          "short_description": "Hearing Continued"
+        }
+      ],
+      "docket_number": "5:23-bk-00774"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "help@lawfirm.com",
+        "noreply01@lawfirm.com;noreply02@lawfirm.com;noreply03@lawfirm.com;noreply04@lawfirm.com;noreply05@lawfirm.com;lawfirmpc@jubileebk.net;lawfirm@recap.email;ecf@casedriver.com"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/pamb_2.txt
+++ b/tests/examples/pacer/nef/s3/pamb_2.txt
@@ -1,0 +1,91 @@
+Return-Path: <PAMB_LiveDB@pamb.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id j1u9gedfmb05gdmb7aiseuqaci2jc8geaef0qco1
+ for lawfirm@recap.email;
+ Tue, 21 May 2024 16:06:18 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of pamb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=PAMB_LiveDB@pamb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of pamb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=PAMB_LiveDB@pamb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=pamb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHT08zZ1hhQ2hLNnhrb0RQdHl6eXBwVlNHT2k5dGFvWitXelRPa0hyQktWSXYzR1dXY3NkUTRFaWtURkxVM05LMVdETmZxbll3ZU8rbDJSV2xXQnRQSWxTM1o3K0ovM0pWclVCWW5QZUgwWHI4YjBYOStJK2lWUWZtdUVnNmV0WG1TV1NpeXV4NUJtZU1ERDFqZVhwNzVvZzJiOWZSNVhTSDVYOUFRZE4xQnJ0VzBONDRKcTBNL3plM1NJRDRiOWtVMkR0dmI5WjU2eEsxc1ozWm9heEZqRHhKNmVESGFBbWJ2VmE0ZWV1cUM0dW05NnJWMFJDTjRwWTVXZ3d3NkF4d09YSFZKZWRkb1F1T3cyYlRzRDg1TVlBcGZmaE9ZM1ZDRTBQYVRLTjBNcUE9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=JshU4xO4U9YUa8IIFhZ8L/OroUtaOiI5f8fmnOu1iWRvS+TsW7YF0A/6rCY86/mPYxYQNy0lT7rwqhY4AIt7ngX/g6NFCMpIW9ZlUMWOtSghoUduM2zzhAhoUM6k9Q/x+z4mAbCuRM9nd6IzjO+2WHP1fyekxrS3ufLaQK3zj8Q=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1716307579; v=1; bh=hhM4QaLvXx8GKTTn/qNK0u++d/gZiPLofEAltR2TN2Y=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.181
+Received: from pambdb.pamb.gtwy.dcn ([156.119.190.181])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 21 May 2024 12:06:17 -0400
+Received: from pambdb.pamb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by pambdb.pamb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 44LG5Twr011524;
+	Tue, 21 May 2024 12:05:35 -0400
+Received: (from ecf_web@localhost)
+	by pambdb.pamb.gtwy.dcn (8.14.7/8.14.4/Submit) id 44LG5DOp011164;
+	Tue, 21 May 2024 12:05:13 -0400
+Date: Tue, 21 May 2024 12:05:13 -0400
+MIME-Version:1.0
+From:PAMB_LiveDB@pamb.uscourts.gov
+To:Courtmail@pamb.uscourts.gov
+Reply-To: pambecf_helpdesk@pamb.uscourts.gov
+Message-Id:<18028722@pamb.uscourts.gov>
+Subject:Ch-13 5:23-bk-00774-MJC -Sandra Sattof  Hearing Continued
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>Middle District of Pennsylvania</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from FirstName LastName entered on 05/21/2024  at 11:54 AM  EDT and filed on 05/21/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Sandra Sattof and David Sattof                                      </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.pamb.uscourts.gov/cgi-bin/DktRpt.pl?276698>5:23-bk-00774-MJC</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+38
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+<B>Proceeding Memo for hearing scheduled on: 05/21/2024
+<BR>MATTER:</B> Motion for Relief from Automatic Stay (2635 Blytheburn Road Rd, Mountain Top, PA) (#[35]) filed by NewRez, LLC dba Shellpoint Mortgage Servicing; Objection by the Debtors (#[36]) 
+<BR><b>APPEARANCES:</b> Jill E. Durkin, Esq. (by remote appearance) 
+<BR><b>DISPOSITION:</b> Hearing held and continued. The automatic stay shall remain in effect through the conclusion of the continued hearing. IT IS SO ORDERED /s/ Mark J. Conway. Record made. 
+<BR> <B> HEARING Scheduled for 06/04/2024 at 10:00 AM at U.S. Courthouse, 197 S. Main St. Wilkes-Barre, PA.</B> (FirstName LastName)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+5:23-bk-00774-MJC Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName on behalf of Debtor 1 Sandra  Sattof</span>
+<br>help@lawfirm.com,  noreply01@lawfirm.com;noreply02@lawfirm.com;noreply03@lawfirm.com;noreply04@lawfirm.com;noreply05@lawfirm.com;lawfirmpc@jubileebk.net;lawfirm@recap.email;ecf@casedriver.com
+<BR>

--- a/tests/examples/pacer/nef/s3/pamb_3.json
+++ b/tests/examples/pacer/nef/s3/pamb_3.json
@@ -1,0 +1,36 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "pamb",
+  "dockets": [
+    {
+      "case_name": "Dennis Edward Layman, Jr",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-04-22",
+          "description": "Employee Income Records Filed by FirstName LastName of Law Firm, P.C. on behalf of Dennis Edward Layman Jr. (FirstName LastName)",
+          "document_number": "13",
+          "document_url": "https://ecf.pamb.uscourts.gov/doc1/154018318112?pdf_header=&magic_num=77077650&de_seq_num=58&caseid=279776",
+          "pacer_case_id": "279776",
+          "pacer_doc_id": "154018318112",
+          "pacer_magic_num": "77077650",
+          "pacer_seq_no": "58",
+          "short_description": "Employee Income Records"
+        }
+      ],
+      "docket_number": "1:24-bk-00833"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "help@lawfirm.com",
+        "noreply01@lawfirm.com;noreply02@lawfirm.com;noreply03@lawfirm.com;noreply04@lawfirm.com;noreply05@lawfirm.com;lawfirmpc@jubileebk.net;lawfirm@recap.email;ecf@casedriver.com",
+        "ustpregion03.ha.ecf@usdoj.gov",
+        "TWecf@pamd13trustee.com"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/pamb_3.txt
+++ b/tests/examples/pacer/nef/s3/pamb_3.txt
@@ -1,0 +1,102 @@
+Return-Path: <PAMB_LiveDB@pamb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id dgb0ijh26ohg96nppm39o5hmd643ncgcgrk7mh81
+ for lawfirm@recap.email;
+ Mon, 22 Apr 2024 15:38:41 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of pamb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=PAMB_LiveDB@pamb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of pamb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=PAMB_LiveDB@pamb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=pamb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFRktzTzlDdTR2YVhJdEwrVWxUMUdnR1A3aE9ZbCtpbG5yb2xOeklOZEdocFBkeCtwelZjbVBlQmkxeHdxNk5wSlR5b2owV0pCNkZGSk53SkdjV0ZSV3dGOWNKSDQ4MUh5Y2dyZHFDbXRQR1NPbmtidkFJZHpOSVNWd29FTXpybDdwTVByVVBCQkdEbjVSMXVKOUpBTnY1dGNEaXE4a24zYndRY1dTK2hvQTRFUmlvOUhwSjdxMkhBczkwblJWQW1aMWhhK3hhV0JsSG11VWUxYmk3UTF1VFl5eElKeTFxWEVtSkZTWlNSNTE4RXlFWmU5QWU4OG5iZzJVbTFoTlFSY2lYbkdza2NldTVTK3A0RVpUK0xRS0R6WlhIWnlqWXV2YTJpZEd1U28xRWc9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=Qj2mMWFFBmqQ15NIa0AhGpALrIFqRkEmfjfHOzCp06vyFCDd5nZT+wQRH3n1K9GvwQ4g+w2SgH4sEckZepqcVADU0WE/PgU0RLVWJEDF86ROJMmX1HwjndQ0QfW2Po027uEHD1Ei7dHdT36pfAXczpiakTKvHsR0+ou4Ah96Ikc=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1713800322; v=1; bh=NsQ93dZETMVVyY1ANkhl1du4lH8dvYw6sXqLIyYxmRs=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.181
+Received: from pambdb.pamb.gtwy.dcn ([156.119.190.181])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 22 Apr 2024 11:38:41 -0400
+Received: from pambdb.pamb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by pambdb.pamb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 43MFbtqB096339;
+	Mon, 22 Apr 2024 11:37:56 -0400
+Received: (from ecf_web@localhost)
+	by pambdb.pamb.gtwy.dcn (8.14.7/8.14.4/Submit) id 43MFbhQM096096;
+	Mon, 22 Apr 2024 11:37:43 -0400
+Date: Mon, 22 Apr 2024 11:37:43 -0400
+MIME-Version:1.0
+From:PAMB_LiveDB@pamb.uscourts.gov
+To:Courtmail@pamb.uscourts.gov
+Reply-To: pambecf_helpdesk@pamb.uscourts.gov
+Message-Id:<17990203@pamb.uscourts.gov>
+Subject:Ch-13 1:24-bk-00833-HWV -Dennis Edward Laym Employee Income Records
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>Middle District of Pennsylvania</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from FirstName LastName entered on 4/22/2024 at 11:37 AM EDT and filed on 4/22/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Dennis Edward Layman, Jr                          </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.pamb.uscourts.gov/cgi-bin/DktRpt.pl?279776>1:24-bk-00833-HWV</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.pamb.uscourts.gov/doc1/154018318112?pdf_header=&magic_num=77077650&de_seq_num=58&caseid=279776'>13</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+  Employee Income Records <i></i>  Filed by  FirstName LastName  of Law Firm, P.C. on behalf of  Dennis Edward Layman Jr.   (FirstName LastName)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+<STRONG>Document description:</STRONG>Main Document  
+<BR><STRONG>Original filename:</STRONG>Paystubs10123to32924.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=1009835235 [Date=4/22/2024] [FileNumber=17990201-
+<BR><TAB>0] [69519a0be97f7a0ebe4072b37ad43ce5b35878a9594a022ed9a6049b5801c6a461
+<BR><TAB>c0398aecefeb09b54d5d01e83c78eebf5c6a99913d801af4422e5e183dce05]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+1:24-bk-00833-HWV Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName on behalf of Debtor 1 Dennis Edward Layman, Jr</span>
+<br>help@lawfirm.com,  noreply01@lawfirm.com;noreply02@lawfirm.com;noreply03@lawfirm.com;noreply04@lawfirm.com;noreply05@lawfirm.com;lawfirmpc@jubileebk.net;lawfirm@recap.email;ecf@casedriver.com
+<BR>
+<BR><span class="personName">  United States Trustee</span>
+<br>ustpregion03.ha.ecf@usdoj.gov
+<BR>
+<BR><span class="personName">FirstName LastName</span>
+<br>TWecf@pamd13trustee.com
+<BR>
+


### PR DESCRIPTION
Helps solve #912

- Found a 18 character limit for the case_name on the subject. This also applies to the`deb_2.txt` example file
- Found that case names with " and " that separates a couple use the first person's name in the subject

Tested this against a 100 recap.emails reported on Sentry. Other instances of the "and" separator (for each case, each row is: file id, subject, case_name, extracted short_description):
```
90 pamb kd7gqbjvshbvavddtgi8dd6shlmdulj7kqd0ido1
Ch-13 1:22-bk-02406-HWV -Roger Dale Moore Motion to Modify Plan
Roger Dale Moore and Barbara Anne Moore
Motion to Modify Plan
========
83 pamb a4rslhlor0j8flmrhoa4vo7g82gh53670uljg1g1
Ch-13 1:22-bk-02406-HWV -Roger Dale Moore  Hearing Continued
Roger Dale Moore and Barbara Anne Moore
Hearing Continued
========
84 pamb sr9m38n8tcqvran7dpf6hvf0dq7jp8h0hjk7mh81
Ch-13 1:23-bk-00456-HWV -Craig Allen Zimmer Hearing Held
Craig Allen Zimmerman and Meredith Ann Zimmerman
Hearing Held
```