### PR TITLE
Changes nj.py opinion scraper to fix #1044 

### DIFF
--- a/juriscraper/opinions/united_states/state/nj.py
+++ b/juriscraper/opinions/united_states/state/nj.py
@@ -20,8 +20,7 @@ class Site(OpinionSiteLinear):
             if "njtax" in self.court_id:
                 pass
             else:
-                if len(name.split("(", 1)) > 1: 
-                    name, other = name.split("(", 1)
+                name, _, _ = name.partition('(') # Partition will split the string at the first '('
             docket = row.xpath(
                 ".//div[@class='badge badge-default rounded-0 one-line-truncate me-1 mt-1']/text()"
             )[0]

--- a/juriscraper/opinions/united_states/state/nj.py
+++ b/juriscraper/opinions/united_states/state/nj.py
@@ -20,7 +20,9 @@ class Site(OpinionSiteLinear):
             if "njtax" in self.court_id:
                 pass
             else:
-                name, _, _ = name.partition('(') # Partition will split the string at the first '('
+                name, _, _ = name.partition(
+                    "("
+                )  # Partition will split the string at the first '('
             docket = row.xpath(
                 ".//div[@class='badge badge-default rounded-0 one-line-truncate me-1 mt-1']/text()"
             )[0]

--- a/juriscraper/opinions/united_states/state/nj.py
+++ b/juriscraper/opinions/united_states/state/nj.py
@@ -20,7 +20,8 @@ class Site(OpinionSiteLinear):
             if "njtax" in self.court_id:
                 pass
             else:
-                name, other = name.split("(", 1)
+                if len(name.split("(", 1)) > 1: 
+                    name, other = name.split("(", 1)
             docket = row.xpath(
                 ".//div[@class='badge badge-default rounded-0 one-line-truncate me-1 mt-1']/text()"
             )[0]


### PR DESCRIPTION
Fixes #1044 by using partition instead of split. Partition returns the part before the separator, the separator itself, and the part after the separator. If the separator isn't found, the first element of the tuple will be the whole string, and the other two will be empty strings.

Not exactly sure on the process of adding a test to test_ScraperExtractFromTextTest.py so would appreciate some guidance there as this is my PR here. 