### PR TITLE
feat(nj): implement backscraper

### DIFF
--- a/juriscraper/opinions/united_states/state/nj.py
+++ b/juriscraper/opinions/united_states/state/nj.py
@@ -1,13 +1,26 @@
+import re
+from datetime import date, datetime
+from typing import Tuple
+from urllib.parse import urlencode
+
+from juriscraper.AbstractSite import logger
+from juriscraper.lib.date_utils import make_date_range_tuples
 from juriscraper.lib.string_utils import titlecase
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
 class Site(OpinionSiteLinear):
+    first_opinion_date = datetime(2013, 1, 14)
+    days_interval = 30
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
-        self.url = "https://www.njcourts.gov/attorneys/opinions/supreme"
+        self.base_url = self.url = (
+            "https://www.njcourts.gov/attorneys/opinions/supreme"
+        )
         self.status = "Published"
+        self.make_backscrape_iterable(kwargs)
 
     def _process_html(self) -> None:
         """Process the html and extract out the opinions
@@ -15,11 +28,17 @@ class Site(OpinionSiteLinear):
         :return: None
         """
         for row in self.html.xpath("//div[@class='card-body']"):
-            url = row.xpath(".//a[@class='text-underline-hover']/@href")[0]
+            container = row.xpath(".//a[@class='text-underline-hover']")
+            if not container:
+                logger.warning(
+                    "Skipping row with no URL: %s",
+                    re.sub(r"\s+", " ", row.text_content()),
+                )
+                continue
 
-            name_content = row.xpath(
-                ".//a[@class='text-underline-hover']/text()"
-            )[0]
+            url = container[0].xpath("@href")[0]
+            # name is sometimes inside a span, not inside the a tag
+            name_content = container[0].xpath("string(.)")
             name_str, _, _ = name_content.partition("(")
 
             docket = row.xpath('.//*[contains(@class, "mt-1")]/text()')[
@@ -41,3 +60,42 @@ class Site(OpinionSiteLinear):
                 case["summary"] = "\n".join(summary)
 
             self.cases.append(case)
+
+    def make_backscrape_iterable(self, kwargs: dict) -> None:
+        """Checks if backscrape start and end arguments have been passed
+        by caller, and parses them accordingly
+
+        :param kwargs: passed when initializing the scraper, may or
+            may not contain backscrape controlling arguments
+        :return None
+        """
+        start = kwargs.get("backscrape_start")
+        end = kwargs.get("backscrape_end")
+
+        if start:
+            start = datetime.strptime(start, "%m/%d/%Y")
+        else:
+            start = self.first_opinion_date
+        if end:
+            end = datetime.strptime(end, "%m/%d/%Y")
+        else:
+            end = datetime.now()
+
+        self.back_scrape_iterable = make_date_range_tuples(
+            start, end, self.days_interval
+        )
+
+    def _download_backwards(self, dates: Tuple[date]) -> None:
+        """Make custom date range request
+
+        :param dates: (start_date, end_date) tuple
+        :return None
+        """
+        logger.info("Backscraping for range %s %s", *dates)
+        params = {
+            "start": dates[0].strftime("%Y-%m-%d"),
+            "end": dates[1].strftime("%Y-%m-%d"),
+        }
+        self.url = f"{self.base_url}?{urlencode(params)}"
+        self.html = self._download()
+        self._process_html()

--- a/juriscraper/opinions/united_states/state/njsuperctappdiv_p.py
+++ b/juriscraper/opinions/united_states/state/njsuperctappdiv_p.py
@@ -2,10 +2,12 @@ from juriscraper.opinions.united_states.state import nj
 
 
 class Site(nj.Site):
+    days_interval = 45
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
-        self.url = (
+        self.base_url = self.url = (
             "https://www.njcourts.gov/attorneys/opinions/published-appellate"
         )
         self.status = "Published"

--- a/juriscraper/opinions/united_states/state/njsuperctappdiv_u.py
+++ b/juriscraper/opinions/united_states/state/njsuperctappdiv_u.py
@@ -5,7 +5,7 @@ class Site(nj.Site):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
-        self.url = (
+        self.base_url = self.url = (
             "https://www.njcourts.gov/attorneys/opinions/unpublished-appellate"
         )
         self.status = "Unpublished"

--- a/juriscraper/opinions/united_states/state/njtaxct_p.py
+++ b/juriscraper/opinions/united_states/state/njtaxct_p.py
@@ -1,9 +1,15 @@
+from datetime import datetime
+
 from juriscraper.opinions.united_states.state import nj
 
 
 class Site(nj.Site):
+    first_opinion_date = datetime(2017, 5, 25)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
-        self.url = "https://www.njcourts.gov/attorneys/opinions/published-tax"
+        self.base_url = self.url = (
+            "https://www.njcourts.gov/attorneys/opinions/published-tax"
+        )
         self.status = "Published"

--- a/juriscraper/opinions/united_states/state/njtaxct_u.py
+++ b/juriscraper/opinions/united_states/state/njtaxct_u.py
@@ -1,11 +1,17 @@
+from datetime import datetime
+
 from juriscraper.opinions.united_states.state import nj
 
 
 class Site(nj.Site):
+    # there is 1 opinion for datetime(2011, 5, 3),
+    # but then none until Feb 2017
+    first_opinion_date = datetime(2011, 5, 3)
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
-        self.url = (
+        self.base_url = self.url = (
             "https://www.njcourts.gov/attorneys/opinions/unpublished-tax"
         )
         self.status = "Unpublished"


### PR DESCRIPTION
Helps solve #929

- Backscraper in nj can also be used in inheriting scrapers: njtaxct_u, njtaxct_p, njsuperctappdiv_p, njsuperctappdiv_u
- Tweak HTML parsing to skip cases with no links, and cases where name is inside a span instead of anchor tag