### PR TITLE
fix(recap.email): parse short description for nhb and tnmb

### DIFF
--- a/juriscraper/pacer/email.py
+++ b/juriscraper/pacer/email.py
@@ -575,7 +575,7 @@ class NotificationEmail(BaseDocketReport, BaseReport):
             # Remove docket number traces "-AAA"
             regex = r"^-.*?\s"
             short_description = re.sub(regex, "", short_description)
-        elif self.court_id in ["pawb", "ndb", "deb", "pamb"]:
+        elif self.court_id in ["pawb", "ndb", "deb", "pamb", "nhb"]:
             # In: Ch-7 22-20823-GLT U LOCK INC Reply
             # Out: Reply
             if case_name in subject:
@@ -590,6 +590,13 @@ class NotificationEmail(BaseDocketReport, BaseReport):
                 short_description = subject.split(case_name.split(" and ")[0])[
                     -1
                 ]
+        elif self.court_id in [
+            "tnmb",
+        ]:
+            # In: Docket Order - Continue Hearing (Auto) Ch 13 Jeffery Wayne Lovell and Tiffany Nicole Lovell 1:24-bk-01377
+            # Out: Docket Order - Continue Hearing (Auto) Ch 13
+            if case_name in subject:
+                short_description = subject.split(case_name)[0]
         else:
             logger.error(
                 "Short description has no parsing for bankruptcy court '%s'",

--- a/tests/examples/pacer/nef/s3/nhb_1.json
+++ b/tests/examples/pacer/nef/s3/nhb_1.json
@@ -1,0 +1,36 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "nhb",
+  "dockets": [
+    {
+      "case_name": "Mykle Lepene",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-07-15",
+          "description": "Affidavit of Compliance with Discharge Requirements pursuant to Section 1328. (LastName, FirstName)",
+          "document_number": "87",
+          "document_url": "https://ecf.nhb.uscourts.gov/doc1/11606636485?pdf_header=&magic_num=10004684&de_seq_num=302&caseid=117776",
+          "pacer_case_id": "117776",
+          "pacer_doc_id": "11606636485",
+          "pacer_magic_num": "10004684",
+          "pacer_seq_no": "302",
+          "short_description": "Affidavit of Compliance with Discharge Requirements"
+        }
+      ],
+      "docket_number": "21-10245"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "attorney@lawfirm.com",
+        "attoreny@lawfirm.com;user@recap.email",
+        "name@lawfirm.org",
+        "name0@lawfirm.org;name1@lawfirm.org;name2@lawfirm.org;name3@lawfirm.org"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/nhb_1.txt
+++ b/tests/examples/pacer/nef/s3/nhb_1.txt
@@ -1,0 +1,107 @@
+Return-Path: <ecf_mail@nhb.uscourts.gov>
+Received: from icmecf102.gtwy.uscourts.gov (icmecf102.gtwy.uscourts.gov [199.107.16.202])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id oib6vl71gp8m14jnarbscvk1biuh2a87unknkh01
+ for user@recap.email;
+ Mon, 15 Jul 2024 19:36:54 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of nhb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=ecf_mail@nhb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of nhb.uscourts.gov designates 199.107.16.202 as permitted sender) client-ip=199.107.16.202; envelope-from=ecf_mail@nhb.uscourts.gov; helo=icmecf102.gtwy.uscourts.gov;
+ dmarc=none header.from=nhb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFIOUpFR1hFY2hUVHlLYWdhTUh5ajc1dEhPSUI3Tnh2TlZkR1RSZ2lTc3ZDSmJDTXpneHJQUWpXQ1k2b0N3MXRlMlJHYStoY3ltaVBnM0RQKzFEaDNiUGlObHVVNlorR2RWQm55dkZqZFRwVUpoQlJtY0p1Z1F2WkozcitYY1g1dUp6OFhLdFFUdzhUNzViMkwrOGZ3WG5QY2RhdXIvRHRXUFdKRWdoYW9UN0JNRE9DNE9TbHEyVjB3dFF3TDlOeVowdHVFVExydENmMzRwNmpjWkN2WG1WZ2lHQVRPUGtyRlRqSU1MWnBra3Q4OFlyTEVGZ0xQZDdPMmtNRjBUV1F5eWNCNk5pYkxQZFROSmVBYVlxWTZOenhnc3RKeFc5NnVZaThrY2xvUHZFT0E9PQ==
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=z8NiVi7meTZa3S9xWJR30O5D9b5pnNLDZed6H/SDNBPdk7/Rt9Ekc7i0aZZbICgPWSYHPRpnvv126U4t5ltahjNMVoDZNgjQlI8GbjMDZe57WoaFJ/YcY81vNKxX9AcaZK6x2UAevpYzg7KUtKY7e7FVQ9d+HC2OttEAfrZEJ1M=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1721072215; v=1; bh=irsOVo9gYcfgp8l1YprBuQ/xgshCQcorC2tXFzchBt4=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.55
+Received: from nhbdb.nhb.gtwy.dcn ([156.119.190.55])
+  by icmecf102.gtwy.uscourts.gov with ESMTP; 15 Jul 2024 15:36:54 -0400
+Received: from nhbdb.nhb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by nhbdb.nhb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 46FJa8Pv042509
+	for <user@recap.email>; Mon, 15 Jul 2024 15:36:10 -0400
+Received: (from ecf_web@localhost)
+	by nhbdb.nhb.gtwy.dcn (8.14.7/8.14.4/Submit) id 46FJZW9x041355;
+	Mon, 15 Jul 2024 15:35:32 -0400
+Date: Mon, 15 Jul 2024 15:35:32 -0400
+MIME-Version:1.0
+From:ecf_mail@nhb.uscourts.gov
+To:user@recap.email
+Message-Id:<6625450@nhb.uscourts.gov>
+Subject:21-10245-BAH Chapter 13 Mykle Lepene  Affidavit of Compliance with Discharge Requirements
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>District of New Hampshire Live Database</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from Sumski, Lawrence entered on 7/15/2024 at 3:35 PM EDT and filed on 7/15/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Mykle Lepene                                      </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.nhb.uscourts.gov/cgi-bin/DktRpt.pl?117776>21-10245-BAH</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+<a href='https://ecf.nhb.uscourts.gov/doc1/11606636485?pdf_header=&magic_num=10004684&de_seq_num=302&caseid=117776'>87</a>
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Affidavit of Compliance with Discharge Requirements pursuant to Section 1328.  (LastName, FirstName)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+
+<BR><STRONG>Case Number: 21-10245-BAH</STRONG>
+<BR><STRONG>Document description:</STRONG> 
+<BR><STRONG>Original filename:</STRONG>C:\fakepath\21-10245 xPleading AFFIDAVIT re Discharge of Debtor.pdf
+<BR><STRONG>Electronic document
+ Stamp:</STRONG>
+<BR><TAB>[STAMP bkecfStamp_ID=988526710 [Date=7/15/2024] [FileNumber=6625433-0]
+<BR><TAB> [23845912d719a3e9f8b9bd699c6f8bbee251bcaba2f812a4f43747c6a442d367cdaa
+<BR><TAB>ab007f3a5efc6b972d526811f5885f383c3c6c597560f4df46d240cc4407]]
+<BR>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+21-10245-BAH Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName M. LastName on behalf of Creditor Eliza Conley-Lepene</span>
+<br>attorney@lawfirm.com,  attoreny@lawfirm.com;user@recap.email
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Debtor Mykle  Lepene</span>
+<br>name@lawfirm.org,  name0@lawfirm.org;name1@lawfirm.org;name2@lawfirm.org;name3@lawfirm.org
+<BR>
+
+<BR>
+<B>
+21-10245-BAH Notice will not be electronically mailed to:
+</B>
+
+<BR>
+

--- a/tests/examples/pacer/nef/s3/tnmb_1.json
+++ b/tests/examples/pacer/nef/s3/tnmb_1.json
@@ -1,0 +1,37 @@
+{
+  "appellate": false,
+  "contains_attachments": false,
+  "court_id": "tnmb",
+  "dockets": [
+    {
+      "case_name": "Jeffery Wayne Lovell and Tiffany Nicole Lovell",
+      "date_filed": null,
+      "docket_entries": [
+        {
+          "date_filed": "2024-07-15",
+          "description": "Order Continuing Hearing Re: (RE: related document(s)[21] Objection to Confirmation of the Plan (Creditor), [3] Chapter 13 Plan). Hearing has been rescheduled for 08/14/2024 at 09:00 AM, Joint Hearing Courtroom (NSH) (Virtual hearing if allowed see website for details) 701 Broadway, Nashville, TN 37203. (las)",
+          "document_number": "27",
+          "document_url": null,
+          "pacer_case_id": "393537",
+          "pacer_doc_id": null,
+          "pacer_magic_num": null,
+          "pacer_seq_no": null,
+          "short_description": "Docket Order - Continue Hearing (Auto) Ch 13"
+        }
+      ],
+      "docket_number": "1:24-bk-01377"
+    }
+  ],
+  "email_recipients": [
+    {
+      "email_addresses": [
+        "attorney@lawfirm.com",
+        "user@recap.email",
+        "user@firm.com",
+        "user@firm.COM",
+        "ustpregion08.na.ecf@usdoj.gov"
+      ],
+      "name": ""
+    }
+  ]
+}

--- a/tests/examples/pacer/nef/s3/tnmb_1.txt
+++ b/tests/examples/pacer/nef/s3/tnmb_1.txt
@@ -1,0 +1,105 @@
+Return-Path: <TNMBADMIN_ECF@tnmb.uscourts.gov>
+Received: from icmecf101.gtwy.uscourts.gov (icmecf101.gtwy.uscourts.gov [199.107.16.200])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id daavku0f2g9ggfq261vvbg89di6i25musc9o1fg1
+ for user@recap.email;
+ Mon, 15 Jul 2024 20:08:54 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of tnmb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=TNMBADMIN_ECF@tnmb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of tnmb.uscourts.gov designates 199.107.16.200 as permitted sender) client-ip=199.107.16.200; envelope-from=TNMBADMIN_ECF@tnmb.uscourts.gov; helo=icmecf101.gtwy.uscourts.gov;
+ dmarc=none header.from=tnmb.uscourts.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFHZEhoYXFyMHlzNEZTWWl2NDNuV2pZOWp1SzZKRWx1Y1J4MTYyNGJFTU5walNBRGJlUGdpU2NvY2JyelF2KzduaTRjTlFzbEIxN1ZTTzVBWVNVMWcyVUc1TU0wbGFoNWZmWDZPU2s4VGtPOSswdVg2R0JySzBvQmNxZ1VVS0xKODJ4Rmd0Nk5Gdk10SVl5ZXBSaVl6Skxzc1VQOTFpVGhLYWw3WE9WOFVBazRUVTJuRm5HZFFFNTIrcFIvVFBKdGw0enlyU3BRQlpKM3h2R242VENTYWJBYTdpNVRxMFhoS1VwSEpBZXIzQ2UvNEluSUtteXNWZEhILzVjejVXck0xS0RRYWpPQXZJMGhXeElTaEc1Wk9YSzRaOENvWkRyWGFqT1dGNDViTHV3TFZucG5SdElpVnJiNGp1MmJpYkZjeTQ9
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=ihIL5Nqb3okvC8h7OsYNw451nLF42mbtRo0CJMcNFo/LOXPujqeF50ouLHGKEkbw3axIKTqdp7HtdHM9ASz/xcFEPsvlxjfdODlrJHerEP+kKmcKnmo5uh36xGwxK/L2BnsAD439NFFgQBI6XSk3WtymDz8BpSiY6Z5oI5L1hvs=; c=relaxed/simple; s=7v7vs6w47njt4pimodk5mmttbegzsi6n; d=amazonses.com; t=1721074135; v=1; bh=30ZVL55+i3Kbvg8XQRvA5gped81caHwib7jphYzMFHg=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+X-SBRS: None
+X-REMOTE-IP: 156.119.190.130
+Received: from tnmbdb.tnmb.gtwy.dcn ([156.119.190.130])
+  by icmecf101.gtwy.uscourts.gov with ESMTP; 15 Jul 2024 16:08:54 -0400
+Received: from tnmbdb.tnmb.gtwy.dcn (localhost.localdomain [127.0.0.1])
+	by tnmbdb.tnmb.gtwy.dcn (8.14.7/8.14.7) with ESMTP id 46FK889V110934;
+	Mon, 15 Jul 2024 15:08:09 -0500
+Received: (from ecf_web@localhost)
+	by tnmbdb.tnmb.gtwy.dcn (8.14.7/8.14.4/Submit) id 46FK7fwX110404;
+	Mon, 15 Jul 2024 15:07:41 -0500
+Date: Mon, 15 Jul 2024 15:07:41 -0500
+X-Authentication-Warning: tnmbdb.tnmb.gtwy.dcn: ecf_web set sender to TNMBADMIN_ECF@tnmb.uscourts.gov using -f
+MIME-Version:1.0
+From:TNMBADMIN_ECF@tnmb.uscourts.gov
+To:courtmail@tnmb.uscourts.gov
+Message-Id:<29433560@tnmb.uscourts.gov>
+Subject: Docket Order - Continue Hearing (Auto) Ch 13 Jeffery Wayne Lovell and Tiffany Nicole Lovell 1:24-bk-01377
+Content-Type: text/html
+
+<p><strong>***NOTE TO PUBLIC ACCESS USERS*** Judicial Conference of the United States policy permits attorneys of record and parties in a case (including pro se litigants) to receive one free electronic copy of all documents filed electronically, if receipt is required by law or directed by the filer. PACER access fees apply to all other users.  To avoid later charges, download a copy of each document during this first viewing. However, if the referenced document is a transcript, the free copy and 30-page limit do not apply.</strong></p>
+
+
+
+
+<p align=center><strong>U.S. Bankruptcy Court</strong></p>
+
+<p align=center><strong>MIDDLE DISTRICT OF TENNESSEE</strong></p>
+Notice of Electronic Filing
+<BR>
+<div>
+<BR>The following transaction was received from las entered on 07/15/2024  at 3:07 PM  CDT and filed on 07/15/2024 
+
+<BR>
+
+
+
+<table border=0 cellspacing=0>
+<tr><td><strong>Case Name:</strong>
+</td><td>Jeffery Wayne Lovell and Tiffany Nicole Lovell                             </td></tr>
+<tr><td><strong>Case Number:</strong></td><td><A HREF=https://ecf.tnmb.uscourts.gov/cgi-bin/DktRpt.pl?393537>1:24-bk-01377</A></td></tr>
+
+<tr><td><strong>Document Number:</strong></td>
+<td>
+27
+</td></tr>
+</table>
+
+
+
+
+<p><strong>Docket Text:</strong>
+
+<BR>
+Order Continuing Hearing Re:  (RE: related document(s)[21] Objection to Confirmation of the Plan (Creditor), [3] Chapter 13 Plan).  Hearing has been rescheduled for 08/14/2024 at 09:00 AM, Joint Hearing Courtroom (NSH); (Virtual hearing if allowed; see website for details); 701 Broadway, Nashville, TN 37203. (las)
+</p>
+
+<p>The following document(s) are associated with this transaction:</p>
+<table>
+
+</table>
+</div>
+
+
+
+
+<BR><B>
+1:24-bk-01377 Notice will be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">FirstName LastName on behalf of Creditor   Advanced Building Solutions, Inc.</span>
+<br>attorney@lawfirm.com,  user@recap.email
+<BR>
+<BR><span class="personName">FirstName LastName on behalf of Creditor   Onslow Bay Financial LLC</span>
+<br>user@firm.com,  user@firm.COM
+<BR>
+<BR><span class="personName">  US TRUSTEE</span>
+<br>ustpregion08.na.ecf@usdoj.gov
+<BR>
+
+<BR>
+<B>
+1:24-bk-01377 Notice will not be electronically mailed to:
+</B>
+
+<BR>
+
+<BR><span class="personName">  Capital One Auto Finance, a division of Capital One, N.A., c/o AIS Portfolio Services, LLC</span>
+<BR>11111 N SomeAve. Dept.
+<BR>Some City, OK 11111
+<BR>


### PR DESCRIPTION
Related to #912

Handle short description parsing in _parse_bankruptcy_short_description for nhb and tnmb