### PR TITLE
fix(log_tools): rename default logger

### DIFF
--- a/juriscraper/lib/log_tools.py
+++ b/juriscraper/lib/log_tools.py
@@ -20,7 +20,7 @@ def make_default_logger(file_path=LOG_FILENAME):
 
     :return: a logger object
     """
-    logger = logging.getLogger("Logger")
+    logger = logging.getLogger(__name__)
     if not len(logger.handlers):
         logger.setLevel(logging.DEBUG)
         # Create a handler and attach it to the logger


### PR DESCRIPTION
Changed named from "Logger" to `__name__` or "juriscraper.lib.log_tools" This follows the hierarchical naming convention used by Python's logging configuration and helps understand logging config in Courtlistener

From freelawproject/courtlistener#4188