### PR TITLE
fix(oklaag): correct self.url

### DIFF
--- a/juriscraper/opinions/united_states/state/oklaag.py
+++ b/juriscraper/opinions/united_states/state/oklaag.py
@@ -16,7 +16,7 @@ class Site(okla.Site):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
         year = datetime.today().year
-        self.url = f"https://www.oscn.net/applications/oscn/Index.asp?ftdb=STOKCSSC&year={year}&level=1"
+        self.url = f"https://www.oscn.net/applications/oscn/Index.asp?ftdb=STOKAG&year={year}&level=1"
         self.status = "Published"
         self.expected_content_types = ["text/html"]
 


### PR DESCRIPTION
Fixes #1091

URL had been pointing to the `okla` site, incorrectly, since the last update to the Oklahoma sites