### PR TITLE
fix(ny, nyappdiv, nyappterm, nytrial): add X-Api-Token header

### DIFF
--- a/juriscraper/opinions/united_states/state/ny.py
+++ b/juriscraper/opinions/united_states/state/ny.py
@@ -8,12 +8,40 @@ History:
  2016-05-04: Updated by arderyp to handle typos in docket string format
 """
 
+import os
 import re
 from datetime import date
 
+from juriscraper.AbstractSite import logger
 from juriscraper.lib.html_utils import get_html5_parsed_text
 from juriscraper.lib.string_utils import convert_date_string
 from juriscraper.OpinionSite import OpinionSite
+
+
+def set_api_token_header(scraper_site: OpinionSite) -> None:
+    """
+    Puts the NY_API_TOKEN in the X-Api-Token header
+    Creates the Site.headers attribute, copying the
+    scraper_site.request[headers]
+
+    :param scraper_site: a Site Object
+    :returns: None
+    """
+    if scraper_site.test_mode_enabled():
+        return
+
+    api_token = os.environ.get("NY_API_TOKEN")
+    if not api_token:
+        logger.warning(
+            "NY_API_TOKEN environment variable is not set. "
+            "It is required for scraping New York Courts"
+        )
+        return
+
+    scraper_site.request["headers"]["X-Api-Token"] = api_token
+    # This headers attribute will be used on the Courtlistener caller
+    # to get the binary_content
+    scraper_site.headers = {**scraper_site.request["headers"]}
 
 
 class Site(OpinionSite):
@@ -31,6 +59,7 @@ class Site(OpinionSite):
             month=today.strftime("%B"),
         )
         self.court_id = self.__module__
+        set_api_token_header(self)
 
     def _make_html_tree(self, text):
         return get_html5_parsed_text(text)

--- a/juriscraper/opinions/united_states/state/nyappdiv_1st.py
+++ b/juriscraper/opinions/united_states/state/nyappdiv_1st.py
@@ -12,6 +12,7 @@ from dateutil.rrule import MONTHLY, rrule
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.html_utils import get_html5_parsed_text
 from juriscraper.lib.string_utils import convert_date_string
+from juriscraper.opinions.united_states.state.ny import set_api_token_header
 from juriscraper.OpinionSite import OpinionSite
 
 
@@ -27,6 +28,7 @@ class Site(OpinionSite):
         self.division = 1
         self.url = self.build_url()
         self.expected_content_types = ["application/pdf", "text/html"]
+        set_api_token_header(self)
 
     def _get_case_names(self):
         path = f"{self.row_base_path}/td[1]"

--- a/juriscraper/opinions/united_states/state/nyappterm_1st.py
+++ b/juriscraper/opinions/united_states/state/nyappterm_1st.py
@@ -8,6 +8,7 @@ from typing import Any, Dict, Optional, Tuple
 
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.date_utils import make_date_range_tuples
+from juriscraper.opinions.united_states.state.ny import set_api_token_header
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
@@ -25,6 +26,7 @@ class Site(OpinionSiteLinear):
         self._set_parameters()
         self.expected_content_types = ["application/pdf", "text/html"]
         self.make_backscrape_iterable(kwargs)
+        set_api_token_header(self)
 
     def _set_parameters(
         self,

--- a/juriscraper/opinions/united_states/state/nytrial.py
+++ b/juriscraper/opinions/united_states/state/nytrial.py
@@ -17,6 +17,7 @@ from lxml.html import fromstring
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.judge_parsers import normalize_judge_string
 from juriscraper.lib.string_utils import harmonize
+from juriscraper.opinions.united_states.state.ny import set_api_token_header
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
@@ -36,6 +37,7 @@ class Site(OpinionSiteLinear):
         )
         self.back_scrape_iterable = [i.date() for i in date_keys]
         self.expected_content_types = ["application/pdf", "text/html"]
+        set_api_token_header(self)
 
     def build_url(self, target_date: Optional[date] = None) -> str:
         """URL as is loads most recent month page


### PR DESCRIPTION
Fixes #1042

Add a function to set the required api token in both headers objects used in Juriscraper / Courtlistener. For this to work, we will need to modify CL to use the headers for ny courts.

Use that function on ny, nyappdiv, nyappterm, nytrial, which are base classes for more scrapers