### PR TITLE
feat(pacer): Adds the de_seq_num to the download method

### DIFF
--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -140,6 +140,7 @@ class BaseReport:
         pacer_doc_id: str,
         pacer_magic_num: Optional[str],
         got_receipt: str,
+        de_seq_num: Optional[str] = None,
     ) -> Tuple[Response, str]:
         """Query the doc1 download URL.
 
@@ -181,6 +182,9 @@ class BaseReport:
         if pacer_magic_num is not None:
             data["magic_num"] = pacer_magic_num
 
+        if de_seq_num:
+            data["de_seq_num"] = de_seq_num
+
         timeout = (60, 300)
         logger.info(f"POSTing URL: {url} with params: {data}")
         r = self.session.post(url, data=data, timeout=timeout)
@@ -192,6 +196,7 @@ class BaseReport:
         pacer_doc_id: int,
         pacer_magic_num: Optional[str] = None,
         appellate: bool = False,
+        de_seq_num: Optional[str] = None,
     ) -> Tuple[Optional[Response], str]:
         """Download a PDF from PACER.
 
@@ -207,7 +212,6 @@ class BaseReport:
 
             # Create PACER base url from court_id and pacer_doc_id
             # Magic link parameters
-            # We don't need the de_seq_num parameter to fetch the free document
             if appellate:
                 url = make_docs1_url(self.court_id, pacer_doc_id, True)
                 # For appellate documents the magic_number is the uid param
@@ -221,6 +225,9 @@ class BaseReport:
                     "magic_num": pacer_magic_num,
                     "use_magic": "1",  # Bypass the free look confirmation.
                 }
+
+            if de_seq_num:
+                params["de_seq_num"] = de_seq_num
 
             # Add parameters to the PACER base url and make a GET request
             req_timeout = (60, 300)
@@ -242,7 +249,11 @@ class BaseReport:
         else:
             # If no magic_number use normal method to fetch the document
             r, url = self._query_pdf_download(
-                pacer_case_id, pacer_doc_id, pacer_magic_num, got_receipt="1"
+                pacer_case_id,
+                pacer_doc_id,
+                pacer_magic_num,
+                got_receipt="1",
+                de_seq_num=de_seq_num,
             )
 
             # Use r.content instead of r.text for performance. See #564


### PR DESCRIPTION
This PR introduces a new optional argument, de_seq_num, to the download_pdf and _query_pdf_download methods. By providing a default value for this argument, potential conflicts with existing method implementations are mitigated.

Fixes #1088

After merging this PR; I'll create another one in CL to update the [process_recap_email](https://github.com/freelawproject/courtlistener/blob/723b7ec84101b18fa2f0aa0dcb7ef7788dc74361/cl/recap/tasks.py#L2451-L2668) task.
