### PR TITLE
fix(massappct_u): no longer uses mass headers

### DIFF
--- a/juriscraper/opinions/united_states/state/massappct_u.py
+++ b/juriscraper/opinions/united_states/state/massappct_u.py
@@ -12,7 +12,6 @@ from datetime import date, timedelta
 from urllib.parse import urlencode
 
 from juriscraper.lib.string_utils import titlecase
-from juriscraper.opinions.united_states.state import mass
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
@@ -26,11 +25,12 @@ class Site(OpinionSiteLinear):
         self.court_id = self.__module__
         self.expected_content_types = ["text"]
 
-        # `mass` and `massappct` require custom headers for document
-        # downloading in Courtlistener. Due to the way court IDs are
-        # assigned, we need a headers attribute for `massappct_u`
-        # even if it is not strictly needed for downloading docs
-        self.headers = mass.Site().headers
+        # the site we scrape does not require custom headers
+        # However, `massappct_u`` is treated as `massappct` in
+        # Courtlistener, which does requires a self.headers attribute
+        # Passing extra headers besides User-Agent will break
+        # document download
+        self.headers = {"User-Agent": "Courtlistener"}
 
     def make_url(self) -> str:
         """Build the urls to query

--- a/sample_caller.py
+++ b/sample_caller.py
@@ -87,6 +87,10 @@ def scrape_court(site, binaries=False):
             # clean it up.
             data = extract_doc_content(data)
             data = site.cleanup_content(data)
+            v_print(
+                3,
+                f"Showing extracted document data (500 chars):\n {data[:500]}",
+            )
 
         # Normally, you'd do your save routines here...
         v_print(1, "\nAdding new item:")


### PR DESCRIPTION
FIxes #1103

Also, add v_print to the sample_caller binaries download, for easier debugging