### PR TITLE
refactor(mass, ny, sample_caller): add flag site.needs_special_headers

### DIFF
--- a/juriscraper/AbstractSite.py
+++ b/juriscraper/AbstractSite.py
@@ -57,6 +57,11 @@ class AbstractSite:
             "url": None,
         }
 
+        # Some courts will block Juriscraper or Courtlistener's user-agent
+        # or may need special headers. This flag let's the caller know it
+        # should use the modified `self.request["headers"]`
+        self.needs_special_headers = False
+
         # Sub-classed metadata
         self.court_id = None
         self.url = None

--- a/juriscraper/opinions/united_states/state/mass.py
+++ b/juriscraper/opinions/united_states/state/mass.py
@@ -32,19 +32,10 @@ class Site(OpinionSiteLinear):
         self.url = "https://www.mass.gov/info-details/new-opinions"
         self.court_id = self.__module__
         self.court_identifier = "SJC"
-        # This self.headers is used because the court blocks all non browser
-        # style user-agents.
-        self.headers = {
-            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            "Sec-Fetch-Site": "none",
-            "Sec-Fetch-Mode": "navigate",
-            "Host": "www.mass.gov",
+        self.request["headers"] = {
             "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3 Safari/605.1.15",
-            "Accept-Language": "en-US,en;q=0.9",
-            "Sec-Fetch-Dest": "document",
-            "Connection": "keep-alive",
         }
-        self.request["headers"] = self.headers
+        self.needs_special_headers = True
 
     def _process_html(self):
         for row in self.html.xpath(".//a/@href[contains(.,'download')]/.."):

--- a/juriscraper/opinions/united_states/state/massappct_u.py
+++ b/juriscraper/opinions/united_states/state/massappct_u.py
@@ -25,13 +25,6 @@ class Site(OpinionSiteLinear):
         self.court_id = self.__module__
         self.expected_content_types = ["text"]
 
-        # the site we scrape does not require custom headers
-        # However, `massappct_u`` is treated as `massappct` in
-        # Courtlistener, which does requires a self.headers attribute
-        # Passing extra headers besides User-Agent will break
-        # document download
-        self.headers = {"User-Agent": "Courtlistener"}
-
     def make_url(self) -> str:
         """Build the urls to query
 

--- a/juriscraper/opinions/united_states/state/ny.py
+++ b/juriscraper/opinions/united_states/state/ny.py
@@ -38,10 +38,8 @@ def set_api_token_header(scraper_site: OpinionSite) -> None:
         )
         return
 
-    scraper_site.request["headers"]["X-Api-Token"] = api_token
-    # This headers attribute will be used on the Courtlistener caller
-    # to get the binary_content
-    scraper_site.headers = {**scraper_site.request["headers"]}
+    scraper_site.request["headers"]["X-APIKEY"] = api_token
+    scraper_site.needs_special_headers = True
 
 
 class Site(OpinionSite):

--- a/sample_caller.py
+++ b/sample_caller.py
@@ -4,7 +4,9 @@ import sys
 import traceback
 from collections import defaultdict
 from optparse import OptionParser
-from urllib import parse, request
+from urllib import parse
+
+import requests
 
 from juriscraper.lib.importer import build_module_list, site_yielder
 from juriscraper.lib.string_utils import trunc
@@ -50,26 +52,51 @@ def scrape_court(site, binaries=False):
 
         if binaries:
             try:
-                opener = request.build_opener()
-                for cookie_dict in site.cookies:
-                    opener.addheaders.append(
-                        (
-                            "Cookie",
-                            f"{cookie_dict['name']}={cookie_dict['value']}",
-                        )
+                # some sites require a custom ssl_context, contained in the Site's
+                # session. However, we can't send a request with both a
+                # custom ssl_context and `verify = False`
+                has_cipher = hasattr(site, "cipher")
+                s = (
+                    site.request["session"]
+                    if has_cipher
+                    else requests.session()
+                )
+
+                if site.needs_special_headers:
+                    headers = site.request["headers"]
+                else:
+                    headers = {"User-Agent": "CourtListener"}
+
+                # Note that we do a GET even if site.method is POST. This is
+                # deliberate.
+                r = s.get(
+                    download_url,
+                    verify=has_cipher,  # WA has a certificate we don't understand
+                    headers=headers,
+                    cookies=site.cookies,
+                    timeout=300,
+                )
+
+                # test for expected content type (thanks mont for nil)
+                if site.expected_content_types:
+                    # Clean up content types like "application/pdf;charset=utf-8"
+                    # and 'application/octet-stream; charset=UTF-8'
+                    content_type = (
+                        r.headers.get("Content-Type")
+                        .lower()
+                        .split(";")[0]
+                        .strip()
                     )
-                r = opener.open(download_url)
-                expected_content_types = site.expected_content_types
-                response_type = r.headers.get("Content-Type", "").lower()
-                # test for expected content type response
-                if (
-                    expected_content_types
-                    and response_type not in expected_content_types
-                ):
-                    exceptions["DownloadingError"].append(download_url)
-                    v_print(3, f"DownloadingError: {download_url}")
-                    v_print(3, traceback.format_exc())
-                data = r.read()
+                    m = any(
+                        content_type in mime.lower()
+                        for mime in site.expected_content_types
+                    )
+                    if not m:
+                        exceptions["DownloadingError"].append(download_url)
+                        v_print(3, f"DownloadingError: {download_url}")
+                        v_print(3, traceback.format_exc())
+
+                data = r.content
 
                 # test for empty files (thank you CA1)
                 if len(data) == 0:


### PR DESCRIPTION
Related to freelawproject/courtlistener#4281

- Update sample caller to reflect Courtlistener's get_binary_content behaviour
- get rid of self.headers, which was a copy of self.request["headers"] wherever it was used
- add a flag `needs_special_headers` for the caller to know it has to use the self.request["headers"]
- simplify `mass` headers, the only thing needed was the changed user-agent
- minn is not working, will leave it as is and fix it in another issue
- Updated NY api key header name following latest email
- removed massappct_u self.headers, since the site has no special headers requirements