### PR TITLE
Fixed IndexOutOfRange error in DocketReport::_set_metadata_values method

### DIFF
--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -1507,7 +1507,7 @@ class DocketReport(BaseDocketReport, BaseReport):
         table = self.tree.xpath(
             # Match any td containing Date [fF]iled
             '//td[.//text()[contains(translate(., "f", "F"), "Date Filed:") '
-            'or contains(translate(., "f", "F"), "Filed Date:")]]'
+            'or contains(translate(., "d", "D"), "Filed Date:")]]'
             # And find its highest ancestor table that lacks a center tag.
             "/ancestor::table[not(.//center)][last()]"
         )[0]

--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -1506,7 +1506,8 @@ class DocketReport(BaseDocketReport, BaseReport):
         # The first ancestor table of the table cell containing "date filed"
         table = self.tree.xpath(
             # Match any td containing Date [fF]iled
-            '//td[.//text()[contains(translate(., "f", "F"), "Date Filed:")]]'
+            '//td[.//text()[contains(translate(., "f", "F"), "Date Filed:") '
+            'or contains(translate(., "f", "F"), "Filed Date:")]]'
             # And find its highest ancestor table that lacks a center tag.
             "/ancestor::table[not(.//center)][last()]"
         )[0]


### PR DESCRIPTION
```
Court: District of New Jersey
Case Number:	2:23-cv-01194
Pacer CaseID:	509180	
Court Code: njd
```

For this case docket report page has different format.

![image](https://github.com/user-attachments/assets/8219311b-a9a9-42b9-ae5b-97224ad4a325)

This difference causes Index out of range error because function expects `Date Filed` instead of `Filed Date`. 

Added `Filed Date` as alternative to `xpath()` method