### PR TITLE
Fix IA attachment description keys

### DIFF
--- a/juriscraper/pacer/internet_archive.py
+++ b/juriscraper/pacer/internet_archive.py
@@ -175,14 +175,9 @@ class InternetArchive(BaseDocketReport):
 
         de_nodes = self.tree.xpath("//document_list/document")
         docket_entries = []
-        prev_date_filed = None
         for de_node in de_nodes:
             de = {
                 "document_number": de_node.xpath("./@doc_num")[0],
-                "description": self._xpath_text_0(de_node, "./long_desc"),
-                "short_description": self._xpath_text_0(
-                    de_node, "./short_desc"
-                ),
                 "pacer_seq_no": self._xpath_text_0(
                     de_node, "./pacer_de_seq_num"
                 )
@@ -191,6 +186,12 @@ class InternetArchive(BaseDocketReport):
             attachment_number = de_node.xpath("./@attachment_num")[0]
             if attachment_number != "0":
                 de["attachment_number"] = attachment_number
+                de["description"] = self._xpath_text_0(de_node, "./short_desc")
+            else:
+                de["description"] = self._xpath_text_0(de_node, "./long_desc")
+                de["short_description"] = self._xpath_text_0(
+                    de_node, "./short_desc"
+                )
 
             date_filed_str = self._xpath_text_0(de_node, "./date_filed")
             if date_filed_str:
@@ -200,15 +201,9 @@ class InternetArchive(BaseDocketReport):
                 except ValueError:
                     # Fails for dates like 0000-00-00
                     de["date_filed"] = None
-                else:
-                    prev_date_filed = de["date_filed"]
             else:
                 # No date found.
-                if de.get("attachment_number"):
-                    # If it's an attachment, it probably lacks a date. Get it
-                    # from the previously stored item.
-                    de["date_filed"] = prev_date_filed
-                else:
+                if not de.get("attachment_number"):
                     # If not an attachment, it's probably an old docket entry,
                     # which sometimes lack dates. Press on.
                     continue
@@ -226,6 +221,7 @@ class InternetArchive(BaseDocketReport):
                 except IndexError:
                     continue
                 if last_de.get("document_number") == de["document_number"]:
+                    del de["document_number"]
                     attachments = last_de.get("attachments", [])
                     attachments.append(de)
                     last_de["attachments"] = attachments

--- a/tests/examples/pacer/dockets_internet_archive/almd_49523.json
+++ b/tests/examples/pacer/dockets_internet_archive/almd_49523.json
@@ -1149,12 +1149,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2014-07-09",
-          "description": "",
-          "document_number": "625",
+          "description": "Advertisement Certification Report and Notice of Forfeiture",
           "pacer_doc_id": "01702313993",
-          "pacer_seq_no": null,
-          "short_description": "Advertisement Certification Report and Notice of Forfeiture"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2014-07-09",
@@ -1168,12 +1165,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2014-07-09",
-          "description": "",
-          "document_number": "626",
+          "description": "Exhibit A",
           "pacer_doc_id": "01702314758",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit A"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2014-07-09",
@@ -1195,12 +1189,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2014-07-09",
-          "description": "",
-          "document_number": "629",
+          "description": "Exhibit A",
           "pacer_doc_id": "01702315696",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit A"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2014-07-09",
@@ -1238,21 +1229,15 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2014-07-28",
-          "description": "",
-          "document_number": "635",
+          "description": "Stipulation of Final Settlement and Release of All Claims as to Third Party Pet",
           "pacer_doc_id": "01702325954",
-          "pacer_seq_no": null,
-          "short_description": "Stipulation of Final Settlement and Release of All Claims as to Third Party Pet"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2014-07-28",
-          "description": "",
-          "document_number": "635",
+          "description": "Text of Proposed Order",
           "pacer_doc_id": "01702325955",
-          "pacer_seq_no": null,
-          "short_description": "Text of Proposed Order"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2014-07-28",

--- a/tests/examples/pacer/dockets_internet_archive/azd_1061043.json
+++ b/tests/examples/pacer/dockets_internet_archive/azd_1061043.json
@@ -13,75 +13,51 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "1",
+          "description": "Civil Cover Sheet",
           "pacer_doc_id": "025018027677",
-          "pacer_seq_no": null,
-          "short_description": "Civil Cover Sheet"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit",
           "pacer_doc_id": "025018027678",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit",
           "pacer_doc_id": "025018027679",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit",
           "pacer_doc_id": "025018027680",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "5",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit",
           "pacer_doc_id": "025018027681",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "6",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit",
           "pacer_doc_id": "025018027682",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "7",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit",
           "pacer_doc_id": "025018027683",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "8",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit",
           "pacer_doc_id": "025018027684",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2017-10-25",

--- a/tests/examples/pacer/dockets_internet_archive/azd_318008.json
+++ b/tests/examples/pacer/dockets_internet_archive/azd_318008.json
@@ -13,12 +13,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2006-09-07",
-          "description": "",
-          "document_number": "1",
+          "description": "Civil Cover Sheet",
           "pacer_doc_id": "02501840501",
-          "pacer_seq_no": null,
-          "short_description": "Civil Cover Sheet"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2006-09-07",
@@ -552,75 +549,51 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2008-03-26",
-          "description": "",
-          "document_number": "67",
+          "description": "Exhibit A: Riverdeep Complaint",
           "pacer_doc_id": "02502837709",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit A: Riverdeep Complaint"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2008-03-26",
-          "description": "",
-          "document_number": "67",
+          "description": "Exhibit B: Westlaw Cases",
           "pacer_doc_id": "02502837710",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit B: Westlaw Cases"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2008-03-26",
-          "description": "",
-          "document_number": "67",
+          "description": "Exhibit C - Midwest's Answer's to Plaintiff's Second Set of Inter",
           "pacer_doc_id": "02502837711",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit C - Midwest's Answer's to Plaintiff's Second Set of Inter"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2008-03-26",
-          "description": "",
-          "document_number": "67",
+          "description": "Exhibit D: 071130 Midwest's Settlement Letter",
           "pacer_doc_id": "02502837712",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit D: 071130 Midwest's Settlement Letter"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "5",
-          "date_filed": "2008-03-26",
-          "description": "",
-          "document_number": "67",
+          "description": "Exhibit E - Midwest's Settlement Conference Memorandum",
           "pacer_doc_id": "02502837713",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit E - Midwest's Settlement Conference Memorandum"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "6",
-          "date_filed": "2008-03-26",
-          "description": "",
-          "document_number": "67",
+          "description": "Exhibit F - Excerpts from Deposition of Robert Vitale1",
           "pacer_doc_id": "02502837714",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit F - Excerpts from Deposition of Robert Vitale1"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "7",
-          "date_filed": "2008-03-26",
-          "description": "",
-          "document_number": "67",
+          "description": "Exhibit G - U.S. Trademark Registration No. 3,318,243",
           "pacer_doc_id": "02502837715",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit G - U.S. Trademark Registration No. 3,318,243"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "8",
-          "date_filed": "2008-03-26",
-          "description": "",
-          "document_number": "67",
+          "description": "Text of Proposed Order",
           "pacer_doc_id": "02502837716",
-          "pacer_seq_no": null,
-          "short_description": "Text of Proposed Order"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2008-03-26",
@@ -714,12 +687,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2008-05-09",
-          "description": "",
-          "document_number": "78",
+          "description": "Memorandum in Support of Motion for Partial Summary Judgment",
           "pacer_doc_id": "02502995843",
-          "pacer_seq_no": null,
-          "short_description": "Memorandum in Support of Motion for Partial Summary Judgment"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2008-05-09",
@@ -733,30 +703,21 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2008-05-09",
-          "description": "",
-          "document_number": "79",
+          "description": "Supplement Statement of Facts in Support of Plaintiff's Motion for Summary",
           "pacer_doc_id": "02502996134",
-          "pacer_seq_no": null,
-          "short_description": "Supplement Statement of Facts in Support of Plaintiff's Motion for Summary"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2008-05-09",
-          "description": "",
-          "document_number": "79",
+          "description": "Exhibit Exhibits 1-7 to SOF in Support of Motion for Summary Judgment",
           "pacer_doc_id": "02502996135",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Exhibits 1-7 to SOF in Support of Motion for Summary Judgment"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2008-05-09",
-          "description": "",
-          "document_number": "79",
+          "description": "Exhibit Exhibits 7-14 to SOF in Support of Motion for Summary Judgment",
           "pacer_doc_id": "02502996136",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Exhibits 7-14 to SOF in Support of Motion for Summary Judgment"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2008-05-09",
@@ -1435,20 +1396,16 @@
         {
           "attachment_number": "1",
           "date_filed": "2009-03-16",
-          "description": "Attachment 1SEALED Minute Entry. Proceedings held before Judge David G Campbell on 3/16/2009. (Court Reporter Patricia Lyons.) (cc: Dosek/Marvinney/CD)(MAP)",
-          "document_number": "163",
+          "description": "",
           "pacer_doc_id": "02513170767",
-          "pacer_seq_no": null,
-          "short_description": ""
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
           "date_filed": "2009-03-16",
-          "description": "Attachment 2SEALED Minute Entry. Proceedings held before Judge David G Campbell on 3/16/2009. (Court Reporter Patricia Lyons.) (cc: Dosek/Marvinney/CD)(MAP)",
-          "document_number": "163",
+          "description": "",
           "pacer_doc_id": "02513170768",
-          "pacer_seq_no": null,
-          "short_description": ""
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2009-03-16",
@@ -1520,28 +1477,22 @@
           "attachment_number": "1",
           "date_filed": null,
           "description": "",
-          "document_number": "195",
           "pacer_doc_id": "02513307026",
-          "pacer_seq_no": null,
-          "short_description": ""
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
           "date_filed": null,
           "description": "",
-          "document_number": "195",
           "pacer_doc_id": "02513307027",
-          "pacer_seq_no": null,
-          "short_description": ""
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
           "date_filed": null,
           "description": "",
-          "document_number": "195",
           "pacer_doc_id": "02513307028",
-          "pacer_seq_no": null,
-          "short_description": ""
+          "pacer_seq_no": null
         }
       ],
       "date_filed": null,

--- a/tests/examples/pacer/dockets_internet_archive/cacb_1669936.json
+++ b/tests/examples/pacer/dockets_internet_archive/cacb_1669936.json
@@ -13,39 +13,27 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2014-09-10",
           "description": "",
-          "document_number": "1",
           "pacer_doc_id": "973073614340",
-          "pacer_seq_no": null,
-          "short_description": ""
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2014-09-10",
           "description": "",
-          "document_number": "1",
           "pacer_doc_id": "973073614343",
-          "pacer_seq_no": null,
-          "short_description": ""
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2014-09-10",
           "description": "",
-          "document_number": "1",
           "pacer_doc_id": "973073614346",
-          "pacer_seq_no": null,
-          "short_description": ""
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2014-09-10",
           "description": "",
-          "document_number": "1",
           "pacer_doc_id": "973073614349",
-          "pacer_seq_no": null,
-          "short_description": ""
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2014-09-10",

--- a/tests/examples/pacer/dockets_internet_archive/cand_194617.json
+++ b/tests/examples/pacer/dockets_internet_archive/cand_194617.json
@@ -21,30 +21,21 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-08-01",
-          "description": "",
-          "document_number": "2",
+          "description": "Standing Order",
           "pacer_doc_id": "03503892652",
-          "pacer_seq_no": null,
-          "short_description": "Standing Order"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2007-08-01",
-          "description": "",
-          "document_number": "2",
+          "description": "CM Standing Order",
           "pacer_doc_id": "03503894028",
-          "pacer_seq_no": null,
-          "short_description": "CM Standing Order"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2007-08-01",
           "description": "",
-          "document_number": "2",
           "pacer_doc_id": "03503613775",
-          "pacer_seq_no": null,
-          "short_description": ""
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-08-01",
@@ -242,12 +233,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-11-16",
-          "description": "",
-          "document_number": "26",
+          "description": "Proposed Order",
           "pacer_doc_id": "03503948510",
-          "pacer_seq_no": null,
-          "short_description": "Proposed Order"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-11-16",
@@ -261,57 +249,39 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-11-16",
-          "description": "",
-          "document_number": "27",
+          "description": "Exhibit 1",
           "pacer_doc_id": "03503901275",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 1"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2007-11-16",
-          "description": "",
-          "document_number": "27",
+          "description": "Exhibit 2",
           "pacer_doc_id": "03503951142",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 2"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2007-11-16",
-          "description": "",
-          "document_number": "27",
+          "description": "Exhibit 3",
           "pacer_doc_id": "03503951351",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 3"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2007-11-16",
-          "description": "",
-          "document_number": "27",
+          "description": "Exhibit 4",
           "pacer_doc_id": "03503948773",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 4"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "5",
-          "date_filed": "2007-11-16",
-          "description": "",
-          "document_number": "27",
+          "description": "Exhibit 5",
           "pacer_doc_id": "03503950641",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 5"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "6",
-          "date_filed": "2007-11-16",
-          "description": "",
-          "document_number": "27",
+          "description": "Exhibit 6",
           "pacer_doc_id": "03503923345",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 6"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-11-16",
@@ -333,12 +303,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-11-30",
-          "description": "",
-          "document_number": "29",
+          "description": "Exhibit Decision in Ohio Valley Environmental Coalition v. Whitman",
           "pacer_doc_id": "03501864454",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Decision in Ohio Valley Environmental Coalition v. Whitman"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-11-30",
@@ -368,12 +335,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-12-07",
-          "description": "",
-          "document_number": "32",
+          "description": "Exhibit 1",
           "pacer_doc_id": "03504127613",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 1"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-12-07",
@@ -459,12 +423,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2008-01-10",
-          "description": "",
-          "document_number": "42",
+          "description": "Exhibit A",
           "pacer_doc_id": "03504204927",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit A"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2008-01-10",
@@ -502,12 +463,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2008-01-18",
-          "description": "",
-          "document_number": "46",
+          "description": "Exhibit A",
           "pacer_doc_id": "03504232561",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit A"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2008-01-18",
@@ -545,12 +503,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2008-03-13",
-          "description": "",
-          "document_number": "50",
+          "description": "Proposed Order Granting Motion by Intervenor-Defendant Dow AgroSciences LLC to D",
           "pacer_doc_id": "03504400072",
-          "pacer_seq_no": null,
-          "short_description": "Proposed Order Granting Motion by Intervenor-Defendant Dow AgroSciences LLC to D"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2008-03-13",
@@ -564,12 +519,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2008-03-14",
-          "description": "",
-          "document_number": "51",
+          "description": "Standing Order",
           "pacer_doc_id": "03504405100",
-          "pacer_seq_no": null,
-          "short_description": "Standing Order"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2008-03-14",
@@ -607,12 +559,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2008-04-23",
-          "description": "",
-          "document_number": "55",
+          "description": "Proposed Order",
           "pacer_doc_id": "03504526274",
-          "pacer_seq_no": null,
-          "short_description": "Proposed Order"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2008-04-23",
@@ -666,21 +615,15 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2008-05-22",
-          "description": "",
-          "document_number": "61",
+          "description": "Exhibit 1",
           "pacer_doc_id": "03504612718",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 1"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2008-05-22",
-          "description": "",
-          "document_number": "61",
+          "description": "Proposed Order Granting Intervenor Dow AgroSciences LLC&#039;s Motion for Leave",
           "pacer_doc_id": "03504612719",
-          "pacer_seq_no": null,
-          "short_description": "Proposed Order Granting Intervenor Dow AgroSciences LLC&#039;s Motion for Leave"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2008-05-22",
@@ -758,21 +701,15 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2008-09-16",
-          "description": "",
-          "document_number": "70",
+          "description": "Proposed Motion for Reconsideration",
           "pacer_doc_id": "03504931595",
-          "pacer_seq_no": null,
-          "short_description": "Proposed Motion for Reconsideration"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2008-09-16",
-          "description": "",
-          "document_number": "70",
+          "description": "Exhibit 1 to Motion for Reconsideration",
           "pacer_doc_id": "03504931596",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 1 to Motion for Reconsideration"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2008-09-16",

--- a/tests/examples/pacer/dockets_internet_archive/cand_287492.json
+++ b/tests/examples/pacer/dockets_internet_archive/cand_287492.json
@@ -821,12 +821,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2017-01-06",
-          "description": "",
-          "document_number": "102",
+          "description": "Proposed Order",
           "pacer_doc_id": "035015013360",
-          "pacer_seq_no": null,
-          "short_description": "Proposed Order"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2017-01-06",

--- a/tests/examples/pacer/dockets_internet_archive/dcd_119997.json
+++ b/tests/examples/pacer/dockets_internet_archive/dcd_119997.json
@@ -13,201 +13,135 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 1",
           "pacer_doc_id": "04501625604",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 1"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 2",
           "pacer_doc_id": "04501625292",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 2"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 3",
           "pacer_doc_id": "04501625587",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 3"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 4",
           "pacer_doc_id": "04501624966",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 4"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "5",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 5",
           "pacer_doc_id": "04501625517",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 5"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "6",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 6",
           "pacer_doc_id": "04501625075",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 6"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "7",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 7",
           "pacer_doc_id": "04501625429",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 7"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "8",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 8",
           "pacer_doc_id": "04501624951",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 8"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "9",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 9",
           "pacer_doc_id": "04501625472",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 9"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "10",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 10",
           "pacer_doc_id": "04501625189",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 10"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "11",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 11",
           "pacer_doc_id": "04501625642",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 11"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "12",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 12",
           "pacer_doc_id": "04501625427",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 12"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "13",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 13",
           "pacer_doc_id": "04501624969",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 13"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "14",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 14",
           "pacer_doc_id": "04501625177",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 14"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "15",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 15",
           "pacer_doc_id": "04501625094",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 15"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "16",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 16",
           "pacer_doc_id": "04501625639",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 16"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "17",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 17",
           "pacer_doc_id": "04501625192",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 17"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "18",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 18",
           "pacer_doc_id": "04501625358",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 18"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "19",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 19",
           "pacer_doc_id": "04501625290",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 19"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "20",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 20",
           "pacer_doc_id": "04501625140",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 20"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "21",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 21",
           "pacer_doc_id": "04501625701",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 21"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "22",
-          "date_filed": "2006-03-29",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit 22",
           "pacer_doc_id": "04501625033",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit 22"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2006-03-29",
@@ -269,12 +203,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2006-08-07",
-          "description": "",
-          "document_number": "8",
+          "description": "*Restricted*",
           "pacer_doc_id": "04501803019",
-          "pacer_seq_no": null,
-          "short_description": "*Restricted*"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2006-08-07",
@@ -320,21 +251,15 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-03-15",
-          "description": "",
-          "document_number": "13",
+          "description": "Exhibit Memorandum of Points and Authorities",
           "pacer_doc_id": "04501642354",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Memorandum of Points and Authorities"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2007-03-15",
-          "description": "",
-          "document_number": "13",
+          "description": "Answer to Complaint",
           "pacer_doc_id": "04501623622",
-          "pacer_seq_no": null,
-          "short_description": "Answer to Complaint"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-03-15",
@@ -380,165 +305,111 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Statement of Facts",
           "pacer_doc_id": "0450871721",
-          "pacer_seq_no": null,
-          "short_description": "Statement of Facts"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Affidavit of Roberta Gambale",
           "pacer_doc_id": "0450871976",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Affidavit of Roberta Gambale"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Affidavit of Miguel Hull",
           "pacer_doc_id": "0450872460",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Affidavit of Miguel Hull"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Affidavit of Christopher West",
           "pacer_doc_id": "0450871983",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Affidavit of Christopher West"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "5",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Affidavit of Roxanne D. Neloms",
           "pacer_doc_id": "0450872471",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Affidavit of Roxanne D. Neloms"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "6",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Affidavit of Domiento Hill",
           "pacer_doc_id": "0450871899",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Affidavit of Domiento Hill"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "7",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex. 4",
           "pacer_doc_id": "0450872157",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex. 4"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "8",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex.5",
           "pacer_doc_id": "0450871842",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex.5"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "9",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex.6",
           "pacer_doc_id": "0450872092",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex.6"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "10",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex. 6",
           "pacer_doc_id": "0450872074",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex. 6"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "11",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex. 9",
           "pacer_doc_id": "0450871711",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex. 9"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "12",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex. 11",
           "pacer_doc_id": "0450872393",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex. 11"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "13",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex. 13",
           "pacer_doc_id": "0450872141",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex. 13"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "14",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex. 14",
           "pacer_doc_id": "0450872294",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex. 14"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "15",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex. 15",
           "pacer_doc_id": "0450872033",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex. 15"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "16",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex. 16",
           "pacer_doc_id": "0450872047",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex. 16"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "17",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex. 20",
           "pacer_doc_id": "0450872400",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex. 20"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "18",
-          "date_filed": "2007-06-08",
-          "description": "",
-          "document_number": "18",
+          "description": "Exhibit Ex. 22",
           "pacer_doc_id": "0450872007",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Ex. 22"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-06-08",
@@ -568,30 +439,21 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "21",
+          "description": "Exhibit",
           "pacer_doc_id": "0450904612",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "21",
+          "description": "Exhibit",
           "pacer_doc_id": "0450904804",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "21",
+          "description": "Exhibit",
           "pacer_doc_id": "0450904453",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-07-13",
@@ -605,93 +467,63 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "22",
+          "description": "Memorandum of Points and Authorities",
           "pacer_doc_id": "0450905049",
-          "pacer_seq_no": null,
-          "short_description": "Memorandum of Points and Authorities"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "22",
+          "description": "Statement of Facts",
           "pacer_doc_id": "0450904361",
-          "pacer_seq_no": null,
-          "short_description": "Statement of Facts"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "22",
+          "description": "Exhibit",
           "pacer_doc_id": "0450904702",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "22",
+          "description": "*Restricted*",
           "pacer_doc_id": "0450905027",
-          "pacer_seq_no": null,
-          "short_description": "*Restricted*"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "5",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "22",
+          "description": "Exhibit",
           "pacer_doc_id": "0450904597",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "6",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "22",
+          "description": "Exhibit",
           "pacer_doc_id": "0450904573",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "7",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "22",
+          "description": "Exhibit",
           "pacer_doc_id": "0450905025",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "8",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "22",
+          "description": "Exhibit",
           "pacer_doc_id": "0450904442",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "9",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "22",
+          "description": "*Restricted*",
           "pacer_doc_id": "0450904941",
-          "pacer_seq_no": null,
-          "short_description": "*Restricted*"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "10",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "22",
+          "description": "Text of Proposed Order",
           "pacer_doc_id": "0450904829",
-          "pacer_seq_no": null,
-          "short_description": "Text of Proposed Order"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-07-13",
@@ -705,48 +537,33 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "23",
+          "description": "Opposition",
           "pacer_doc_id": "0450904333",
-          "pacer_seq_no": null,
-          "short_description": "Opposition"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "23",
+          "description": "Statement of Facts in Dispute",
           "pacer_doc_id": "0450905032",
-          "pacer_seq_no": null,
-          "short_description": "Statement of Facts in Dispute"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "23",
+          "description": "Exhibit",
           "pacer_doc_id": "0450904657",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "23",
+          "description": "Exhibit",
           "pacer_doc_id": "0450904392",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "5",
-          "date_filed": "2007-07-13",
-          "description": "",
-          "document_number": "23",
+          "description": "Exhibit",
           "pacer_doc_id": "0450904787",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-07-13",
@@ -760,192 +577,129 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Statement of Facts",
           "pacer_doc_id": "0450923161",
-          "pacer_seq_no": null,
-          "short_description": "Statement of Facts"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Statement of Facts",
           "pacer_doc_id": "0450923212",
-          "pacer_seq_no": null,
-          "short_description": "Statement of Facts"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923049",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923413",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "5",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923277",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "6",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923664",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "7",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923192",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "8",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923550",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "9",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923188",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "10",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923207",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "11",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923411",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "12",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923447",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "13",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923156",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "14",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923181",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "15",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923120",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "16",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923490",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "17",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923527",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "18",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923410",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "19",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923130",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "20",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923045",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "21",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "24",
+          "description": "Exhibit",
           "pacer_doc_id": "0450923342",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-08-03",
@@ -959,192 +713,129 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Statement of Facts",
           "pacer_doc_id": "04501918588",
-          "pacer_seq_no": null,
-          "short_description": "Statement of Facts"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Statement of Facts Plaintiff reply the defendents statement of material facts",
           "pacer_doc_id": "04501918926",
-          "pacer_seq_no": null,
-          "short_description": "Statement of Facts Plaintiff reply the defendents statement of material facts"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918648",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918986",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "5",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501919040",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "6",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918800",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "7",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501919150",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "8",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918838",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "9",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501919023",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "10",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918808",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "11",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501919162",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "12",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918990",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "13",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918711",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "14",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918863",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "15",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918607",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "16",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501919121",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "17",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918892",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "18",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501919088",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "19",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918763",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "20",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501918729",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "21",
-          "date_filed": "2007-08-03",
-          "description": "",
-          "document_number": "25",
+          "description": "Exhibit",
           "pacer_doc_id": "04501919071",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-08-03",
@@ -1158,57 +849,39 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-08-24",
-          "description": "",
-          "document_number": "26",
+          "description": "Exhibit",
           "pacer_doc_id": "0450939916",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2007-08-24",
-          "description": "",
-          "document_number": "26",
+          "description": "Exhibit",
           "pacer_doc_id": "0450939622",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2007-08-24",
-          "description": "",
-          "document_number": "26",
+          "description": "Exhibit",
           "pacer_doc_id": "0450940052",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2007-08-24",
-          "description": "",
-          "document_number": "26",
+          "description": "Exhibit",
           "pacer_doc_id": "0450939597",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "5",
-          "date_filed": "2007-08-24",
-          "description": "",
-          "document_number": "26",
+          "description": "*Restricted*",
           "pacer_doc_id": "0450939790",
-          "pacer_seq_no": null,
-          "short_description": "*Restricted*"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "6",
-          "date_filed": "2007-08-24",
-          "description": "",
-          "document_number": "26",
+          "description": "ATTACHMENT B",
           "pacer_doc_id": "0450939646",
-          "pacer_seq_no": null,
-          "short_description": "ATTACHMENT B"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-08-24",
@@ -1222,12 +895,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2007-12-04",
-          "description": "",
-          "document_number": "27",
+          "description": "Supplement",
           "pacer_doc_id": "0450923908",
-          "pacer_seq_no": null,
-          "short_description": "Supplement"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2007-12-04",

--- a/tests/examples/pacer/dockets_internet_archive/flmd_330522.json
+++ b/tests/examples/pacer/dockets_internet_archive/flmd_330522.json
@@ -13,30 +13,21 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2016-11-14",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit A",
           "pacer_doc_id": "047016761589",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit A"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2016-11-14",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit B",
           "pacer_doc_id": "047016761590",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit B"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2016-11-14",
-          "description": "",
-          "document_number": "1",
+          "description": "Civil Cover Sheet",
           "pacer_doc_id": "047016761591",
-          "pacer_seq_no": null,
-          "short_description": "Civil Cover Sheet"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2016-11-14",

--- a/tests/examples/pacer/dockets_internet_archive/nysd_476194.json
+++ b/tests/examples/pacer/dockets_internet_archive/nysd_476194.json
@@ -613,30 +613,21 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "76",
+          "description": "Exhibit Exhibit A",
           "pacer_doc_id": "127021236431",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Exhibit A"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "76",
+          "description": "Exhibit Exhibit B",
           "pacer_doc_id": "127021236432",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Exhibit B"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2017-10-25",
-          "description": "",
-          "document_number": "76",
+          "description": "Exhibit Exhibit C",
           "pacer_doc_id": "127021236433",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit Exhibit C"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2017-10-25",

--- a/tests/examples/pacer/dockets_internet_archive/ohsd_170541.json
+++ b/tests/examples/pacer/dockets_internet_archive/ohsd_170541.json
@@ -13,39 +13,27 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2014-04-11",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit A",
           "pacer_doc_id": "14304939403",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit A"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2014-04-11",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit B",
           "pacer_doc_id": "14304939404",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit B"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "3",
-          "date_filed": "2014-04-11",
-          "description": "",
-          "document_number": "1",
+          "description": "Civil Cover Sheet",
           "pacer_doc_id": "14304939405",
-          "pacer_seq_no": null,
-          "short_description": "Civil Cover Sheet"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "4",
-          "date_filed": "2014-04-11",
-          "description": "",
-          "document_number": "1",
+          "description": "Summons Form",
           "pacer_doc_id": "14304939406",
-          "pacer_seq_no": null,
-          "short_description": "Summons Form"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2014-04-11",

--- a/tests/examples/pacer/dockets_internet_archive/txnd_202294.json
+++ b/tests/examples/pacer/dockets_internet_archive/txnd_202294.json
@@ -13,21 +13,15 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2011-01-02",
-          "description": "",
-          "document_number": "1",
+          "description": "Cover Sheet",
           "pacer_doc_id": "17705464614",
-          "pacer_seq_no": null,
-          "short_description": "Cover Sheet"
+          "pacer_seq_no": null
         },
         {
           "attachment_number": "2",
-          "date_filed": "2011-01-02",
-          "description": "",
-          "document_number": "1",
+          "description": "Exhibit(s) List of Does",
           "pacer_doc_id": "17705464615",
-          "pacer_seq_no": null,
-          "short_description": "Exhibit(s) List of Does"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2011-01-02",

--- a/tests/examples/pacer/dockets_internet_archive/utd_103577.json
+++ b/tests/examples/pacer/dockets_internet_archive/utd_103577.json
@@ -21,12 +21,9 @@
       "attachments": [
         {
           "attachment_number": "1",
-          "date_filed": "2017-01-05",
-          "description": "",
-          "document_number": "2",
+          "description": "Civil Cover Sheet civil cover sheet",
           "pacer_doc_id": "18303853603",
-          "pacer_seq_no": null,
-          "short_description": "Civil Cover Sheet civil cover sheet"
+          "pacer_seq_no": null
         }
       ],
       "date_filed": "2017-01-05",


### PR DESCRIPTION
Attachments should not have `short_description` keys but rather just a `description` key. Also remove redundant `document_number` and `date_filed` keys from attachments.