### PR TITLE
fix(AbstractSite): put cache-control key inside headers dict

### DIFF
--- a/juriscraper/AbstractSite.py
+++ b/juriscraper/AbstractSite.py
@@ -53,9 +53,13 @@ class AbstractSite:
         self.request = {
             "verify": certifi.where(),
             "session": requests.session(),
-            "headers": {"User-Agent": "Juriscraper"},
-            # Disable CDN caching on sites like SCOTUS (ahem)
-            "cache-control": "no-cache, no-store, max-age=1",
+            "headers": {
+                "User-Agent": "Juriscraper",
+                # Disable CDN caching on sites like SCOTUS (ahem)
+                "Cache-Control": "no-cache, max-age=0, must-revalidate",
+                # backwards compatibility with HTTP/1.0 caches
+                "Pragma": "no-cache",
+            },
             "parameters": {},
             "request": None,
             "status": None,


### PR DESCRIPTION
fix(AbstractSite): put cache-control key inside headers dict
    
Solves #1110
    
cache-control key was not in the proper place, so it didn't do 
anything. Also, update the header value.
    
Adds `Pragma` header with 'no-cache' value for older caches