### PR TITLE
feat(pacer): Updates logic to create error message.

### DIFF
--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -267,6 +267,13 @@ class BaseReport:
                 )
 
             error = None
+            if b"Cannot locate the case with caseid" in r.content:
+                # Second download attempt failed. log case ID and URL for
+                # debugging
+                error = (
+                    f"Cannot locate the case with caseid: "
+                    f"{pacer_case_id} at {url}"
+                )
             if b"could not retrieve dktentry for dlsid" in r.content:
                 error = (
                     f"Failed to get docket entry in case: "

--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -292,12 +292,22 @@ class BaseReport:
                 )
             if b"You do not have access to this transcript." in r.content:
                 error = f"Unable to get transcript. {pacer_case_id=}, {url=}"
-            if b"Sealed Document" in r.content or b"Under Seal" in r.content:
+
+            sealed_document_phrases = [
+                b"Sealed Document",
+                b"Under Seal",
+                b"Document is Sealed",
+                b"This document is SEALED",
+            ]
+            if any(phrase in r.content for phrase in sealed_document_phrases):
                 # See: https://ecf.almd.uscourts.gov/doc1/01712589088
                 # See: https://ecf.cand.uscourts.gov/doc1/035122021132
+                # See: https://ecf.caed.uscourts.gov/doc1/03319001890
                 # Matches against:
-                # "Sealed Document" and
+                # "Sealed Document"
                 # "This document is currently Under Seal and not available..."
+                # "Document is Sealed."
+                # "This document is SEALED"
                 error = f"Document is sealed: {pacer_case_id=} {url=}"
             if (
                 b"This image is not available for viewing by non-court users"

--- a/juriscraper/pacer/reports.py
+++ b/juriscraper/pacer/reports.py
@@ -293,6 +293,11 @@ class BaseReport:
             if b"You do not have access to this transcript." in r.content:
                 error = f"Unable to get transcript. {pacer_case_id=}, {url=}"
 
+            if b"No matter of public record" in r.content:
+                error = (
+                    f"No matter of public record has been filed. "
+                    f"{pacer_case_id=}, {url=}"
+                )
             sealed_document_phrases = [
                 b"Sealed Document",
                 b"Under Seal",


### PR DESCRIPTION
While debugging another issue in the `recap-fetch` API, I noticed that our code was incorrectly identifying certain sealed documents on PACER. This led to a misleading error message being added to the fetch queue:

> Unable to download PDF. PDF not served as binary data and unable to find iframe src attribute. URL: https://ecf.caed.uscourts.gov/doc1/03319001890, caseid: 300601, magic_num: None. court_id='caed'

To address this issue, I've added a new phrase to the sealed document check logic and refactored the if statement

Here's another example of a sealed document: https://ecf.vawd.uscourts.gov/doc1/19111488805