### PR TITLE
fix(ky): make date range smaller

### DIFF
--- a/juriscraper/opinions/united_states/state/ky.py
+++ b/juriscraper/opinions/united_states/state/ky.py
@@ -29,7 +29,7 @@ from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 class Site(OpinionSiteLinear):
     # Home: https://appellatepublic.kycourts.net/login
     first_opinion_date = datetime(1982, 2, 18).date()
-    days_interval = 10  # page size of 25
+    days_interval = 7  # page size of 25
 
     api_court = "Kentucky Supreme Court"
     api_url = (
@@ -62,7 +62,7 @@ class Site(OpinionSiteLinear):
         """
         if not start:
             end = datetime.now()
-            start = end - timedelta(30)
+            start = end - timedelta(7)
 
         logger.info("Date range %s %s", start, end)
         params = {
@@ -73,8 +73,8 @@ class Site(OpinionSiteLinear):
             "searchFields[1].operation": "<=",
             "searchFields[1].values[0]": end.strftime("%m/%d/%Y"),
             "searchFields[1].indexFieldName": "filedDate",
-            "searchFilters[0].indexFieldName": "caseHeader.court",
             "searchFilters[0].operation": "=",
+            "searchFilters[0].indexFieldName": "caseHeader.court",
             "searchFilters[0].values[0]": self.api_court,
         }
         self.url = f"{self.api_url}{urlencode(params)}"
@@ -118,6 +118,12 @@ class Site(OpinionSiteLinear):
                 # Drop from the disposition everything after "BY JUDGE..."
                 # May contain the case name
                 disposition = re.split(self.judge_regex, disposition)[0]
+
+            if disposition.upper() in [
+                "OPINION OF THE COURT",
+                "OPINION AND ORDER",
+            ]:
+                disposition = ""
 
             if self.test_mode_enabled():
                 # detail request has been manually nested in the test file


### PR DESCRIPTION
Solves https://github.com/freelawproject/juriscraper/issues/1151

Date range of 30 days for regular scraper made the page return stale results; even when not exceeding the page size limit. Using a smaller range returns current results

Also, refactor disposition parsing to exclude placeholder values