### PR TITLE
feat(sc): use extract_from_text to get docket_number

### DIFF
--- a/juriscraper/opinions/united_states/state/sc.py
+++ b/juriscraper/opinions/united_states/state/sc.py
@@ -19,6 +19,7 @@ Contact information:
  - Web Developer (who can help with firewall issues): 803-734-0373, Winkie Clark
 """
 
+import re
 from datetime import date
 from typing import Dict, List, Tuple
 
@@ -37,6 +38,7 @@ class Site(OpinionSiteLinear):
     court = "supreme-court"
     days_interval = 27  # guarantees picking each month
     first_opinion_date = date(2000, 1, 1)
+    docket_regex = r"Appellate Case No. (?P<docket>\d{4}-\d+)"
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -119,3 +121,8 @@ class Site(OpinionSiteLinear):
             date_obj.year,
             str(date_obj.month).zfill(2),
         )
+
+    def extract_from_text(self, scraped_text: str) -> dict:
+        if match := re.search(self.docket_regex, scraped_text):
+            return {"Docket": {"docket_number": match.group("docket")}}
+        return {}

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -691,6 +691,50 @@ class ScraperExtractFromText(unittest.TestCase):
                 {},
             ),
         ],
+        "juriscraper.opinions.united_states.state.sc": [
+            (
+                # https://www.courtlistener.com/api/rest/v4/opinions/10744852/
+                "                   THE STATE OF SOUTH CAROLINA\n                        In The Supreme Court\n\n             In the Matter of Lawrence J. Purvis, Jr., Respondent.\n\n             Appellate Case No. 2024-000453\n\n\n                              Opinion No. 28244\n             Submitted October 30, 2024 – Filed November 20, 2024\n\n\n",
+                {
+                    "Docket": {
+                        "docket_number": "2024-000453",
+                    },
+                },
+            )
+        ],
+        "juriscraper.opinions.united_states.state.sc_u": [
+            (
+                # https://www.courtlistener.com/api/rest/v4/opinions/10732544/
+                "THIS OPINION HAS NO PRECEDENTIAL VALUE. IT SHOULD NOT BE\n   CITED OR RELIED ON AS PRECEDENT IN ANY PROCEEDING\n        EXCEPT AS PROVIDED BY RULE 268(d)(2), SCACR.\n\n                 THE STATE OF SOUTH CAROLINA\n                      In The Supreme Court\n\n        Robin Allen, Petitioner,\n\n        v.\n\n        Richard Winn Academy, Kristen Chaisson (in her\n        individual capacity and as Head of School), and John\n        Ryan II, Respondents.\n\n        Appellate Case No. 2023-000805\n\n\n\n     ON WRIT OF CERTIORARI TO THE COURT OF APPEALS\n\n\n                     Appeal from Fairfield County\n                Eugene C. Griffith, Jr., Circuit Court Judge\n\n\n                Memorandum Opinion No. 2024-MO-024\n       ",
+                {
+                    "Docket": {
+                        "docket_number": "2023-000805",
+                    },
+                },
+            )
+        ],
+        "juriscraper.opinions.united_states.state.scctapp_u": [
+            (
+                # https://www.courtlistener.com/api/rest/v4/opinions/10756176/
+                "THIS OPINION HAS NO PRECEDENTIAL VALUE. IT SHOULD NOT BE\n   CITED OR RELIED ON AS PRECEDENT IN ANY PROCEEDING\n        EXCEPT AS PROVIDED BY RULE 268(d)(2), SCACR.\n\n                THE STATE OF SOUTH CAROLINA\n                    In The Court of Appeals\n\n        South Carolina Department of Social Services,\n        Respondent,\n\n        v.\n\n        Corey M. Nelson, Appellant.\n\n        In the interest of a minor under the age of eighteen.\n\n        Appellate Case No. 2024-000816\n\n\n\n                     Appeal From Richland County\n                  M. Scott Rankin, Family Court Judge\n\n\n ",
+                {
+                    "Docket": {
+                        "docket_number": "2024-000816",
+                    },
+                },
+            )
+        ],
+        "juriscraper.opinions.united_states.state.scctapp": [
+            (
+                # https://www.courtlistener.com/api/rest/v4/opinions/10744853/
+                "                     THE STATE OF SOUTH CAROLINA\n                         In The Court of Appeals\n\n             Crescent Homes SC, LLC, Appellant,\n\n             v.\n\n             CJN, LLC, Respondent.\n\n             Appellate Case No. 2022-000897\n\n\n\n                        Appeal From Greenville County\n                    Charles B. Simmons, Jr., Master-in-Equity\n\n\n                               Opinion No. 6093\n                  Heard May 9, 2024 – Filed November 20, 2024\n\n\n                                   AFFIRMED\n\n\n             Ellis Reed-Hill Lesemann and Benjamin Houston Joyce,\n             both of Lesemann & Associates, LLC, of Charleston, for\n   ",
+                {
+                    "Docket": {
+                        "docket_number": "2022-000897",
+                    },
+                },
+            )
+        ],
     }
 
     def test_extract_from_text(self):


### PR DESCRIPTION
Solves https://github.com/freelawproject/juriscraper/issues/1188

The value we were previously collecting as a docket number was a sort of document ID