### PR TITLE
fix(appellate): Corrects download_pdf return type

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,10 @@ Releases are also tagged in git, if that's helpful.
 
 ## Coming up
 
-- N/A
+- Fixes:
+  - `AppellateDocketReport.download_pdf` now returns a two-tuple containing the
+    response object or None and a str. This aligns with the changes introduced
+    in v 2.5.1.
 
 ## Current
 

--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from lxml import html
 from lxml.etree import _ElementUnicodeResult
+from requests import Response
 
 from ..lib.judge_parsers import normalize_judge_string
 from ..lib.log_tools import make_default_logger
@@ -260,13 +261,16 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
         self._clear_caches()
         super().parse()
 
-    def download_pdf(self, pacer_doc_id, pacer_case_id=None):
+    def download_pdf(
+        self, pacer_doc_id, pacer_case_id=None
+    ) -> tuple[Optional[Response], str]:
         """Download a PDF from an appellate court.
 
         :param pacer_case_id: The case ID for the docket
         :param pacer_doc_id: The document ID for the item.
-        :return: request.Response object containing the PDF, if one can be
-        found, else returns None.
+        :return: A tuple of the request.Response object containing a PDF, if
+        one can be found (is not sealed, gone, etc.). And a string indicating
+        the error message, if there is one or else an empty string.
 
         This is a functional curl command to get a PDF (though the cookies have
         been changed to protect the innocent):
@@ -331,8 +335,8 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
                 pacer_doc_id,
                 self.court_id,
             )
-            return r
-        return None
+            return r, ""
+        return None, "Unable to download PDF."
 
     @property
     def metadata(self):


### PR DESCRIPTION
This PR fixes inconsistency in `download_pdf` behavior for `AppellateDocketReport` class

While working on https://github.com/freelawproject/courtlistener/issues/3877,  I found that the return type of `download_pdf` method in the `AppellateDocketReport` class is different from what's documented in the [changes.md](https://github.com/freelawproject/juriscraper/blob/dde9d687c6c1051585c03d3baf8c6b27b81a0898/CHANGES.md) file.
This PR fixes that so it behaves the same as the `download_pdf` method from the `BaseReport` class. 

This change makes it easier to use both `AppellateDocketReport` alongside other classes that inherit from `BaseReport` without needing any special workarounds.
