### PR TITLE
feat(appellate): Handle Attachment Pages in download_pdf

### DIFF
--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -329,14 +329,24 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
         )
         r = self.session.get(self.url, params=query_params)
         r.raise_for_status()
-        if is_pdf(r):
-            logger.info(
-                "Got PDF binary data for document #%s in court %s",
-                pacer_doc_id,
-                self.court_id,
+
+        if b"Documents are attached to this filing" in r.content:
+            error_message = (
+                "This PACER document is part of an attachment page. "
+                "Our system currently lacks the metadata for this attachment. "
+                "Please purchase the attachment page and try again."
             )
-            return r, ""
-        return None, "Unable to download PDF."
+            return None, error_message
+
+        if not is_pdf(r):
+            return None, "Unable to download PDF."
+
+        logger.info(
+            "Got PDF binary data for document #%s in court %s",
+            pacer_doc_id,
+            self.court_id,
+        )
+        return r, ""
 
     @property
     def metadata(self):

--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -332,9 +332,8 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
 
         if b"Documents are attached to this filing" in r.content:
             error_message = (
-                "This PACER document is part of an attachment page. "
-                "Our system currently lacks the metadata for this attachment. "
-                "Please purchase the attachment page and try again."
+                "Unable to download PDF. "
+                "An attachment page was returned instead."
             )
             return None, error_message
 


### PR DESCRIPTION
This PR improves the `download_pdf` method to handle cases where attachment pages are returned instead of the expected PDF documents.