### PR TITLE
915 Added support for parsing docket numbers wrapped in a tel: href in the appellate docket report

### DIFF
--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -43,7 +43,6 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
     docket_number_dist_regex = re.compile(
         r"((\d{1,2}:)?\d\d-[a-zA-Z]{1,4}-\d{1,10})"
     )
-    docket_number_lookup_regex = "Docket #|Case Number"
 
     CACHE_ATTRS = ["metadata", "docket_entries"]
 
@@ -358,9 +357,7 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
 
         data = {
             "court_id": self.court_id,
-            "docket_number": self._get_tail_by_regex(
-                self.docket_number_lookup_regex
-            ),
+            "docket_number": self._parse_docket_number(),
             "case_name": self._get_case_name(),
             "panel": self._get_panel(),
             "nature_of_suit": self._get_tail_by_regex("Nature of Suit"),
@@ -479,6 +476,32 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
         attorney["roles"] = roles
         attorney["contact"] = "\n".join(contacts)
         return attorney
+
+    def _parse_docket_number(self) -> str:
+        """Parse the docket_number from the appellate report.
+        :return: The docket_number.
+        """
+
+        docket_number_regex = "Docket #|Case Number"
+        # Try to parse docket_number first using _get_tail_by_regex.
+        if docket_number := self._get_tail_by_regex(docket_number_regex):
+            return docket_number
+
+        # If that doesn't work, fall back to parsing the docket_number wrapped
+        # in a "tel:" href.
+        nodes = self.tree.re_xpath(
+            f'//*[re:match(text(), "{docket_number_regex}")]'
+        )
+        if not nodes:
+            return ""
+
+        a_node = nodes[0].xpath(
+            "following-sibling::a[starts-with(@href, 'tel:')][1]"
+        )
+        if a_node and a_node[0].text:
+            return clean_string(a_node[0].text)
+
+        return ""
 
     @property
     def parties(self):
@@ -920,16 +943,7 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
         node = node if node is not None else self.tree
         nodes = node.re_xpath(f'//*[re:match(text(), "{regex}")]')
         try:
-            tail_text = nodes[0].tail
-            tail_text = tail_text.strip() if tail_text is not None else ""
-            # If there's no tail text and we're parsing the docket_number,
-            # fall back to parsing the docket_number wrapped in a "tel:" href.
-            if not tail_text and regex == self.docket_number_lookup_regex:
-                a_nodes = nodes[0].xpath(
-                    "following-sibling::a[starts-with(@href, 'tel:')][1]"
-                )
-                tail_text = a_nodes[0].text or "" if a_nodes else ""
-            tail = clean_string(tail_text)
+            tail = clean_string(nodes[0].tail.strip())
         except (IndexError, AttributeError):
             if cast_to_date:
                 return None

--- a/tests/examples/pacer/dockets/appellate/ca5_212643.html
+++ b/tests/examples/pacer/dockets/appellate/ca5_212643.html
@@ -1,0 +1,473 @@
+<head>
+	<title>23-30126 Docket</title>
+	<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
+<link rel="stylesheet" type="text/css" media="all" href="TransportRoom?servlet=ShowPagePublic&amp;page=PACER.css">
+<style type="text/css" media="print">.noprint{display:none;}</style></head>
+<body>
+<div class="noprint">
+<table border="0" cellspacing="0" cellpadding="0" width="100%" bgcolor="#0000af">
+<tbody><tr><td>
+	<!-- THESE ITEMS ARE ON THE LEFT PORTION OF THE MENU -->
+	<table border="0" cellspacing="0" cellpadding="0" align="left" bgcolor="#0000af">
+	<tbody><tr valign="middle" align="left">
+		<td><a href="/n/AttorneyFiling"><img src="TransportRoom?servlet=cmecf_logo.gif" alt="CM/ECF" title="File"></a></td>
+		<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=CaseSearch.jsp">Case Search</a>&nbsp;&nbsp;&nbsp;</td>
+		<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=PACERCalendar.jsp">Calendar</a>&nbsp;&nbsp;&nbsp;</td>
+		<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=PACEROpinion.jsp">Opinions</a>&nbsp;&nbsp;&nbsp;</td>
+		<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=OrderJudgment.jsp">Orders/Judgments</a>&nbsp;&nbsp;&nbsp;</td>
+<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=Briefs.jsp">Briefs</a>&nbsp;&nbsp;&nbsp;</td>
+<td><a style="color: #ffffff; font-weight:bold;" href="javascript:downloadData(&quot;XML&quot;);">XML</a>&nbsp;&nbsp;&nbsp;</td>
+		<td><a style="color: #ffffff; font-weight:bold;" href="javascript:downloadData(&quot;TXT&quot;);">TXT</a>&nbsp;&nbsp;&nbsp;</td>
+</tr>
+	</tbody></table>
+</td><td>
+<!-- THESE ITEMS ARE ON THE RIGHT PORTION OF THE MENU -->
+	<table border="0" cellspacing="0" cellpadding="0" align="right" bgcolor="#0000af">
+	<tbody><tr>
+<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=InvalidUserLogin.jsp&amp;logout=y">Logout</a>&nbsp;&nbsp;&nbsp;</td>
+<td><a style="color: #ffffff; font-weight:bold;" href="TransportRoom?servlet=PacerHelp.jsp#CaseSummary">Help</a>&nbsp;&nbsp;</td>
+	</tr>
+	</tbody></table>
+</td></tr>
+</tbody></table>
+<br>
+</div>
+<script type="text/javascript">
+function downloadData(aType) {
+	document.f1.outputXML_TXT.value = aType;
+	document.f1.submit();
+}
+</script>
+
+<form name="f1" action="TransportRoom?servlet=CaseSummary.jsp" method="post">
+<input type="hidden" name="outputXML_TXT">
+<input type="hidden" name="servlet" value="CaseSummary.jsp">
+<input type="hidden" name="CSRF" value="csrf_7953432221489077282">
+<input type="hidden" name="caseNum" value="23-30126">
+<input type="hidden" name="fullDocketReport" value="Y">
+<input type="hidden" name="incOrigDkt" value="Y">
+<input type="hidden" name="incPrior" value="Y">
+<input type="hidden" name="incAssoc" value="Y">
+<input type="hidden" name="incPanel" value="Y">
+<input type="hidden" name="incPtyAty" value="Y">
+<input type="hidden" name="incCaption" value="long">
+<input type="hidden" name="incDktEntries" value="Y">
+<input type="hidden" name="dateFrom" value="">
+<input type="hidden" name="dateTo" value="">
+<input type="hidden" name="incPdfMulti" value="Y">
+<input type="hidden" name="actionType" value="Run Docket Report"><input name="CSRF" type="hidden" value="csrf_7953432221489077282">
+</form>
+<table width="100%" border="0">
+	<tbody><tr><td align="right"></td></tr>
+	<tr><td align="center"><b>General Docket<br>
+	United States Court of Appeals for the Fifth Circuit</b></td>
+	</tr>
+</tbody></table><div class="btn-group" id="recap-action-button"><a class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"><i class="fa fa-spinner fa-spin recap-btn-spinner-hidden" id="recap-button-spinner"></i> RECAP Actions<span class="caret"></span></a><ul class="dropdown-menu"><h2 class="dropdown-header" id="action-button-dropdown-header">CourtListener</h2><li id="view-docket-button"><a href="https://www.courtlistener.com/recap/gov.uscourts.ca5.212643/" target="_blank">View this docket</a></li><div class="recap-dropdown-divider"></div><li><a href="javascript:void(0);" id="refresh-recap-links" role="button">Refresh RECAP Links</a></li></ul></div>
+<table width="100%" border="1" cellpadding="4">
+<!-- ===================== NEW SECTION - Case Stub ======================== -->
+<tbody><tr><td>
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tbody><tr><td><b>Court of Appeals Docket #: </b><a href="tel:23-30126">23-30126</a></td>
+		<td valign="top" align="right" rowspan="2">
+		<b>Docketed:</b> 03/07/2023</td></tr>
+<tr><td>USA v. Broussard</td></tr>
+	<tr><td><b>Appeal From:</b>  
+	Western District of Louisiana, Lafayette</td>
+</tr>
+	<tr><td><b>Fee Status:</b>  Fee Paid</td>
+</tr>
+	</tbody></table>
+</td></tr>
+<!-- ==================== NEW SECTION - Case Type ========================= -->
+<tr><td>
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tbody><tr><td><b>Case Type Information:</b></td></tr>
+	<tr><td><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;1)</b> Criminal (DCRIM)</td></tr>
+	<tr><td><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;2)</b> Direct Criminal</td></tr>
+	<tr><td><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;3)</b> </td></tr>
+	<tr><td></td></tr>
+	</tbody></table>
+</td></tr>
+<!-- =================== NEW SECTION - Orig Court ========================= -->
+<tr><td>
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tbody><tr><td colspan="4"><b>Originating Court Information:</b></td></tr>
+<tr><td colspan="4">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b>District: </b>0536-6 : <a href="https://ecf.lawd.uscourts.gov/cgi-bin/DktRpt.pl?caseNumber=6:21-CR-138-1" target="_BLANK">6:21-CR-138-1</a></td></tr>
+<tr><td colspan="4">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b>Court Reporter: </b>Cathleen E. Marquardt, Court Reporter</td></tr><tr><td colspan="4">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b>Originating Judge: </b>David Cleveland Joseph, U.S. District Judge</td></tr><tr><td colspan="2"><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Date Filed: </b>06/16/2021</td></tr>
+<tr>
+<td><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Date NOA Filed:</b></td>
+<td><b>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Date Rec'd COA:</b></td>
+</tr>
+<tr>
+<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;03/03/2023</td>
+<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;03/03/2023</td>
+</tr>
+</tbody></table>
+</td></tr>
+<!-- =============== NEW SECTION - Prior and/or Assoc Cases =============== -->
+<tr><td>
+<!-- NEW SUBSECTION - Prior Cases -->
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tbody><tr><td colspan="2"><b>Prior Cases:</b></td></tr>
+<tr><td colspan="9">
+</td></tr><tr><td colspan="9">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<a href="TransportRoom?servlet=DocketReportFilter.jsp&amp;caseNum=22-30652" target="_blank" '="">22-30652</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b>Date Filed:</b> 10/14/2022&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b>Date Disposed:</b> 11/10/2022&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b>Disposition:</b> Dismissed</td></tr>
+</tbody></table>
+<br>
+<!-- NEW SUBSECTION - Assoc Cases -->
+	<table width="100%" border="0" cellpadding="0" cellspacing="0">
+	<tbody><tr><td colspan="2"><b>Current Cases:</b></td></tr>
+<tr><td colspan="5">&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;None</td></tr>
+</tbody></table>
+</td></tr>
+<!-- ================= NEW SECTION - Panel Assignment ===================== -->
+<tr><td><b>Panel Assignment:</b>
+
+	&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Not available
+</td></tr>
+</tbody></table>
+
+<!-- ===================NEW SECTION - Party/Aty List ====================== -->
+<br>
+<!-- NEW SHEET -->
+<table width="100%" border="1" cellpadding="0">
+<tbody><tr><td>
+	<table width="100%" border="0" cellpadding="4" cellspacing="0">
+<tbody><tr><td colspan="2"></td></tr>
+	<tr><td valign="top" width="50%">United States of America<br>
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Plaintiff&nbsp;-&nbsp;Appellee
+
+</td>
+		<td valign="top" width="50%">
+Thomas Forrest Phillips<br>Direct: <a href="tel:337-262-6618">337-262-6618</a><br>Email: thomas.phillips3@usdoj.gov<br>Fax: <a href="tel:337-262-6680">337-262-6680</a><br>[COR LD NTC Government]<br>U.S. Attorney's Office<br>Western District of Louisiana<br>Suite 2200<br>800 Lafayette Street<br>Lafayette, LA 70501-6832<br><br>
+Camille Ann Domingue, Assistant U.S. Attorney<br>Direct: <a href="tel:337-262-6618">337-262-6618</a><br>Email: Camille.Domingue@usdoj.gov<br>[COR NTC Government]<br>U.S. Attorney's Office<br>Western District of Louisiana<br>Suite 2200<br>800 Lafayette Street<br>Lafayette, LA 70501-6832</td></tr>
+<tr><td colspan="2">v.<br><br></td></tr>
+	<tr><td valign="top" width="50%">Brian Broussard, also known as Lil Brian<br>
+
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Defendant&nbsp;-&nbsp;Appellant
+
+</td>
+		<td valign="top" width="50%">
+Andre' Robert Belanger, Esq.<br>Direct: <a href="tel:225-383-9703">225-383-9703</a><br>Email: andre@manassehandgill.com<br>Fax: <a href="tel:225-383-9704">225-383-9704</a><br>[COR LD NTC Retained]<br>Manasseh, Gill, Knipe &amp; Belanger, P.L.C.<br>8075 Jefferson Highway<br>Baton Rouge, LA 70809</td></tr>
+</tbody></table>
+</td></tr>
+</tbody></table>
+<!-- ==================== NEW SECTION - Case Caption ================== -->
+	<h1 style="page-break-before: always;"> </h1>
+	<table width="100%" border="1" cellpadding="4">
+	<tbody><tr><td>
+	United States of America, <br>
+<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Plaintiff - Appellee<br>
+<br>
+v.<br>
+<br>
+Brian Broussard, <br>
+<br>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Defendant - Appellant</td></tr>
+	</tbody></table>
+<!-- ================= NEW SECTION - DOCKET ENTRIES =================== -->
+	<h1 style="page-break-before: always;"> </h1>
+<form name="dktEntry" action="TransportRoom" method="GET" target="_blank">
+<table width="100%" border="1" cellpadding="0">
+		<tbody><tr><td>
+		<table border="0" cellpadding="4">
+<!-- NEED 1 -->
+		<tbody><tr><td valign="top">03/07/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10057372" onclick="sumSelected(this,2,202400);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506667755?caseId=212643&amp;recapDocNum=1&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506667755" data-pacer-dls-id="00506667755" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="1" data-attachment-number="0">&nbsp;1&nbsp;</a>
+<br><font size="-2">2 pg, 197.66 KB</font></td><td width="90%" valign="top">DIRECT CRIMINAL CASE docketed. NOA filed by Appellant Mr. Brian Broussard.  [23-30126] (SEP) [Entered: 03/07/2023 07:55 AM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">03/07/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10057378" onclick="sumSelected(this,4,117605);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506667772?caseId=212643&amp;recapDocNum=4&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506667772" data-pacer-dls-id="00506667772" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="4" data-attachment-number="0">&nbsp;4&nbsp;</a>
+<br><font size="-2">4 pg, 114.85 KB</font></td><td width="90%" valign="top">JURISDICTIONAL REVIEW COMPLETE. Transcript order due on 03/22/2023 for Appellant Brian Broussard.  [23-30126] (SEP) [Entered: 03/07/2023 08:00 AM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">03/07/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10057449" onclick="sumSelected(this,1,136095);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506667892?caseId=212643&amp;recapDocNum=5&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506667892" data-pacer-dls-id="00506667892" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="5" data-attachment-number="0">&nbsp;5&nbsp;</a>
+<br><font size="-2">1 pg, 132.91 KB</font></td><td width="90%" valign="top">APPEARANCE FORM received from Ms. Camille Ann Domingue for USA for the court's review. Lead Counsel? Yes. [23-30126] (Camille Ann Domingue ) [Entered: 03/07/2023 08:56 AM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">03/07/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10058215" onclick="sumSelected(this,0,0);">
+
+		&nbsp;6&nbsp;
+</td><td width="90%" valign="top">APPEARANCE FORM FILED by Attorney Camille Ann Domingue for Appellee USA in <a href="tel:23-30126">23-30126</a> [23-30126] (NFD) [Entered: 03/07/2023 04:26 PM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">03/15/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10063812" onclick="sumSelected(this,1,70239);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506678204?caseId=212643&amp;recapDocNum=8&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506678204" data-pacer-dls-id="00506678204" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="8" data-attachment-number="0">&nbsp;8&nbsp;</a>
+<br><font size="-2">1 pg, 68.59 KB</font></td><td width="90%" valign="top">APPEARANCE FORM received from Mr. Andre' Robert Belanger, Esq. for Mr. Brian Broussard for the court's review. Lead Counsel? Yes. [23-30126] (Andre' Robert Belanger ) [Entered: 03/15/2023 03:34 PM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">03/16/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10064521" onclick="sumSelected(this,0,0);">
+
+		&nbsp;9&nbsp;
+</td><td width="90%" valign="top">APPEARANCE FORM FILED by Attorney Andre' Robert Belanger for Appellant Brian Broussard in <a href="tel:23-30126">23-30126</a> [23-30126] (AGL) [Entered: 03/16/2023 02:25 PM]</td></tr>
+<!-- NEED 2 -->
+		<tr><td valign="top">03/27/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10071462" onclick="sumSelected(this,1,459734);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506690688?caseId=212643&amp;recapDocNum=10&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506690688" data-pacer-dls-id="00506690688" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="10" data-attachment-number="0">&nbsp;10&nbsp;</a>
+<br><font size="-2">1 pg, 448.96 KB</font></td><td width="90%" valign="top">ATTORNEY TRANSCRIPT ORDER form filed by Appellant Mr. Brian Broussardfor the Court to process. Date of service: 03/27/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellee: Domingue. [23-30126] (Andre' Robert Belanger ) [Entered: 03/27/2023 04:32 PM]</td></tr>
+<!-- NEED 3 -->
+		<tr><td valign="top">03/28/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10071799" onclick="sumSelected(this,0,0);">
+
+		&nbsp;11&nbsp;
+</td><td width="90%" valign="top">TRANSCRIPT ORDER received from Appellant Mr. Brian Broussard. DETAILS: Transcript Order: Court Reporter: Cathleen E. Marquardt. Transcript Order ddl satisfied. Ct. Reporter Acknowledgment due on 04/07/2023 for Cathleen Marquardt, Court Reporter. Electronic Filing Processed: [<a href="https://ecf.ca5.uscourts.gov/docs1/00506690688?caseId=212643&amp;recapDocNum=10&amp;recapCaseNum=23-30126" target="_self" data-pacer-doc-id="00506690688" data-pacer-dls-id="00506690688" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="10" data-attachment-number="0">10</a>] [23-30126] (PAC) [Entered: 03/28/2023 09:34 AM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">04/06/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10080308" onclick="sumSelected(this,1,1558516);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506704383?caseId=212643&amp;recapDocNum=12&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506704383" data-pacer-dls-id="00506704383" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="12" data-attachment-number="0">&nbsp;12&nbsp;</a>
+<br><font size="-2">1 pg, 1.49 MB</font></td><td width="90%" valign="top">COURT REPORTER ACKNOWLEDGMENT received from Cathleen E. Marquardt. [23-30126] (Cathleen E. Marquardt ) [Entered: 04/06/2023 05:11 PM]</td></tr>
+<!-- NEED 5 -->
+		<tr><td valign="top">04/12/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10082704" onclick="sumSelected(this,0,0);">
+
+		&nbsp;13&nbsp;
+</td><td width="90%" valign="top">ACKNOWLEDGMENT Transcript Order: Court Reporter: Cathleen E. Marquardt, Est. Completion Dt: 05/05/2023, Est. No.of Pgs: 16, Dt. Fin Arrangements Made: 04/05/2023, Dt. Trans. to be Filed: 05/05/2023, Proceeding Type and Date: Sentencing 02/17/2023. Ct. Reporter Acknowledgment ddl satisfied. Transcript Due/Court Reporter Discount Date is 05/05/2023 for Cathleen E. Marquardt, Court Reporter [23-30126] (PAC) [Entered: 04/12/2023 08:09 AM]</td></tr>
+<!-- NEED 2 -->
+		<tr><td valign="top">05/09/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10104519" onclick="sumSelected(this,1,1560441);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506744548?caseId=212643&amp;recapDocNum=14&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506744548" data-pacer-dls-id="00506744548" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="14" data-attachment-number="0">&nbsp;14&nbsp;</a>
+<br><font size="-2">1 pg, 1.49 MB</font></td><td width="90%" valign="top">NOTICE RECEIVED from Cathleen E. Marquardt that the transcript ordered by Appellant Mr. Brian Broussard is complete and has been filed in the District Court. [23-30126] (Cathleen E. Marquardt ) [Entered: 05/09/2023 04:38 PM]</td></tr>
+<!-- NEED 2 -->
+		<tr><td valign="top">05/09/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10104650" onclick="sumSelected(this,0,0);">
+
+		&nbsp;15&nbsp;
+</td><td width="90%" valign="top">TRANSCRIPT FILED IN DISTRICT COURT Transcript Order: Court Reporter: Cathleen E. Marquardt, Dt. Filed in Dist. Ct: 05/09/2023 Transcript Due/Court Reporter Discount Date canceled [23-30126] (AGL) [Entered: 05/10/2023 08:16 AM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">05/10/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10104651" onclick="sumSelected(this,0,0);">
+
+		&nbsp;16&nbsp;
+</td><td width="90%" valign="top">ELECTRONIC RECORD ON APPEAL REQUESTED from District Court for 6:21-CR-138-1. Electronic ROA due on 05/25/2023. [23-30126] (AGL) [Entered: 05/10/2023 08:17 AM]</td></tr>
+<!-- NEED 2 -->
+		<tr><td valign="top">05/31/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10119389" onclick="sumSelected(this,0,0);">
+
+		&nbsp;17&nbsp;
+</td><td width="90%" valign="top">ELECTRONIC RECORD ON APPEAL FILED. Admitted Exhibits on File in District Court? Yes. Video/Audio Exhibits on File in District Court? Yes Electronic ROA deadline satisfied. [23-30126] (DDL) [Entered: 05/31/2023 10:31 AM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">05/31/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10119404" onclick="sumSelected(this,5,123881);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506769259?caseId=212643&amp;recapDocNum=20&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506769259" data-pacer-dls-id="00506769259" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="20" data-attachment-number="0">&nbsp;20&nbsp;</a>
+<br><font size="-2">5 pg, 120.98 KB</font></td><td width="90%" valign="top">BRIEFING NOTICE ISSUED A/Pet's Brief Due on 07/10/2023 for Appellant Brian Broussard. [23-30126] (DDL) [Entered: 05/31/2023 10:37 AM]</td></tr>
+<!-- NEED 5 -->
+		<tr><td valign="top">07/10/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10146989" onclick="sumSelected(this,29,219572);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506815391?caseId=212643&amp;recapDocNum=21&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506815391" data-pacer-dls-id="00506815391" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="21" data-attachment-number="0">&nbsp;21&nbsp;</a>
+<br><font size="-2">29 pg, 214.43 KB</font></td><td width="90%" valign="top">APPELLANT'S BRIEF FILED <br> A/Pet's Brief deadline satisfied. Appellee's Brief due on 08/09/2023 for Appellee United States of America [23-30126]<br>REVIEWED AND/OR EDITED - The original text prior to review appeared as follows: APPELLANT'S BRIEF FILED by Mr. Brian Broussard. Date of service: 07/10/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellee: Domingue [23-30126] (Andre' Robert Belanger ) [Entered: 07/10/2023 04:14 PM]</td></tr>
+<!-- NEED 5 -->
+		<tr><td valign="top">07/10/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10147028" onclick="sumSelected(this,85,77251940);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506815451?caseId=212643&amp;recapDocNum=22&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506815451" data-pacer-dls-id="00506815451" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="22" data-attachment-number="0">&nbsp;22&nbsp;</a>
+<br><font size="-2">85 pg, 73.67 MB</font></td><td width="90%" valign="top">SUFFICIENT RECORD EXCERPTS FILED. Sufficient Record Excerpts deadline satisfied. [23-30126] REVIEWED AND/OR EDITED - The original text prior to review appeared as follows: RECORD EXCERPTS FILED. Record Excerpts NOT Sufficient as they require over page limitation. Optional contents exceed page limitations by 132 pages. Instructions to Attorney: PLEASE READ THE ATTACHED NOTICE FOR INSTRUCTIONS ON HOW TO REMEDY THE DEFAULT. Sufficient Record Excerpts due on 07/25/2023 for Appellant Brian Broussard [23-30126] REVIEWED AND/OR EDITED - The original text prior to review appeared as follows: RECORD EXCERPTS FILED by Appellant Mr. Brian Broussard. Date of service: 07/10/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellee: Domingue [23-30126] (Andre' Robert Belanger ) [Entered: 07/10/2023 04:33 PM]</td></tr>
+<!-- NEED 3 -->
+		<tr><td valign="top">07/11/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10147580" onclick="sumSelected(this,4,148789);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506816365?caseId=212643&amp;recapDocNum=23&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506816365" data-pacer-dls-id="00506816365" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="23" data-attachment-number="0">&nbsp;23&nbsp;</a>
+<br><font size="-2">4 pg, 145.3 KB</font></td><td width="90%" valign="top">UNOPPOSED MOTION filed by Appellee USA to view and obtain sealed document, to suspend briefing notice dated 05/31/2023 [23]. Date of service: 07/11/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellee: Domingue [23-30126] (Camille Ann Domingue ) [Entered: 07/11/2023 11:53 AM]</td></tr>
+<!-- NEED 2 -->
+		<tr><td valign="top">07/11/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10147847" onclick="sumSelected(this,0,0);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506816832?caseId=212643&amp;recapDocNum=24&amp;recapCaseNum=23-30126" title="Open Restricted Document" target="_self" data-pacer-doc-id="00506816832" data-pacer-dls-id="00506816832" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="24" data-attachment-number="0">&nbsp;24&nbsp;</a>
+<br><font size="-2">0 pg, 0 KB</font></td><td width="90%" valign="top">PROPOSED SUFFICIENT RECORD EXCERPTS filed by Appellant Mr. Brian Broussard [<a href="https://ecf.ca5.uscourts.gov/docs1/00506815451?caseId=212643&amp;recapDocNum=22&amp;recapCaseNum=23-30126" target="_self" data-pacer-doc-id="00506815451" data-pacer-dls-id="00506815451" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="22" data-attachment-number="0">22</a>] Date of service: 07/11/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellee: Domingue [23-30126] (Andre' Robert Belanger ) [Entered: 07/11/2023 02:20 PM]</td></tr>
+<!-- NEED 2 -->
+		<tr><td valign="top">07/13/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10149762" onclick="sumSelected(this,1,93656);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506819911?caseId=212643&amp;recapDocNum=28&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506819911" data-pacer-dls-id="00506819911" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="28" data-attachment-number="0">&nbsp;28&nbsp;</a>
+<br><font size="-2">1 pg, 91.46 KB</font></td><td width="90%" valign="top">CLERK ORDER granting Motion to view and obtain sealed document filed by Appellee USA [<a href="https://ecf.ca5.uscourts.gov/docs1/00506816365?caseId=212643&amp;recapDocNum=23&amp;recapCaseNum=23-30126" target="_self" data-pacer-doc-id="00506816365" data-pacer-dls-id="00506816365" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="23" data-attachment-number="0">23</a>]; denying Motion to suspend briefing notice filed by Appellee USA [<a href="https://ecf.ca5.uscourts.gov/docs1/00506816365?caseId=212643&amp;recapDocNum=23&amp;recapCaseNum=23-30126" target="_self" data-pacer-doc-id="00506816365" data-pacer-dls-id="00506816365" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="23" data-attachment-number="0">23</a>] [23-30126] (MAS) [Entered: 07/13/2023 02:43 PM]</td></tr>
+<!-- NEED 0 -->
+		<tr><td valign="top">07/17/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10151789" onclick="sumSelected(this,1,137892);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506823302?caseId=212643&amp;recapDocNum=29&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506823302" data-pacer-dls-id="00506823302" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="29" data-attachment-number="0">&nbsp;29&nbsp;</a>
+<br><font size="-2">1 pg, 134.66 KB</font></td><td width="90%" valign="top">APPEARANCE FORM for the court's review. Lead Counsel? Yes. [23-30126] (Thomas Forrest Phillips ) [Entered: 07/17/2023 02:39 PM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">07/19/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10153498" onclick="sumSelected(this,0,0);">
+
+		&nbsp;30&nbsp;
+</td><td width="90%" valign="top">APPEARANCE FORM FILED by Attorney(s) Thomas Forrest Phillips for party(s) Appellee USA, in case <a href="tel:23-30126">23-30126</a> [23-30126] (MAS) [Entered: 07/19/2023 11:26 AM]</td></tr>
+<!-- NEED 5 -->
+		<tr><td valign="top">08/07/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10167695" onclick="sumSelected(this,47,384733);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506849329?caseId=212643&amp;recapDocNum=32&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506849329" data-pacer-dls-id="00506849329" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="32" data-attachment-number="0">&nbsp;32&nbsp;</a>
+<br><font size="-2">47 pg, 375.72 KB</font></td><td width="90%" valign="top">APPELLEE'S BRIEF FILED # of Copies Provided: 0 E/Res's Brief deadline satisfied. Reply Brief due on 08/28/2023 for Appellant Brian Broussard [23-30126]<br>REVIEWED AND/OR EDITED - The original text prior to review appeared as follows: APPELLEE'S BRIEF FILED by USA. Date of service: 08/07/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellees: Domingue, Phillips [23-30126] (Thomas Forrest Phillips ) [Entered: 08/07/2023 05:19 PM]</td></tr>
+<!-- NEED 4 -->
+		<tr><td valign="top">08/28/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10183263" onclick="sumSelected(this,13,189637);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00506875227?caseId=212643&amp;recapDocNum=37&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00506875227" data-pacer-dls-id="00506875227" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="37" data-attachment-number="0">&nbsp;37&nbsp;</a>
+<br><font size="-2">13 pg, 185.19 KB</font></td><td width="90%" valign="top">APPELLANT'S REPLY BRIEF FILED # of Copies Provided: 0<br> Reply Brief deadline satisfied [23-30126]<br>REVIEWED AND/OR EDITED - The original text prior to review appeared as follows: APPELLANT'S REPLY BRIEF FILED by Mr. Brian Broussard. Date of service: 08/28/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellees: Domingue, Phillips [23-30126] (Andre' Robert Belanger ) [Entered: 08/28/2023 03:36 PM]</td></tr>
+<!-- NEED 5 -->
+		<tr><td valign="top">12/26/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10266542" onclick="sumSelected(this,2,83187);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00507013431?caseId=212643&amp;recapDocNum=51&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00507013431" data-pacer-dls-id="00507013431" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="51" data-attachment-number="0">&nbsp;51&nbsp;</a>
+<br><font size="-2">2 pg, 81.24 KB</font></td><td width="90%" valign="top">PAPER COPIES REQUESTED for the Appellant Brief filed by Appellant Mr. Brian Broussard in <a href="tel:23-30126">23-30126</a> [<a href="https://ecf.ca5.uscourts.gov/docs1/00506815391?caseId=212643&amp;recapDocNum=21&amp;recapCaseNum=23-30126" target="_self" data-pacer-doc-id="00506815391" data-pacer-dls-id="00506815391" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="21" data-attachment-number="0">21</a>], Record Excerpts filed by Appellant Mr. Brian Broussard in <a href="tel:23-30126">23-30126</a> [<a href="https://ecf.ca5.uscourts.gov/docs1/00506815451?caseId=212643&amp;recapDocNum=22&amp;recapCaseNum=23-30126" target="_self" data-pacer-doc-id="00506815451" data-pacer-dls-id="00506815451" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="22" data-attachment-number="0">22</a>], Appellee Brief filed by Appellee USA in <a href="tel:23-30126">23-30126</a> [<a href="https://ecf.ca5.uscourts.gov/docs1/00506849329?caseId=212643&amp;recapDocNum=32&amp;recapCaseNum=23-30126" target="_self" data-pacer-doc-id="00506849329" data-pacer-dls-id="00506849329" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="32" data-attachment-number="0">32</a>], Appellant Reply Brief filed by Appellant Mr. Brian Broussard in <a href="tel:23-30126">23-30126</a> [<a href="https://ecf.ca5.uscourts.gov/docs1/00506875227?caseId=212643&amp;recapDocNum=37&amp;recapCaseNum=23-30126" target="_self" data-pacer-doc-id="00506875227" data-pacer-dls-id="00506875227" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="37" data-attachment-number="0">37</a>]. Paper Copies of Brief due on 12/29/2023 for Appellant Brian Broussard and Appellee United States of America.. Paper Copies of Record Excerpts due on 12/29/2023 for Appellant Brian Broussard. [23-30126] (CBW) [Entered: 12/26/2023 03:16 PM]</td></tr>
+<!-- NEED 2 -->
+		<tr><td valign="top">12/29/2023</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10268180" onclick="sumSelected(this,0,0);">
+
+		&nbsp;52&nbsp;
+</td><td width="90%" valign="top">Paper copies of Appellee Brief filed by Appellee USA in <a href="tel:23-30126">23-30126</a> received. Paper copies match electronic version of document? Yes # of Copies Provided: 7. Paper Copies of Brief due deadline satisfied. [23-30126] (KMP) [Entered: 12/29/2023 08:32 AM]</td></tr>
+<!-- NEED 2 -->
+		<tr><td valign="top">01/04/2024</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10271249" onclick="sumSelected(this,0,0);">
+
+		&nbsp;53&nbsp;
+</td><td width="90%" valign="top">Paper copies of Appellant Brief filed by Appellant Mr. Brian Broussard in <a href="tel:23-30126">23-30126</a> received. Paper copies match electronic version of document? Yes # of Copies Provided: 7. [23-30126] (KMP) [Entered: 01/04/2024 01:14 PM]</td></tr>
+<!-- NEED 3 -->
+		<tr><td valign="top">01/04/2024</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10271251" onclick="sumSelected(this,0,0);">
+
+		&nbsp;54&nbsp;
+</td><td width="90%" valign="top">Paper copies of Appellant Reply Brief filed by Appellant Mr. Brian Broussard in <a href="tel:23-30126">23-30126</a> received. Paper copies match electronic version of document? Yes # of Copies Provided: 7. Paper Copies of Brief due deadline satisfied. [23-30126] (KMP) [Entered: 01/04/2024 01:15 PM]</td></tr>
+<!-- NEED 5 -->
+		<tr><td valign="top">01/04/2024</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10271264" onclick="sumSelected(this,1,70186);">
+<a href="https://ecf.ca5.uscourts.gov/docs1/00507021895?caseId=212643&amp;recapDocNum=55&amp;recapCaseNum=23-30126" title="Open Document" target="_self" data-pacer-doc-id="00507021895" data-pacer-dls-id="00507021895" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="55" data-attachment-number="0">&nbsp;55&nbsp;</a>
+<br><font size="-2">1 pg, 68.54 KB</font></td><td width="90%" valign="top">Paper copies of Record Excerpts filed by Appellant Mr. Brian Broussard in <a href="tel:23-30126">23-30126</a> received. Paper copies match electronic version of document? No They require: The paper copies received do not match the sufficient electronically filed record excerpts accepted by the court as sufficient on July 11, 2023. # of Copies Provided: 4. Paper Copies of Record Excerpts due deadline satisfied.. Sufficient Paper Copies of Record Excerpts Due on 01/09/2024 for Appellant Brian Broussard. [23-30126] (KMP) [Entered: 01/04/2024 01:22 PM]</td></tr>
+<!-- NEED 1 -->
+		<tr><td valign="top">01/10/2024</td><td valign="top" nowrap="">
+<input type="checkbox" name="d" value="10275585" onclick="sumSelected(this,0,0);">
+
+		&nbsp;57&nbsp;
+</td><td width="90%" valign="top">Paper copies of Record Excerpts [<a href="https://ecf.ca5.uscourts.gov/docs1/00507021895?caseId=212643&amp;recapDocNum=55&amp;recapCaseNum=23-30126" target="_self" data-pacer-doc-id="00507021895" data-pacer-dls-id="00507021895" data-pacer-case-id="212643" data-pacer-tab-id="28" data-document-number="55" data-attachment-number="0">55</a>] received as sufficient. Sufficient Paper Copies of Record Excerpts due deadline satisfied. [23-30126] (KMP) [Entered: 01/10/2024 02:43 PM]</td></tr>
+</tbody></table></td></tr></tbody></table>
+<script type="text/javascript">
+	function ProcessForm() {
+		document.dktEntry.submit();
+		return true;
+	}
+	function tooManyDocs() {
+		if (document.dktEntry.submitbtn.disabled == false) {
+			document.dktEntry.submitbtn.disabled = true;
+			alert("Too many documents are selected: "+getSize(totNumByte)
+			+".\nPlease remove some selections to be below 20 MB.");
+		}
+		document.dktEntry.totPageFld.value=" too many!";
+	}
+	var totNumPage = 0.0;
+	var totNumByte = 0.0;
+	var maxSize = 0;
+	function getSize(bytes) {
+		//using 1024^2 instead of 1000^2
+		if (bytes >= 1048576)
+			return Math.round(bytes/1048576*100)/100 + " MB";
+		return Math.round(bytes/1024*100)/100 + " KB";
+	}
+	function sumSelected(aField, numPage, numByte) {
+		if (aField.checked == true) {
+			totNumPage = totNumPage + numPage;
+			totNumByte = totNumByte + numByte;
+		} else {
+			totNumPage = totNumPage - numPage;
+			totNumByte = totNumByte - numByte;
+		}
+		document.dktEntry.totPageFld.value=totNumPage;
+		document.dktEntry.totByteFld.value=getSize(totNumByte);
+		if (totNumByte > 20971520) {
+			tooManyDocs();
+		} else {
+			document.dktEntry.submitbtn.disabled = false;
+		}
+	}
+	function checkEm(aField, yesNo){
+		if (aField.length == null) {
+			aField.checked = yesNo;
+		} else {
+			for (i = 0; i < aField.length; i++)
+				aField[i].checked = yesNo;
+		}
+		if (yesNo == false) {
+			totNumPage = 0.0;
+			totNumByte = 0.0;
+		} else {
+			totNumPage = 199;
+			totNumByte = 82808503;
+		}
+		document.dktEntry.totPageFld.value=totNumPage;
+		document.dktEntry.totByteFld.value=getSize(totNumByte);
+		if (totNumByte > 20971520) {
+			tooManyDocs();
+		} else {
+			document.dktEntry.submitbtn.disabled = false;
+		}
+	}
+</script>
+<h1 style="page-break-before: always;"> </h1>
+<b>
+<input type="hidden" name="servlet" value="ShowDocMulti">
+<input type="hidden" name="caseId" value="212643">
+<input type="button" value="Clear All" onclick="checkEm(document.dktEntry.d, false);return false;">
+<br>
+<br><input type="radio" name="outputType" value="docrpt" checked=""> Documents and Docket Summary
+<br><input type="radio" name="outputType" value="doc"> Documents Only
+<br><br><input value="y" type="checkbox" name="incPdfFooter"> Include Page Numbers
+<br><br>
+Selected Pages: <input name="totPageFld" type="text" size="8" onfocus="this.blur();">
+&nbsp;Selected Size: <input name="totByteFld" type="text" size="8" onfocus="this.blur();"> (Max: 20 MB)<br>Totals reflect accessible documents only and do not include unauthorized restricted documents.<br><br><input value="View Selected" name="submitbtn" type="button" onclick="ProcessForm();">
+</b>
+</form>
+<script type="text/javascript">
+	checkEm(document.dktEntry.d, false);
+</script>
+
+<form name="doDocPostURLForm" method="post" target="_self" action="TransportRoom">
+  <input name="servlet" type="hidden" value="ShowDoc">
+  <input name="dls_id" type="hidden" value="">
+  <input name="caseId" type="hidden" value="">
+  <input name="dktType" type="hidden" value="dktPublic">
+</form>
+
+<script type="text/javascript">
+function doDocPostURL(dls, caseIdStr){
+  document.doDocPostURLForm.dls_id.value = dls;
+  document.doDocPostURLForm.caseId.value = caseIdStr;
+  document.doDocPostURLForm.submit();
+  return false;
+}
+</script>
+<br>
+<hr><center><table border="1" bgcolor="WHITE" width="500">
+<tbody><tr><th colspan="4"><font size="+1" color="DARKRED">PACER Service Center</font></th></tr>
+<tr><th colspan="4"><font color="DARKBLUE">Transaction Receipt</font></th></tr>
+<tr></tr>
+<tr></tr>
+<tr><td colspan="4" align="CENTER">
+<font size="-1" color="DARKBLUE">5th Circuit - Appellate - 02/02/2024 14:35:32</font></td></tr>
+<tr><th align="LEFT"><font size="-1" color="DARKBLUE">PACER Login:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">markeisha_ross</font></td><th align="LEFT">
+<font size="-1" color="DARKBLUE">Client Code:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">&nbsp;</font></td></tr><tr><th align="LEFT">
+<font size="-1" color="DARKBLUE">Description:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">Docket Report (full)</font></td><th align="LEFT">
+<font size="-1" color="DARKBLUE">
+Search Criteria:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE"><a href="tel:23-30126">23-30126</a></font></td></tr><tr><th align="LEFT">
+<font size="-1" color="DARKBLUE">Billable Pages:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">3</font></td><th align="LEFT">
+<font size="-1" color="DARKBLUE">Cost:</font></th><td align="LEFT">
+<font size="-1" color="DARKBLUE">0.30</font></td></tr>
+</tbody></table>
+</center>
+
+<div class="noprint">
+<hr>
+<center>
+<table border="0" cellspacing="0" cellpadding="3" style="width: 95%; text-align: center; margin-left: auto; margin-right: auto;">
+<tbody><tr>
+<td><a href="TransportRoom?servlet=CourtInfo.jsp&amp;menu=yes">Court Information</a>&nbsp;&nbsp;</td>
+<td><a href="http://coa.circ5.dcn/">Court Home</a>&nbsp;&nbsp;</td>
+<td><a href="http://www.pacer.gov">PACER Service Center</a>&nbsp;&nbsp;</td>
+ <td><a href="https://pacer.login.uscourts.gov/csologin/login.jsf?pscCourtId=05CA&amp;appurl=https://ecf.ca5.uscourts.gov/n/beam/servlet/TransportRoom">Change Client</a>&nbsp;&nbsp;</td>
+<td><a href="https://pacer.login.uscourts.gov/csobill-hist/billingmenu.jsf" target="_blank">Billing History</a>&nbsp;&nbsp;</td>
+<td><a href="mailto:pacer@psc.uscourts.gov?Subject=Appellate_PACER_comment">Contact Us</a>&nbsp;&nbsp;</td>
+</tr>
+</tbody></table>
+</center>
+</div>
+
+
+</body>

--- a/tests/examples/pacer/dockets/appellate/ca5_212643.html
+++ b/tests/examples/pacer/dockets/appellate/ca5_212643.html
@@ -71,7 +71,7 @@ function downloadData(aType) {
 		<td valign="top" align="right" rowspan="2">
 		<b>Docketed:</b> 03/07/2023</td></tr>
 <tr><td>USA v. Broussard</td></tr>
-	<tr><td><b>Appeal From:</b>  
+	<tr><td><b>Appeal From:</b>
 	Western District of Louisiana, Lafayette</td>
 </tr>
 	<tr><td><b>Fee Status:</b>  Fee Paid</td>

--- a/tests/examples/pacer/dockets/appellate/ca5_212643.json
+++ b/tests/examples/pacer/dockets/appellate/ca5_212643.json
@@ -1,0 +1,301 @@
+{
+  "appeal_from": "Western District of Louisiana, Lafayette",
+  "case_name": "United States v. Broussard",
+  "case_type_information": "Criminal (DCRIM), Direct Criminal",
+  "court_id": "ca5",
+  "date_filed": "2023-03-07",
+  "date_terminated": null,
+  "docket_entries": [
+    {
+      "date_entered": "2023-03-07",
+      "date_filed": "2023-03-07",
+      "description": "DIRECT CRIMINAL CASE docketed. NOA filed by Appellant Mr. Brian Broussard. [23-30126] (SEP) [Entered: 03/07/2023 07:55 AM]",
+      "document_number": "1",
+      "pacer_doc_id": "00506667755",
+      "pacer_seq_no": "10057372"
+    },
+    {
+      "date_entered": "2023-03-07",
+      "date_filed": "2023-03-07",
+      "description": "JURISDICTIONAL REVIEW COMPLETE. Transcript order due on 03/22/2023 for Appellant Brian Broussard. [23-30126] (SEP) [Entered: 03/07/2023 08:00 AM]",
+      "document_number": "4",
+      "pacer_doc_id": "00506667772",
+      "pacer_seq_no": "10057378"
+    },
+    {
+      "date_entered": "2023-03-07",
+      "date_filed": "2023-03-07",
+      "description": "APPEARANCE FORM received from Ms. Camille Ann Domingue for USA for the court's review. Lead Counsel? Yes. [23-30126] (Camille Ann Domingue ) [Entered: 03/07/2023 08:56 AM]",
+      "document_number": "5",
+      "pacer_doc_id": "00506667892",
+      "pacer_seq_no": "10057449"
+    },
+    {
+      "date_entered": "2023-03-07",
+      "date_filed": "2023-03-07",
+      "description": "APPEARANCE FORM FILED by Attorney Camille Ann Domingue for Appellee USA in 23-30126 [23-30126] (NFD) [Entered: 03/07/2023 04:26 PM]",
+      "document_number": "6",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10058215"
+    },
+    {
+      "date_entered": "2023-03-15",
+      "date_filed": "2023-03-15",
+      "description": "APPEARANCE FORM received from Mr. Andre' Robert Belanger, Esq. for Mr. Brian Broussard for the court's review. Lead Counsel? Yes. [23-30126] (Andre' Robert Belanger ) [Entered: 03/15/2023 03:34 PM]",
+      "document_number": "8",
+      "pacer_doc_id": "00506678204",
+      "pacer_seq_no": "10063812"
+    },
+    {
+      "date_entered": "2023-03-16",
+      "date_filed": "2023-03-16",
+      "description": "APPEARANCE FORM FILED by Attorney Andre' Robert Belanger for Appellant Brian Broussard in 23-30126 [23-30126] (AGL) [Entered: 03/16/2023 02:25 PM]",
+      "document_number": "9",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10064521"
+    },
+    {
+      "date_entered": "2023-03-27",
+      "date_filed": "2023-03-27",
+      "description": "ATTORNEY TRANSCRIPT ORDER form filed by Appellant Mr. Brian Broussardfor the Court to process. Date of service: 03/27/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellee: Domingue. [23-30126] (Andre' Robert Belanger ) [Entered: 03/27/2023 04:32 PM]",
+      "document_number": "10",
+      "pacer_doc_id": "00506690688",
+      "pacer_seq_no": "10071462"
+    },
+    {
+      "date_entered": "2023-03-28",
+      "date_filed": "2023-03-28",
+      "description": "TRANSCRIPT ORDER received from Appellant Mr. Brian Broussard. DETAILS: Transcript Order: Court Reporter: Cathleen E. Marquardt. Transcript Order ddl satisfied. Ct. Reporter Acknowledgment due on 04/07/2023 for Cathleen Marquardt, Court Reporter. Electronic Filing Processed: [10] [23-30126] (PAC) [Entered: 03/28/2023 09:34 AM]",
+      "document_number": "11",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10071799"
+    },
+    {
+      "date_entered": "2023-04-06",
+      "date_filed": "2023-04-06",
+      "description": "COURT REPORTER ACKNOWLEDGMENT received from Cathleen E. Marquardt. [23-30126] (Cathleen E. Marquardt ) [Entered: 04/06/2023 05:11 PM]",
+      "document_number": "12",
+      "pacer_doc_id": "00506704383",
+      "pacer_seq_no": "10080308"
+    },
+    {
+      "date_entered": "2023-04-12",
+      "date_filed": "2023-04-12",
+      "description": "ACKNOWLEDGMENT Transcript Order: Court Reporter: Cathleen E. Marquardt, Est. Completion Dt: 05/05/2023, Est. No.of Pgs: 16, Dt. Fin Arrangements Made: 04/05/2023, Dt. Trans. to be Filed: 05/05/2023, Proceeding Type and Date: Sentencing 02/17/2023. Ct. Reporter Acknowledgment ddl satisfied. Transcript Due/Court Reporter Discount Date is 05/05/2023 for Cathleen E. Marquardt, Court Reporter [23-30126] (PAC) [Entered: 04/12/2023 08:09 AM]",
+      "document_number": "13",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10082704"
+    },
+    {
+      "date_entered": "2023-05-09",
+      "date_filed": "2023-05-09",
+      "description": "NOTICE RECEIVED from Cathleen E. Marquardt that the transcript ordered by Appellant Mr. Brian Broussard is complete and has been filed in the District Court. [23-30126] (Cathleen E. Marquardt ) [Entered: 05/09/2023 04:38 PM]",
+      "document_number": "14",
+      "pacer_doc_id": "00506744548",
+      "pacer_seq_no": "10104519"
+    },
+    {
+      "date_entered": "2023-05-10",
+      "date_filed": "2023-05-09",
+      "description": "TRANSCRIPT FILED IN DISTRICT COURT Transcript Order: Court Reporter: Cathleen E. Marquardt, Dt. Filed in Dist. Ct: 05/09/2023 Transcript Due/Court Reporter Discount Date canceled [23-30126] (AGL) [Entered: 05/10/2023 08:16 AM]",
+      "document_number": "15",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10104650"
+    },
+    {
+      "date_entered": "2023-05-10",
+      "date_filed": "2023-05-10",
+      "description": "ELECTRONIC RECORD ON APPEAL REQUESTED from District Court for 6:21-CR-138-1. Electronic ROA due on 05/25/2023. [23-30126] (AGL) [Entered: 05/10/2023 08:17 AM]",
+      "document_number": "16",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10104651"
+    },
+    {
+      "date_entered": "2023-05-31",
+      "date_filed": "2023-05-31",
+      "description": "ELECTRONIC RECORD ON APPEAL FILED. Admitted Exhibits on File in District Court? Yes. Video/Audio Exhibits on File in District Court? Yes Electronic ROA deadline satisfied. [23-30126] (DDL) [Entered: 05/31/2023 10:31 AM]",
+      "document_number": "17",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10119389"
+    },
+    {
+      "date_entered": "2023-05-31",
+      "date_filed": "2023-05-31",
+      "description": "BRIEFING NOTICE ISSUED A/Pet's Brief Due on 07/10/2023 for Appellant Brian Broussard. [23-30126] (DDL) [Entered: 05/31/2023 10:37 AM]",
+      "document_number": "20",
+      "pacer_doc_id": "00506769259",
+      "pacer_seq_no": "10119404"
+    },
+    {
+      "date_entered": "2023-07-10",
+      "date_filed": "2023-07-10",
+      "description": "APPELLANT'S BRIEF FILED A/Pet's Brief deadline satisfied. Appellee's Brief due on 08/09/2023 for Appellee United States of America [23-30126]REVIEWED AND/OR EDITED - The original text prior to review appeared as follows: APPELLANT'S BRIEF FILED by Mr. Brian Broussard. Date of service: 07/10/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellee: Domingue [23-30126] (Andre' Robert Belanger ) [Entered: 07/10/2023 04:14 PM]",
+      "document_number": "21",
+      "pacer_doc_id": "00506815391",
+      "pacer_seq_no": "10146989"
+    },
+    {
+      "date_entered": "2023-07-10",
+      "date_filed": "2023-07-10",
+      "description": "SUFFICIENT RECORD EXCERPTS FILED. Sufficient Record Excerpts deadline satisfied. [23-30126] REVIEWED AND/OR EDITED - The original text prior to review appeared as follows: RECORD EXCERPTS FILED. Record Excerpts NOT Sufficient as they require over page limitation. Optional contents exceed page limitations by 132 pages. Instructions to Attorney: PLEASE READ THE ATTACHED NOTICE FOR INSTRUCTIONS ON HOW TO REMEDY THE DEFAULT. Sufficient Record Excerpts due on 07/25/2023 for Appellant Brian Broussard [23-30126] REVIEWED AND/OR EDITED - The original text prior to review appeared as follows: RECORD EXCERPTS FILED by Appellant Mr. Brian Broussard. Date of service: 07/10/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellee: Domingue [23-30126] (Andre' Robert Belanger ) [Entered: 07/10/2023 04:33 PM]",
+      "document_number": "22",
+      "pacer_doc_id": "00506815451",
+      "pacer_seq_no": "10147028"
+    },
+    {
+      "date_entered": "2023-07-11",
+      "date_filed": "2023-07-11",
+      "description": "UNOPPOSED MOTION filed by Appellee USA to view and obtain sealed document, to suspend briefing notice dated 05/31/2023 [23]. Date of service: 07/11/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellee: Domingue [23-30126] (Camille Ann Domingue ) [Entered: 07/11/2023 11:53 AM]",
+      "document_number": "23",
+      "pacer_doc_id": "00506816365",
+      "pacer_seq_no": "10147580"
+    },
+    {
+      "date_entered": "2023-07-11",
+      "date_filed": "2023-07-11",
+      "description": "PROPOSED SUFFICIENT RECORD EXCERPTS filed by Appellant Mr. Brian Broussard [22] Date of service: 07/11/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellee: Domingue [23-30126] (Andre' Robert Belanger ) [Entered: 07/11/2023 02:20 PM]",
+      "document_number": "24",
+      "pacer_doc_id": "00506816832",
+      "pacer_seq_no": "10147847"
+    },
+    {
+      "date_entered": "2023-07-13",
+      "date_filed": "2023-07-13",
+      "description": "CLERK ORDER granting Motion to view and obtain sealed document filed by Appellee USA [23]; denying Motion to suspend briefing notice filed by Appellee USA [23] [23-30126] (MAS) [Entered: 07/13/2023 02:43 PM]",
+      "document_number": "28",
+      "pacer_doc_id": "00506819911",
+      "pacer_seq_no": "10149762"
+    },
+    {
+      "date_entered": "2023-07-17",
+      "date_filed": "2023-07-17",
+      "description": "APPEARANCE FORM for the court's review. Lead Counsel? Yes. [23-30126] (Thomas Forrest Phillips ) [Entered: 07/17/2023 02:39 PM]",
+      "document_number": "29",
+      "pacer_doc_id": "00506823302",
+      "pacer_seq_no": "10151789"
+    },
+    {
+      "date_entered": "2023-07-19",
+      "date_filed": "2023-07-19",
+      "description": "APPEARANCE FORM FILED by Attorney(s) Thomas Forrest Phillips for party(s) Appellee USA, in case 23-30126 [23-30126] (MAS) [Entered: 07/19/2023 11:26 AM]",
+      "document_number": "30",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10153498"
+    },
+    {
+      "date_entered": "2023-08-07",
+      "date_filed": "2023-08-07",
+      "description": "APPELLEE'S BRIEF FILED # of Copies Provided: 0 E/Res's Brief deadline satisfied. Reply Brief due on 08/28/2023 for Appellant Brian Broussard [23-30126]REVIEWED AND/OR EDITED - The original text prior to review appeared as follows: APPELLEE'S BRIEF FILED by USA. Date of service: 08/07/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellees: Domingue, Phillips [23-30126] (Thomas Forrest Phillips ) [Entered: 08/07/2023 05:19 PM]",
+      "document_number": "32",
+      "pacer_doc_id": "00506849329",
+      "pacer_seq_no": "10167695"
+    },
+    {
+      "date_entered": "2023-08-28",
+      "date_filed": "2023-08-28",
+      "description": "APPELLANT'S REPLY BRIEF FILED # of Copies Provided: 0 Reply Brief deadline satisfied [23-30126]REVIEWED AND/OR EDITED - The original text prior to review appeared as follows: APPELLANT'S REPLY BRIEF FILED by Mr. Brian Broussard. Date of service: 08/28/2023 via email - Attorney for Appellant: Belanger; Attorney for Appellees: Domingue, Phillips [23-30126] (Andre' Robert Belanger ) [Entered: 08/28/2023 03:36 PM]",
+      "document_number": "37",
+      "pacer_doc_id": "00506875227",
+      "pacer_seq_no": "10183263"
+    },
+    {
+      "date_entered": "2023-12-26",
+      "date_filed": "2023-12-26",
+      "description": "PAPER COPIES REQUESTED for the Appellant Brief filed by Appellant Mr. Brian Broussard in 23-30126 [21], Record Excerpts filed by Appellant Mr. Brian Broussard in 23-30126 [22], Appellee Brief filed by Appellee USA in 23-30126 [32], Appellant Reply Brief filed by Appellant Mr. Brian Broussard in 23-30126 [37]. Paper Copies of Brief due on 12/29/2023 for Appellant Brian Broussard and Appellee United States of America.. Paper Copies of Record Excerpts due on 12/29/2023 for Appellant Brian Broussard. [23-30126] (CBW) [Entered: 12/26/2023 03:16 PM]",
+      "document_number": "51",
+      "pacer_doc_id": "00507013431",
+      "pacer_seq_no": "10266542"
+    },
+    {
+      "date_entered": "2023-12-29",
+      "date_filed": "2023-12-29",
+      "description": "Paper copies of Appellee Brief filed by Appellee USA in 23-30126 received. Paper copies match electronic version of document? Yes # of Copies Provided: 7. Paper Copies of Brief due deadline satisfied. [23-30126] (KMP) [Entered: 12/29/2023 08:32 AM]",
+      "document_number": "52",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10268180"
+    },
+    {
+      "date_entered": "2024-01-04",
+      "date_filed": "2024-01-04",
+      "description": "Paper copies of Appellant Brief filed by Appellant Mr. Brian Broussard in 23-30126 received. Paper copies match electronic version of document? Yes # of Copies Provided: 7. [23-30126] (KMP) [Entered: 01/04/2024 01:14 PM]",
+      "document_number": "53",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10271249"
+    },
+    {
+      "date_entered": "2024-01-04",
+      "date_filed": "2024-01-04",
+      "description": "Paper copies of Appellant Reply Brief filed by Appellant Mr. Brian Broussard in 23-30126 received. Paper copies match electronic version of document? Yes # of Copies Provided: 7. Paper Copies of Brief due deadline satisfied. [23-30126] (KMP) [Entered: 01/04/2024 01:15 PM]",
+      "document_number": "54",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10271251"
+    },
+    {
+      "date_entered": "2024-01-04",
+      "date_filed": "2024-01-04",
+      "description": "Paper copies of Record Excerpts filed by Appellant Mr. Brian Broussard in 23-30126 received. Paper copies match electronic version of document? No They require: The paper copies received do not match the sufficient electronically filed record excerpts accepted by the court as sufficient on July 11, 2023. # of Copies Provided: 4. Paper Copies of Record Excerpts due deadline satisfied.. Sufficient Paper Copies of Record Excerpts Due on 01/09/2024 for Appellant Brian Broussard. [23-30126] (KMP) [Entered: 01/04/2024 01:22 PM]",
+      "document_number": "55",
+      "pacer_doc_id": "00507021895",
+      "pacer_seq_no": "10271264"
+    },
+    {
+      "date_entered": "2024-01-10",
+      "date_filed": "2024-01-10",
+      "description": "Paper copies of Record Excerpts [55] received as sufficient. Sufficient Paper Copies of Record Excerpts due deadline satisfied. [23-30126] (KMP) [Entered: 01/10/2024 02:43 PM]",
+      "document_number": "57",
+      "pacer_doc_id": null,
+      "pacer_seq_no": "10275585"
+    }
+  ],
+  "docket_number": "23-30126",
+  "fee_status": "Fee Paid",
+  "nature_of_suit": "",
+  "originating_court_information": {
+    "assigned_to": "",
+    "court_id": "lawd",
+    "court_reporter": "Cathleen E. Marquardt, Court Reporter",
+    "date_disposed": "2022-11-10",
+    "date_filed": "2021-06-16",
+    "date_filed_noa": "2023-03-03",
+    "date_received_coa": "2023-03-03",
+    "disposition": "Dismissed",
+    "docket_number": "6:21-CR-138",
+    "ordering_judge": ""
+  },
+  "panel": [],
+  "parties": [
+    {
+      "attorneys": [
+        {
+          "contact": "Direct:  337-262-6618\nEmail: thomas.phillips3@usdoj.gov\nFax:  337-262-6680\nU.S. Attorney's Office\nWestern District of Louisiana\nSuite 2200\n800 Lafayette Street\nLafayette, LA 70501-6832",
+          "name": "Thomas Forrest Phillips",
+          "roles": [
+            "COR LD NTC Government"
+          ]
+        },
+        {
+          "contact": "Direct:  337-262-6618\nEmail: Camille.Domingue@usdoj.gov\nU.S. Attorney's Office\nWestern District of Louisiana\nSuite 2200\n800 Lafayette Street\nLafayette, LA 70501-6832",
+          "name": "Camille Ann Domingue, Assistant U.S. Attorney",
+          "roles": [
+            "COR NTC Government"
+          ]
+        }
+      ],
+      "name": "United States of America",
+      "type": "Plaintiff\u00a0-\u00a0Appellee"
+    },
+    {
+      "attorneys": [
+        {
+          "contact": "Direct:  225-383-9703\nEmail: andre@manassehandgill.com\nFax:  225-383-9704\nManasseh, Gill, Knipe & Belanger, P.L.C.\n8075 Jefferson Highway\nBaton Rouge, LA 70809",
+          "name": "Andre' Robert Belanger, Esq.",
+          "roles": [
+            "COR LD NTC Retained"
+          ]
+        }
+      ],
+      "name": "Brian Broussard, also known as Lil Brian",
+      "type": "Defendant\u00a0-\u00a0Appellant"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes: #915 

This PR adds support for parsing `docket_numbers` wrapped in a tel: href tag in appellate dockets.

Besides the docket_number parsing, I noticed in the example added that it doesn't have an `Ordering Judge`, but it does have an `Originating Judge`, which we are currently not parsing. Is it the same as an `Ordering Judge`, or is it ok to just ignore it?

<img width="732" alt="Screenshot 2025-01-31 at 7 21 38 p m" src="https://github.com/user-attachments/assets/b28d20a8-7185-4d99-b113-e507b633682b" />
