### PR TITLE
feat(ny): implement `cleanup_content` to delete timestamps

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ Releases are also tagged in git, if that's helpful.
 - Fix `me` Update maine scraper and add backscraper
 - Update `sd` backscraper and extract from text
 - Fix `bia` scraper and add extract from text test cases
-
+- Implement `cleanup_content` for `ny` sites #1393
 
 ## Current
 

--- a/juriscraper/opinions/united_states/state/ny.py
+++ b/juriscraper/opinions/united_states/state/ny.py
@@ -140,7 +140,7 @@ class Site(OpinionSiteLinear):
     def cleanup_content(content: Union[str, bytes]) -> Union[str, bytes]:
         """Remove hash altering timestamps to prevent duplicates
 
-        Recently the NY courts introduced a timestamped script tag, 
+        Recently the NY courts introduced a timestamped script tag,
         apparently for cloudflare analytics. This is causing us to ingest
         duplicates
         """

--- a/juriscraper/opinions/united_states/state/nytrial.py
+++ b/juriscraper/opinions/united_states/state/nytrial.py
@@ -17,6 +17,7 @@ from lxml.html import fromstring
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.judge_parsers import normalize_judge_string
 from juriscraper.lib.string_utils import harmonize
+from juriscraper.opinions.united_states.state import ny
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
@@ -170,3 +171,7 @@ class Site(OpinionSiteLinear):
         m = re.findall(pattern, scraped_text)
         r = list(filter(None, chain.from_iterable(m)))
         return r[0].strip() if r else ""
+
+    @staticmethod
+    def cleanup_content(content: str) -> str:
+        return ny.Site.cleanup_content(content)


### PR DESCRIPTION
Fixes #1393

Affects `ny`, `nytrial`, `nyappdiv` and `nyappterm` scrapers