### PR TITLE
fix(nytrial): Add token auth

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,17 @@ Releases are also tagged in git, if that's helpful.
 
 ## Coming up
 
+The following changes are not yet released, but are code complete:
+
+Features:
+-
+
+Changes:
+- Add auth token to ny trial courts
+
+Fixes:
+-
+
 ## Current
 
 **2.6.67 - 2025-05-08**

--- a/juriscraper/opinions/united_states/state/nytrial.py
+++ b/juriscraper/opinions/united_states/state/nytrial.py
@@ -15,6 +15,7 @@ from dateutil.rrule import MONTHLY, rrule
 from lxml.html import fromstring
 
 from juriscraper.AbstractSite import logger
+from juriscraper.lib.auth_utils import set_api_token_header
 from juriscraper.lib.judge_parsers import normalize_judge_string
 from juriscraper.lib.string_utils import harmonize
 from juriscraper.opinions.united_states.state import ny
@@ -37,6 +38,7 @@ class Site(OpinionSiteLinear):
         )
         self.back_scrape_iterable = [i.date() for i in date_keys]
         self.expected_content_types = ["application/pdf", "text/html"]
+        set_api_token_header(self)
 
     def build_url(self, target_date: Optional[date] = None) -> str:
         """URL as is loads most recent month page


### PR DESCRIPTION
Add Bearer Token for NY Trial Courts. 

Fixes https://github.com/freelawproject/juriscraper/issues/1396
