### PR TITLE
Issue asbca scraper not working 1411

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Changes:
 
 Fixes:
 - Improve test speed by reducing the size of the uscfc_vaccine example array
+- Fix `asbca` scraper to use special headers #1411
 
 ## Current
 **2.6.70 - 2025-05-23**

--- a/juriscraper/opinions/united_states/administrative_agency/asbca.py
+++ b/juriscraper/opinions/united_states/administrative_agency/asbca.py
@@ -36,7 +36,6 @@ class Site(OpinionSiteLinear):
             "upgrade-insecure-requests": "1",
             "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
         }
-        self.expected_content_types = ["text/html", "application/pdf"]
         self.needs_special_headers = True
 
     def _process_html(self):

--- a/juriscraper/opinions/united_states/administrative_agency/asbca.py
+++ b/juriscraper/opinions/united_states/administrative_agency/asbca.py
@@ -36,6 +36,7 @@ class Site(OpinionSiteLinear):
             "upgrade-insecure-requests": "1",
             "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
         }
+        self.expected_content_types = ["text/html", "application/pdf"]
 
     def _process_html(self):
         # Exclude headers and rows that only have the month name

--- a/juriscraper/opinions/united_states/administrative_agency/asbca.py
+++ b/juriscraper/opinions/united_states/administrative_agency/asbca.py
@@ -37,6 +37,7 @@ class Site(OpinionSiteLinear):
             "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
         }
         self.expected_content_types = ["text/html", "application/pdf"]
+        self.needs_special_headers = True
 
     def _process_html(self):
         # Exclude headers and rows that only have the month name


### PR DESCRIPTION
This pull request addresses improvements to the `asbca` scraper functionality and updates the changelog accordingly. The most important changes include fixing the scraper to use special headers and documenting the fix in `CHANGES.md`.

### Scraper functionality updates:
* [`juriscraper/opinions/united_states/administrative_agency/asbca.py`](diffhunk://#diff-a453b57c8b25c47f1b10b35a84ce2fdc975485febc46951c7d65e3bb453482ebR39): Added the `needs_special_headers` attribute to ensure the scraper uses special headers, improving its functionality.

### Documentation updates:
* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R25): Added a note under "Fixes" to document the update to the `asbca` scraper, specifying the use of special headers.