### PR TITLE
fix(bap1): remove _download method from scraper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Features:
 -
 
 Changes:
--
+-  Fix `bap1` not scraping recent data #1422
 
 Fixes:
 -  Fix `tex` get opinions from the orders on causes page #1410

--- a/juriscraper/opinions/united_states/federal_bankruptcy/bap1.py
+++ b/juriscraper/opinions/united_states/federal_bankruptcy/bap1.py
@@ -6,11 +6,12 @@ Court Contact: ca01_BAP@ca1.uscourts.gov, (617) 748-9650
 Author: Gianfranco Rossi
 History:
  - 2023-12-28, grossir: created
+ - 2025-06-11 lmanzur remove _download method from scraper
 """
 
 import calendar
 import re
-from typing import Any, Optional
+from typing import Any
 
 from lxml.html import HtmlElement
 
@@ -47,22 +48,6 @@ class Site(OpinionSiteLinear):
         # There are 29 historical pages as of development in Dec 2023
         # source indexes from 0
         self.back_scrape_iterable = range(29)[::-1]
-
-    def _download(self, request_dict: Optional[dict] = None) -> HtmlElement:
-        """Gets the source's HTML
-
-        For a normal periodic scraper, get the last page where
-        most recent opinions are
-        Backscraper will iterate over all available pages
-
-        :param request_dict: unused in this scraper
-        :return: HTML object from the downloaded page
-        """
-        if self.base_url == self.url:
-            self.html = super()._download()
-            self.url = self.html.xpath("//li/a/@href")[-1]
-
-        return super()._download()
 
     def _download_backwards(self, page_number: int) -> None:
         """Method used by backscraper to download historical records


### PR DESCRIPTION
This pull request addresses two main areas: bug fixes and code cleanup. It includes a fix for the `bap1` scraper to ensure it properly retrieves recent data.

### Bug Fixes:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L21-R21): Added a note about fixing the `bap1` scraper to ensure it correctly scrapes recent data.
* [`juriscraper/opinions/united_states/federal_bankruptcy/bap1.py`](diffhunk://#diff-81fb06141c4e06a63993df9dff3584c4ffe9533af6584c549fcd31fa7383a9ecL51-L66): The `_download` method was removed because it was looking at the last page instead of the main page where all the current opinions are located.

### Code Cleanup:

* [`juriscraper/opinions/united_states/federal_bankruptcy/bap1.py`](diffhunk://#diff-81fb06141c4e06a63993df9dff3584c4ffe9533af6584c549fcd31fa7383a9ecR9-R14): Updated imports to remove `Optional` from `typing`, as it is no longer needed after the removal of the `_download` method.