### PR TITLE
Issue collecting bad docket number values for va 1441

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Changes:
 - Update `uscgcoca` add backscraper #1431
 
 Fixes:
--
+- Fix `va` collecting bad docket_number values #1441
 
 ## Current
 

--- a/juriscraper/opinions/united_states/state/va.py
+++ b/juriscraper/opinions/united_states/state/va.py
@@ -10,7 +10,11 @@ class Site(OpinionSiteLinear):
         self.url = "http://www.courts.state.va.us/scndex.htm"
         self.status = "Published"
 
-    def _process_html(self):
+    def _process_html(self) -> None:
+        """Parses the HTML content to extract case information.
+
+        :return: None
+        """
         if self.test_mode_enabled():
             today = datetime.strptime("11/20/2023", "%m/%d/%Y").date()
         else:
@@ -33,7 +37,7 @@ class Site(OpinionSiteLinear):
             self.cases.append(
                 {
                     "name": row.xpath(".//b/text()")[0].strip(),
-                    "docket": links[0].get("name"),
+                    "docket": links[1].text.strip(" '\""),
                     "url": links[1].get("href"),
                     "summary": summary,
                     "date": date_str,

--- a/juriscraper/opinions/united_states/state/va.py
+++ b/juriscraper/opinions/united_states/state/va.py
@@ -25,8 +25,13 @@ class Site(OpinionSiteLinear):
             if len(links) != 2:
                 continue
             name = row.xpath(".//b/text()")[0].strip()
-            summary = row.text_content().split(name)[1].strip()
-            date_str = summary.split("\n")[0].strip()
+
+            text = row.text_content().split(name)[1].strip()
+            split_test = text.split("\n")
+
+            date_str = split_test[0].strip()
+            summary = split_test[1].strip()
+
             if "Revised" in date_str:
                 date_str = date_str.split("Revised")[1].strip().strip(")")
             date_object = datetime.strptime(date_str, "%m/%d/%Y").date()

--- a/tests/examples/opinions/united_states/va_example.compare.json
+++ b/tests/examples/opinions/united_states/va_example.compare.json
@@ -6,7 +6,7 @@
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "1220536_20231019",
+    "docket_numbers": "220536",
     "summaries": "10/19/2023 Considering defendant?s appeal from his convictions on multiple counts of aggravated sexual battery by a parent under Code \u00a7 18.2-67.3 and taking indecent liberties with a child under Code \u00a7 18.2-370.1, in which he argued that the circuit court erred in determining that the proffered testimony of a witness indicating that the defendant remained outside of the witness? home with her for several hours instead of accompanying his two minor daughters inside to sleep constituted inadmissible alibi testimony not timely disclosed pursuant to Rule 3A:11(d)(2), the Court of Appeals erred in addressing the merits of defendant?s argument where the defendant?s assignment of error indicated that the proffered testimony was not evidence of an alibi because it was instead offered to impeach by contradiction the testimony of his daughters, who were the victims. However, defendant never argued at trial that the proffered testimony was offered for impeachment purposes; rather, he only argued that it was not alibi evidence. As a result, defendant?s argument was waived. That portion of the Court of Appeals? judgment is reversed, but judgment upholding the conviction is affirmed.",
     "case_name_shorts": "Moison"
   },
@@ -17,7 +17,7 @@
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "1210389_20231019",
+    "docket_numbers": "210389",
     "summaries": "10/19/2023 In an as-applied challenge to the constitutionality of the escheat provision of Code \u00a7 58.1-3967, where a city obtained a judicial sale of a parcel of property subject to a statutory lien for delinquent taxes and the sale proceeds wholly satisfied the city?s tax lien, the holding of the circuit court that the statute required it to award a portion of the surplus sale proceeds to the city rather than an unsatisfied junior lienor, while required by the text of the escheat provision, nevertheless violates Article I, Section 11 of the Constitution of Virginia concerning the taking of private property. The circuit court erred in failing to so rule, and the case is remanded for proceedings consistent with this opinion.",
     "case_name_shorts": "McKeithen"
   },
@@ -28,7 +28,7 @@
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "1220715_20231019",
+    "docket_numbers": "220715",
     "summaries": "10/19/2023 In an appeal by the Commonwealth from a decision by the Court of Appeals of Virginia, it is held that Rule 3A:15 does not preclude the circuit court from reconsidering a motion to strike that was erroneously granted in a criminal case. While the Double Jeopardy Clause imposes some restrictions on a trial court?s authority to reconsider a motion to strike, those limitations do not apply here. Consequently, the judgment of the Court of Appeals is reversed, and final judgment is entered on this appeal in favor of the Commonwealth.",
     "case_name_shorts": "McBride"
   },
@@ -39,7 +39,7 @@
     "precedential_statuses": "Published",
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
-    "docket_numbers": "1230172_20231012",
+    "docket_numbers": "230172",
     "summaries": "10/12/2023 On a petition for a writ of habeas corpus, asserting that the Virginia Department of Corrections (?VDOC?) failed to timely release the petitioner from prison because it undercalculated his earned sentence credits (?ESCs?), pursuant to amendments to Code \u00a7 53.1-202.3 adopted by the General Assembly in 2020, the judgment of the circuit court concluding that he was not entitled to immediate release is affirmed.",
     "case_name_shorts": "Anderson"
   }

--- a/tests/examples/opinions/united_states/va_example.compare.json
+++ b/tests/examples/opinions/united_states/va_example.compare.json
@@ -7,7 +7,7 @@
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "220536",
-    "summaries": "10/19/2023 Considering defendant?s appeal from his convictions on multiple counts of aggravated sexual battery by a parent under Code \u00a7 18.2-67.3 and taking indecent liberties with a child under Code \u00a7 18.2-370.1, in which he argued that the circuit court erred in determining that the proffered testimony of a witness indicating that the defendant remained outside of the witness? home with her for several hours instead of accompanying his two minor daughters inside to sleep constituted inadmissible alibi testimony not timely disclosed pursuant to Rule 3A:11(d)(2), the Court of Appeals erred in addressing the merits of defendant?s argument where the defendant?s assignment of error indicated that the proffered testimony was not evidence of an alibi because it was instead offered to impeach by contradiction the testimony of his daughters, who were the victims. However, defendant never argued at trial that the proffered testimony was offered for impeachment purposes; rather, he only argued that it was not alibi evidence. As a result, defendant?s argument was waived. That portion of the Court of Appeals? judgment is reversed, but judgment upholding the conviction is affirmed.",
+    "summaries": "Considering defendant?s appeal from his convictions on multiple counts of aggravated sexual battery by a parent under Code \u00a7 18.2-67.3 and taking indecent liberties with a child under Code \u00a7 18.2-370.1, in which he argued that the circuit court erred in determining that the proffered testimony of a witness indicating that the defendant remained outside of the witness? home with her for several hours instead of accompanying his two minor daughters inside to sleep constituted inadmissible alibi testimony not timely disclosed pursuant to Rule 3A:11(d)(2), the Court of Appeals erred in addressing the merits of defendant?s argument where the defendant?s assignment of error indicated that the proffered testimony was not evidence of an alibi because it was instead offered to impeach by contradiction the testimony of his daughters, who were the victims. However, defendant never argued at trial that the proffered testimony was offered for impeachment purposes; rather, he only argued that it was not alibi evidence. As a result, defendant?s argument was waived. That portion of the Court of Appeals? judgment is reversed, but judgment upholding the conviction is affirmed.",
     "case_name_shorts": "Moison"
   },
   {
@@ -18,7 +18,7 @@
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "210389",
-    "summaries": "10/19/2023 In an as-applied challenge to the constitutionality of the escheat provision of Code \u00a7 58.1-3967, where a city obtained a judicial sale of a parcel of property subject to a statutory lien for delinquent taxes and the sale proceeds wholly satisfied the city?s tax lien, the holding of the circuit court that the statute required it to award a portion of the surplus sale proceeds to the city rather than an unsatisfied junior lienor, while required by the text of the escheat provision, nevertheless violates Article I, Section 11 of the Constitution of Virginia concerning the taking of private property. The circuit court erred in failing to so rule, and the case is remanded for proceedings consistent with this opinion.",
+    "summaries": "In an as-applied challenge to the constitutionality of the escheat provision of Code \u00a7 58.1-3967, where a city obtained a judicial sale of a parcel of property subject to a statutory lien for delinquent taxes and the sale proceeds wholly satisfied the city?s tax lien, the holding of the circuit court that the statute required it to award a portion of the surplus sale proceeds to the city rather than an unsatisfied junior lienor, while required by the text of the escheat provision, nevertheless violates Article I, Section 11 of the Constitution of Virginia concerning the taking of private property. The circuit court erred in failing to so rule, and the case is remanded for proceedings consistent with this opinion.",
     "case_name_shorts": "McKeithen"
   },
   {
@@ -29,7 +29,7 @@
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "220715",
-    "summaries": "10/19/2023 In an appeal by the Commonwealth from a decision by the Court of Appeals of Virginia, it is held that Rule 3A:15 does not preclude the circuit court from reconsidering a motion to strike that was erroneously granted in a criminal case. While the Double Jeopardy Clause imposes some restrictions on a trial court?s authority to reconsider a motion to strike, those limitations do not apply here. Consequently, the judgment of the Court of Appeals is reversed, and final judgment is entered on this appeal in favor of the Commonwealth.",
+    "summaries": "In an appeal by the Commonwealth from a decision by the Court of Appeals of Virginia, it is held that Rule 3A:15 does not preclude the circuit court from reconsidering a motion to strike that was erroneously granted in a criminal case. While the Double Jeopardy Clause imposes some restrictions on a trial court?s authority to reconsider a motion to strike, those limitations do not apply here. Consequently, the judgment of the Court of Appeals is reversed, and final judgment is entered on this appeal in favor of the Commonwealth.",
     "case_name_shorts": "McBride"
   },
   {
@@ -40,7 +40,7 @@
     "blocked_statuses": false,
     "date_filed_is_approximate": false,
     "docket_numbers": "230172",
-    "summaries": "10/12/2023 On a petition for a writ of habeas corpus, asserting that the Virginia Department of Corrections (?VDOC?) failed to timely release the petitioner from prison because it undercalculated his earned sentence credits (?ESCs?), pursuant to amendments to Code \u00a7 53.1-202.3 adopted by the General Assembly in 2020, the judgment of the circuit court concluding that he was not entitled to immediate release is affirmed.",
+    "summaries": "On a petition for a writ of habeas corpus, asserting that the Virginia Department of Corrections (?VDOC?) failed to timely release the petitioner from prison because it undercalculated his earned sentence credits (?ESCs?), pursuant to amendments to Code \u00a7 53.1-202.3 adopted by the General Assembly in 2020, the judgment of the circuit court concluding that he was not entitled to immediate release is affirmed.",
     "case_name_shorts": "Anderson"
   }
 ]


### PR DESCRIPTION
This pull request addresses issues with incorrect docket number values in the Virginia scraper and improves code clarity and functionality. Updates include fixing the extraction logic for docket numbers, enhancing the `_process_html` method with a docstring, and adjusting test cases to reflect the corrected docket number format.

### Fixes to docket number extraction:

* [`juriscraper/opinions/united_states/state/va.py`](diffhunk://#diff-e095b253ebe5ca72f07677837f76543d4ae5490ea6079d140b1f5c2ae8ef0cdcL36-R40): Updated the `_process_html` method to correct the logic for extracting docket numbers, ensuring the proper value is retrieved from the HTML content.

### Code improvements:

* [`juriscraper/opinions/united_states/state/va.py`](diffhunk://#diff-e095b253ebe5ca72f07677837f76543d4ae5490ea6079d140b1f5c2ae8ef0cdcL13-R17): Added a docstring to the `_process_html` method to improve code readability and clarify its purpose.

### Test updates:

* [`tests/examples/opinions/united_states/va_example.compare.json`](diffhunk://#diff-9da5f03b27b414efccfc91bc123edb9b13dc0fa09295d4e94adc947387751bc4L9-R9): Adjusted test cases to reflect the corrected docket number format, ensuring consistency with the updated extraction logic. [[1]](diffhunk://#diff-9da5f03b27b414efccfc91bc123edb9b13dc0fa09295d4e94adc947387751bc4L9-R9) [[2]](diffhunk://#diff-9da5f03b27b414efccfc91bc123edb9b13dc0fa09295d4e94adc947387751bc4L20-R20) [[3]](diffhunk://#diff-9da5f03b27b414efccfc91bc123edb9b13dc0fa09295d4e94adc947387751bc4L31-R31) [[4]](diffhunk://#diff-9da5f03b27b414efccfc91bc123edb9b13dc0fa09295d4e94adc947387751bc4L42-R42)

### Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2L24-R24): Added a note about fixing the Virginia scraper's docket number issue to the changelog.