### PR TITLE
feat(acms): Adds ACMS authentication support to PacerSession 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ Releases are also tagged in git, if that's helpful.
 The following changes are not yet released, but are code complete:
 
 Features:
--
+- Enhances `PacerSession` class to support ACMS authentication.
 
 Changes:
 - Refactor `ACMSDocketReport` to handle missing "date entered" values gracefully

--- a/juriscraper/pacer/__init__.py
+++ b/juriscraper/pacer/__init__.py
@@ -12,7 +12,7 @@ from .docket_report import DocketReport
 from .download_confirmation_page import DownloadConfirmationPage
 from .email import NotificationEmail, S3NotificationEmail
 from .free_documents import FreeOpinionReport
-from .hidden_api import PossibleCaseNumberApi, ShowCaseDocApi
+from .hidden_api import AcmsCaseSearch, PossibleCaseNumberApi, ShowCaseDocApi
 from .http import PacerSession
 from .internet_archive import InternetArchive
 from .list_of_creditors import ListOfCreditors
@@ -20,6 +20,7 @@ from .mobile_query import MobileQuery
 from .rss_feeds import PacerRssFeed
 
 __all__ = [
+    AcmsCaseSearch,
     ACMSAttachmentPage,
     ACMSDocketReport,
     AppellateDocketReport,

--- a/juriscraper/pacer/hidden_api.py
+++ b/juriscraper/pacer/hidden_api.py
@@ -242,3 +242,43 @@ class ShowCaseDocApi(BaseReport):
             raise ParsingException(
                 f"Unable to get doc1-style URL. Instead got {url}"
             )
+
+
+class AcmsCaseSearch(BaseReport):
+    """
+    Looks up an ACMS case by its docket number using the CaseSearch API.
+    """
+
+    def query(self, docket_number):
+        assert self.session is not None, (
+            "session attribute of AcmsCaseSearch cannot be None."
+        )
+        url = f"https://{self.court_id}-showdocservices.azurewebsites.us/api/CaseSearch/{docket_number}"
+        logger.info(f"Querying the CaseSearch endpoint with URL: {url}")
+        self.response = self.session.get(url, params={"exactMatch": True})
+        self.parse()
+
+    def _parse_text(self, text):
+        """Just a stub. No parsing needed here."""
+        pass
+
+    @property
+    def data(self):
+        """
+        Retrieves the parsed case data from the API response.
+
+        The returned dictionary contains the following keys:
+            - '@odata.etag'
+            - 'pcx_caseid'
+            - 'pcx_casenumber'
+            - 'pcx_name'
+            - 'pcx_istestcase'
+
+        :return: A dictionary containing the case data, or an empty dictionary
+                 if no data is found, the response is malformed, or an error
+                 occurred.
+        """
+        case_data = self.response.json()
+        if not case_data:
+            return {}
+        return case_data[0]

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 import re
 
@@ -8,6 +9,7 @@ from juriscraper.lib.exceptions import PacerLoginException
 from juriscraper.lib.html_utils import (
     get_html_parsed_text,
     get_xml_parsed_text,
+    strip_bad_html_tags_insecure,
 )
 from juriscraper.lib.log_tools import make_default_logger
 from juriscraper.pacer.utils import is_pdf, is_text
@@ -120,6 +122,8 @@ class PacerSession(requests.Session):
         self.password = password
         self.client_code = client_code
         self.additional_request_done = False
+        self.acms_user_data = {}
+        self.acms_tokens = {}
 
     def get(self, url, auto_login=True, **kwargs):
         """Overrides request.Session.get with session retry logic.
@@ -377,6 +381,9 @@ class PacerSession(requests.Session):
         self.cookies = session_cookies
         logger.info("New PACER session established.")
 
+        for court_id in ["ca2", "ca9"]:
+            self.get_acms_auth_object(court_id)
+
     def _do_additional_request(self, r: requests.Response) -> bool:
         """Check if we should do an additional request to PACER, sometimes
         PACER returns the login page even though cookies are still valid.
@@ -423,3 +430,110 @@ class PacerSession(requests.Session):
                 "Invalid/expired PACER session and do not have credentials "
                 "for re-login."
             )
+
+    def _get_docket_sheet_url(self, court_id: str) -> str:
+        """
+        Retrieves the base docket sheet URL for a given court ID. This URL
+        serves as the initial entry point to trigger the authentication flow.
+
+        :param court_id: The court identifier
+        :return: The corresponding docket sheet URL.
+        """
+        if court_id == "ca9":
+            return "https://ca9-showdoc.azurewebsites.us/25-2066"
+        elif court_id == "ca2":
+            return "https://ca2-showdoc.azurewebsites.us/25-1569"
+        else:
+            not NotImplemented(
+                f"Docket sheet URL not implemented for court_id: {court_id}"
+            )
+
+    def _get_saml_auth_request_parameters(
+        self, court_id: str
+    ) -> dict[str, str]:
+        """
+        Retrieves SAML authentication request parameters by initiating a request
+        to the DOCKET_SHEET_URL. This simulates the initial browser interaction
+        that triggers the SAML flow, parsing hidden input fields from the
+        response.
+
+        :param court_id: The court identifier.
+        :return: A dictionary where keys are the 'name' attributes and values are
+            the 'value' attributes of hidden input elements found in the SAML
+            authentication request form.
+        """
+        headers = {
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+            "Accept-Encoding": "gzip, deflate, br",
+        }
+        logger.info(f"Attempting to get SAML credentials for {court_id}")
+        # Base URL for retrieving SAML credentials.
+        url = self._get_docket_sheet_url(court_id)
+        response = self._prepare_login_request(url, data={}, headers=headers)
+        result_parts = response.text.split("\r\n")
+        # Handle gzip decoding
+        js_screen = result_parts[-1]
+        try:
+            # Try to decompress if it's gzipped
+            inflated_screen = gzip.decompress(js_screen.encode()).decode()
+        except Exception:
+            # If decompression fails, use the original
+            inflated_screen = js_screen
+
+        # Strip potentially problematic HTML tags for safer parsing.
+        html = strip_bad_html_tags_insecure(inflated_screen)
+        # Extract all hidden input elements from the HTML.
+        hidden_inputs = html.xpath('//input[@type="hidden"]')
+
+        # Return a dictionary of hidden input names and their values.
+        return {
+            input_element.get("name"): input_element.get("value")
+            for input_element in hidden_inputs
+        }
+
+    def get_acms_auth_object(self, court_id: str):
+        """
+        Retrieves the ACMS authentication object by submitting SAML parameters
+        to the SAML_URL. This object typically contains the authentication token
+        and other session-related data.
+
+        This method parses the HTML response to extract a JavaScript  variable
+        named 'model', which contains the authentication data. This is
+        necessary because the authentication data is embedded directly within
+        a script tag in the response HTML.
+
+        :param court_id: The court identifier.
+        :return: A dictionary representing the ACMS authentication object if
+            successfully extracted and parsed from the response.
+        """
+        auth_params = self._get_saml_auth_request_parameters(court_id)
+        if not auth_params:
+            raise PacerLoginException(
+                "Failed to extract ACMS authentication data from SAML response."
+            )
+
+        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        logger.info("Attempting to retrieve ACMS authentication token")
+        saml_url = f"https://{court_id}-showdoc.azurewebsites.us/Saml2/Acs"
+        response = self._prepare_login_request(
+            saml_url, data=auth_params, headers=headers
+        )
+        match = re.search(r"var model = '(.*?)';", response.text)
+        if not match:
+            raise PacerLoginException(
+                "Failed to extract ACMS authentication data from SAML response."
+            )
+
+        model_value = match.group(1)
+        model_string = re.sub("&quot;", '"', model_value)
+        model_json = json.loads(model_string)
+
+        if not self.acms_user_data:
+            data = model_json["PacerUser"]
+            self.acms_user_data = {
+                "CsoId": data["CsoId"],
+                "EmailAddress": data["EmailAddress"],
+                "LoginId": data["LoginId"],
+            }
+
+        self.acms_tokens[court_id] = model_json["AuthToken"]

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -491,11 +491,11 @@ class PacerSession(requests.Session):
         :return: The corresponding docket sheet URL.
         """
         if court_id == "ca9":
-            return "https://ca9-showdoc.azurewebsites.us/25-2066"
+            return "https://ca9-showdoc.azurewebsites.us/"
         elif court_id == "ca2":
-            return "https://ca2-showdoc.azurewebsites.us/25-1569"
+            return "https://ca2-showdoc.azurewebsites.us/"
         else:
-            not NotImplemented(
+            raise NotImplementedError(
                 f"Docket sheet URL not implemented for court_id: {court_id}"
             )
 

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -583,8 +583,7 @@ class PacerSession(requests.Session):
             data = model_json["PacerUser"]
             self.acms_user_data = {
                 "CsoId": data["CsoId"],
-                "EmailAddress": data["EmailAddress"],
-                "LoginId": data["LoginId"],
+                "ContactType": data["ContactType"],
             }
 
         self.acms_tokens[court_id] = model_json["AuthToken"]

--- a/tests/network/test_PacerAuthTest.py
+++ b/tests/network/test_PacerAuthTest.py
@@ -21,6 +21,8 @@ class PacerAuthTest(unittest.TestCase):
                     "NextGenCSO", None, domain=".uscourts.gov", path="/"
                 )
             )
+            self.assertIsNotNone(self.session.acms_user_data)
+            self.assertIsNotNone(self.session.acms_tokens)
         except PacerLoginException:
             self.fail("Could not log into PACER")
 


### PR DESCRIPTION
Key changes: 

- **Integrated ACMS Authentication in `PacerSession`:**

   - **Centralized Authentication Logic**: `PacerSession` now handles ACMS authentication directly, leveraging its existing session management capabilities.

   - **Automatic Bearer Token Handling**: `PacerSession` is enhanced to automatically include the necessary ACMS bearer tokens in request headers when an ACMS-specific request is identified.

  - **Court-Specific ACMS Token Management**: The `PacerSession` class now includes an `acms_tokens` attribute which maps `court_id`s to its respective ACMS authentication token. ( While working on this PR, I noticed that ACMS tokens are valid only for a single court)

- **New `AcmsCaseSearch` Class**: Introduces `AcmsCaseSearch`, a dedicated class for programmatically looking up ACMS cases by their docket number. This class provides a clean interface for retrieving essential case metadata directly from the ACMS API.
   
   The `data` property provides structured access to case details like `pcx_caseid`, `pcx_casenumber`, `pcx_name`, and `pcx_istestcase`.


With this PR in place, we can now begin to tackle issues related to ACMS content purchases. ([#5154](https://github.com/freelawproject/courtlistener/issues/5154), [#4938](https://github.com/freelawproject/courtlistener/issues/4938))