### PR TITLE
feat(acms): Adds logic for attachment retrieval in ACMSAttachmentPage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ Features:
 - Enhances `PacerSession` class to support ACMS authentication.
 - Adds case purchasing functionality to `ACMSDocketReport`.
 - Added support for parsing docket numbers with case types with up to five letters
+- Introduces logic to purchase ACMS docket entry attachment pages.
 
 Changes:
 - Refactor `ACMSDocketReport` to handle missing "date entered" values gracefully

--- a/juriscraper/lib/network_utils.py
+++ b/juriscraper/lib/network_utils.py
@@ -251,7 +251,7 @@ class AcmsApiClient:
         docket_entry_id: str,
         is_case_participant: bool,
         is_restricted_party_filing_entry: bool,
-    ) -> dict[str, Any]:
+    ) -> list[dict[str, Any]]:
         """
         Fetches and maps attachments for a specific docket entry.
 

--- a/juriscraper/pacer/acms_attachment_page.py
+++ b/juriscraper/pacer/acms_attachment_page.py
@@ -5,6 +5,7 @@ import unicodedata
 
 from juriscraper.lib.html_utils import strip_bad_html_tags_insecure
 from juriscraper.lib.log_tools import make_default_logger
+from juriscraper.lib.network_utils import AcmsApiClient
 from juriscraper.lib.string_utils import convert_date_string
 
 from .reports import BaseReport
@@ -17,6 +18,7 @@ class ACMSAttachmentPage(BaseReport):
 
     def __init__(self, court_id, pacer_session=None):
         super().__init__(court_id, pacer_session)
+        self.api_client = AcmsApiClient(pacer_session, court_id)
 
     def _parse_text(self, text):
         """Store the ACMS JSON
@@ -80,6 +82,54 @@ class ACMSAttachmentPage(BaseReport):
             self.is_valid = False
             return
         self.is_valid = True
+
+    def query(self, case_id: str, entry_id: str):
+        """
+        Retrieves details for a specific docket entry and its attachments.
+
+        This method first fetches all docket entries for a case, then isolates
+        the target entry by its ID, and finally retrieves any associated
+        attachments.
+
+        :param case_id: The unique identifier of the case.
+        :param entry_id: The unique identifier of the specific docket entry to
+                         retrieve.
+        """
+        # Fetch Docket Entry Details
+        docket_info = self.api_client.get_docket_entries(case_id)
+
+        # Find the specific docket entry by its ID.
+        # If the entry is not found, 'entry_data' will be None.
+        entry_data = next(
+            filter(
+                lambda v: v["docketEntryId"] == entry_id,
+                docket_info["docketEntries"],
+            ),
+            None,
+        )
+        if not entry_data:
+            logger.warning(
+                f"Docket entry with ID '{entry_id}' not found in case '{case_id}'."
+            )
+            self.is_valid = False
+            self._acms_json = {}
+
+        is_case_participant = docket_info["isUserCaseParticipant"]
+        is_restricted_party_filing_entry = entry_data[
+            "restrictedPartyFilingDocketEntry"
+        ]
+
+        attachment_list = self.api_client.get_attachments(
+            entry_id, is_case_participant, is_restricted_party_filing_entry
+        )
+
+        # Store the processed data and mark as valid.
+        self.is_valid = True
+        self._acms_json = {
+            "caseDetails": {"caseId": case_id},
+            "docketEntry": entry_data,
+            "docketEntryDocuments": attachment_list,
+        }
 
     @property
     def data(self) -> dict:

--- a/juriscraper/pacer/acms_attachment_page.py
+++ b/juriscraper/pacer/acms_attachment_page.py
@@ -113,6 +113,7 @@ class ACMSAttachmentPage(BaseReport):
             )
             self.is_valid = False
             self._acms_json = {}
+            return
 
         is_case_participant = docket_info["isUserCaseParticipant"]
         is_restricted_party_filing_entry = entry_data[

--- a/juriscraper/pacer/acms_attachment_page.py
+++ b/juriscraper/pacer/acms_attachment_page.py
@@ -109,7 +109,8 @@ class ACMSAttachmentPage(BaseReport):
         )
         if not entry_data:
             logger.warning(
-                f"Docket entry with ID '{entry_id}' not found in case '{case_id}'."
+                "Docket entry with ID '%s' not found in case '%s'."
+                % (entry_id, case_id)
             )
             self.is_valid = False
             self._acms_json = {}

--- a/tests/network/test_PacerAcmsAttachmentPageTest.py
+++ b/tests/network/test_PacerAcmsAttachmentPageTest.py
@@ -1,0 +1,49 @@
+import unittest
+from datetime import date
+
+from juriscraper.pacer import ACMSAttachmentPage
+from tests.network import SKIP_IF_NO_PACER_LOGIN, get_pacer_session
+
+
+class AcmsAttachmentPageTest(unittest.TestCase):
+    """A test of basic info for the Case Query"""
+
+    def setUp(self):
+        self.session = get_pacer_session()
+        self.session.login()
+        self.report = ACMSAttachmentPage("ca2", self.session)
+        self.pacer_case_id = (
+            "70c4875d-f112-48e5-ad41-5e6d403ca9cd"  # Ogunbekun v. Town of Brighton
+        )
+        self.docket_doc_id = "21ad9f34-6350-f011-877a-001dd803d067"  # Docket Entry 7
+
+    @SKIP_IF_NO_PACER_LOGIN
+    def test_queries(self):
+        """Do a variety of queries work?"""
+        self.report.query(self.pacer_case_id, self.docket_doc_id)
+        data = self.report.data
+
+        self.assertEqual(
+            7,
+            data["entry_number"],
+            msg="entry number query failed",
+        )
+        self.assertIn(
+            "MOTION, to be relieved as counsel, on behalf of Appellant Ibukun Ogunbekun",
+            data["description"],
+            msg="description query failed",
+        )
+        self.assertEqual(
+            date(2025, 6, 23),
+            data["date_filed"],
+            msg="date_filed query failed",
+        )
+        self.assertEqual(
+            date(2025, 6, 23),
+            data["date_end"],
+            msg="appeal_from query failed",
+        )
+        self.assertIsNotNone(data["attachments"], msg="attachments query failed")
+        self.assertEqual(
+            3, len(data["attachments"]), msg="attachments count query failed"
+        )

--- a/tests/network/test_PacerAcmsAttachmentPageTest.py
+++ b/tests/network/test_PacerAcmsAttachmentPageTest.py
@@ -12,10 +12,10 @@ class AcmsAttachmentPageTest(unittest.TestCase):
         self.session = get_pacer_session()
         self.session.login()
         self.report = ACMSAttachmentPage("ca2", self.session)
-        self.pacer_case_id = (
-            "70c4875d-f112-48e5-ad41-5e6d403ca9cd"  # Ogunbekun v. Town of Brighton
+        self.pacer_case_id = "70c4875d-f112-48e5-ad41-5e6d403ca9cd"  # Ogunbekun v. Town of Brighton
+        self.docket_doc_id = (
+            "21ad9f34-6350-f011-877a-001dd803d067"  # Docket Entry 7
         )
-        self.docket_doc_id = "21ad9f34-6350-f011-877a-001dd803d067"  # Docket Entry 7
 
     @SKIP_IF_NO_PACER_LOGIN
     def test_queries(self):
@@ -43,7 +43,9 @@ class AcmsAttachmentPageTest(unittest.TestCase):
             data["date_end"],
             msg="appeal_from query failed",
         )
-        self.assertIsNotNone(data["attachments"], msg="attachments query failed")
+        self.assertIsNotNone(
+            data["attachments"], msg="attachments query failed"
+        )
         self.assertEqual(
             3, len(data["attachments"]), msg="attachments count query failed"
         )


### PR DESCRIPTION
key changes: 

- Adds the `query` method to `ACMSAttachmentPage` to enable data retrieval.

- Updates `AcmsApiClient` to introduce a helper method to fetch and maps attachments for a specific docket entry.

depends on #1466 