### PR TITLE
1465 Tweaked docket_number_dist_regex regex

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,7 @@ The following changes are not yet released, but are code complete:
 Features:
 - Added support for parsing ACMS NDA notifications
 - Enhances `PacerSession` class to support ACMS authentication.
+- Added support for parsing docket numbers with case types with up to five letters
 
 Changes:
 - Refactor `ACMSDocketReport` to handle missing "date entered" values gracefully

--- a/juriscraper/pacer/docket_report.py
+++ b/juriscraper/pacer/docket_report.py
@@ -50,7 +50,7 @@ class BaseDocketReport:
         r"[tT]erminated:\s+(%s)" % DATE_REGEX, flags=re.IGNORECASE
     )
     docket_number_dist_regex = re.compile(
-        r"(?<!\d)((\d{1,2}:)?\d\d-[a-zA-Z]{1,4}-\d{1,10})"
+        r"(?<!\d)((\d{1,2}:)?\d\d-[a-zA-Z]{1,5}-\d{1,10})"
     )
     docket_number_bankr_regex = re.compile(r"(?:#:\s+)?((\d-)?\d\d-\d*)")
     docket_number_jpml = re.compile(r"(MDL No.\s+\d*)")

--- a/tests/examples/pacer/case_queries/ared_147425.html
+++ b/tests/examples/pacer/case_queries/ared_147425.html
@@ -1,0 +1,51 @@
+
+<!-- saved from url=(0071)https://ecf.ared.uscourts.gov/cgi-bin/iquery.pl?834484473201133-L_1_0-1 -->
+<html><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"><link rel="shortcut icon" href="https://ecf.ared.uscourts.gov/favicon.ico"><title>CM/ECF - ARED - LIVE</title>
+<script type="text/javascript">var default_base_path = "/"; </script><script type="text/javascript">if (top!=self) {top.location.replace(location.href);}</script><link rel="stylesheet" type="text/css" href="./ared_example.txt_files/default.css"><script type="text/javascript" src="./ared_example.txt_files/core.js"></script><link rel="stylesheet" type="text/css" href="./ared_example.txt_files/print.css" media="print"><script type="text/javascript" src="./ared_example.txt_files/menu.pl.download"></script></head><body bgcolor="FFFFFF" text="000000"><iframe id="_yuiResizeMonitor" style="position: absolute; visibility: visible; width: 10em; height: 10em; top: -160px; left: -160px; border-width: 0px;" src="./ared_example.txt_files/saved_resource.html"></iframe>        <div id="topmenu" class="yuimenubar yui-module yui-overlay visible" style="position: static; display: block; z-index: 30; visibility: visible;">
+				<div class="bd"><img src="./ared_example.txt_files/logo-cmecf-sm.png" class="cmecfLogo" id="cmecfLogo" alt="CM/ECF" title="">
+				<ul class="first-of-type">
+<li class="yuimenubaritem first-of-type" id="yui-gen0" groupindex="0" index="0"><a class="yuimenubaritemlabel" href="https://ecf.ared.uscourts.gov/cgi-bin/iquery.pl"><u>Q</u>uery</a></li>
+<li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen1" groupindex="0" index="1"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.ared.uscourts.gov/cgi-bin/DisplayMenu.pl?Reports">Reports <div class="spritedownarrow"></div></a></li>
+<li class="yuimenubaritem yuimenubaritem-hassubmenu" id="yui-gen2" groupindex="0" index="2"><a class="yuimenubaritemlabel yuimenubaritemlabel-hassubmenu" href="https://ecf.ared.uscourts.gov/cgi-bin/DisplayMenu.pl?Utilities"><u>U</u>tilities <div class="spritedownarrow"></div></a></li>
+				<li class="yuimenubaritem" id="yui-gen3" groupindex="0" index="3">
+				<a class="yuimenubaritemlabel" onclick="CMECF.MainMenu.showHelpPage(); return false">Help</a></li>
+				
+<li class="yuimenubaritem" id="yui-gen4" groupindex="0" index="4"><a class="yuimenubaritemlabel" href="https://ecf.ared.uscourts.gov/cgi-bin/login.pl?logout">Log Out</a></li></ul><hr class="hrmenuseparator"></div></div><script type="text/javascript">if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout(CMECF.MainMenu.createMenu, 0);}else{CMECF.util.Event.addListener(window, "load", CMECF.MainMenu.createMenu);}</script>  <div id="cmecfMainContent" style="height: 853px;"><input type="hidden" id="cmecfMainContentScroll" value="0"><center><b><font size="+1">4:25-crcor-00029</font></b> In Re Correspondence<br><b>Date filed:</b> 04/16/2025<br><b>Date terminated:</b> 04/16/2025<br><br>
+</center><br>
+
+		<script language="JavaScript">
+			setcookie("CASE_NUM","4:25-crcor-00029(147425)",default_base_path);
+		</script>
+	<table><tbody><tr><td>
+<div style="margin: 3px 0 1em 3px"><a href="https://ecf.ared.uscourts.gov/cgi-bin/mobile_query.pl?search=caseInfo&amp;caseid=147425">Mobile Query</a></div><font +1=""><strong>Query</strong></font><br>
+
+			<script language="JavaScript">
+				setcookie("CASE_NUM","4-25-crcor-29",default_base_path);
+			</script>
+			<table vspace="0" cellspacing="10" hspace="10" cellpadding="0" align="left" valign="top">
+		<tbody><tr align="left" valign="top">
+		<td align="top">
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/qryAlias.pl?147425">Alias</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/qryAscCases.pl?147425">Associated Cases</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/qryAttorneys.pl?147425">Attorney</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/QryRMSLocation.pl?147425">Case File Location...</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/qrySummary.pl?147425">Case Summary</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/SchedQry.pl?147425">Deadlines/Hearings...</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/DktRpt.pl?147425">Docket Report ...</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/FilerQry.pl?147425">Filers</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/qryMDL.pl?147425">MDL Case Report</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/qryParties.pl?147425">Party</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/RelTransactQry.pl?147425">Related Transactions...</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/StatusQry.pl?147425">Status</a><br>
+			&nbsp;&nbsp;&nbsp;<a href="https://ecf.ared.uscourts.gov/cgi-bin/qryDocument.pl?147425">View a Document</a><br>
+		</td>
+		</tr>	
+		</tbody></table>
+
+
+			<script>
+				function clearDesktopCookie(){
+					document.cookie = "uiexperience=dtp;secure;path=/;expires=Thu, 01-Jan-1970 00:00:01 GMT';";
+				}
+			</script>
+		</td></tr></tbody></table></div></body></html>

--- a/tests/examples/pacer/case_queries/ared_147425.json
+++ b/tests/examples/pacer/case_queries/ared_147425.json
@@ -1,0 +1,13 @@
+{
+  "case_name": "In Re Correspondence",
+  "case_name_raw": "In Re Correspondence",
+  "court_id": "ared",
+  "date_filed": "2025-04-16",
+  "date_terminated": "2025-04-16",
+  "docket_number": "4:25-crcor-00029",
+  "federal_defendant_number": null,
+  "federal_dn_case_type": "crcor",
+  "federal_dn_judge_initials_assigned": null,
+  "federal_dn_judge_initials_referred": null,
+  "federal_dn_office_code": "4"
+}


### PR DESCRIPTION
The `docket_number_dist_regex` was updated to support parsing case types with up to five letters, e.g: `4:25-crcor-00029`