### PR TITLE
fix(minn): restore needs_special_headers flag in scraper initialization

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Changes:
 Fixes:
 - Improve `ny` cleanup_content to remove email protection that was causing
   duplicates #1450
+- Fix `minn` move `need_special_headers` to `__init__` #1470
 
 ## Current
 

--- a/juriscraper/opinions/united_states/state/minn.py
+++ b/juriscraper/opinions/united_states/state/minn.py
@@ -20,7 +20,6 @@ class Site(OpinionSiteLinear):
     court_query = "supct"
     days_interval = 7
     first_opinion_date = date(1998, 1, 1)
-    needs_special_headers = True
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -49,6 +48,7 @@ class Site(OpinionSiteLinear):
             "Connection": "keep-alive",
         }
         self.make_backscrape_iterable(kwargs)
+        self.needs_special_headers = True
 
     def _process_html(self) -> None:
         """Process the html and extract out the opinions


### PR DESCRIPTION
This pull request modifies the `Site` class in `juriscraper/opinions/united_states/state/minn.py` to adjust the handling of the `needs_special_headers` attribute.