### PR TITLE
fix(ariz): update download URLs to use new cdn domain

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Changes:
 Fixes:
 - Improve `ny` cleanup_content to remove email protection that was causing
   duplicates #1450
+- Fix `ariz` update download URLs #1474
 
 ## Current
 

--- a/juriscraper/opinions/united_states/state/ariz.py
+++ b/juriscraper/opinions/united_states/state/ariz.py
@@ -22,7 +22,12 @@ class Site(OpinionSite):
 
     def _get_download_urls(self):
         path = '//a[contains(@id , "hypCaseNum")]/@href'
-        return list(self.html.xpath(path))
+        return [
+            href.replace(
+                "http://www.azcourts.gov", "https://opinions.azcourts.gov"
+            )
+            for href in self.html.xpath(path)
+        ]
 
     def _get_case_names(self):
         path = '//span[contains(@id , "lblTitle")]//text()'


### PR DESCRIPTION
### Bug Fixes:

* **Arizona scraper URLs**: Updated the `_get_download_urls` method in `ariz.py` to replace URLs. This ensures compatibility with the updated source site.