### PR TITLE
fix(pacer): Make ACMS authentication optional in PacerSession

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Features:
 -
 
 Changes:
--
+- Updates `PacerSession` class to make ACMS authentication optional, and disabled it by default.
 
 Fixes:
 -

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -103,7 +103,12 @@ class PacerSession(requests.Session):
     LOGIN_URL = "https://pacer.login.uscourts.gov/services/cso-auth"
 
     def __init__(
-        self, cookies=None, username=None, password=None, client_code=None
+        self,
+        cookies=None,
+        username=None,
+        password=None,
+        client_code=None,
+        get_acms_tokens=False,
     ):
         """
         Instantiate a new PACER API Session with some Juriscraper defaults
@@ -111,6 +116,7 @@ class PacerSession(requests.Session):
         :param username: a PACER account username
         :param password: a PACER account password
         :param client_code: an optional PACER client code for the session
+        :param get_acms_tokens: boolean flag to enable ACMS authentication during login.
         """
         super().__init__()
         self.headers["User-Agent"] = "Juriscraper"
@@ -128,6 +134,7 @@ class PacerSession(requests.Session):
         self.password = password
         self.client_code = client_code
         self.additional_request_done = False
+        self.get_acms_tokens = get_acms_tokens
         self.acms_user_data = {}
         self.acms_tokens = {}
 
@@ -432,8 +439,9 @@ class PacerSession(requests.Session):
         self.cookies = session_cookies
         logger.info("New PACER session established.")
 
-        for court_id in ["ca2", "ca9"]:
-            self.get_acms_auth_object(court_id)
+        if self.get_acms_tokens:
+            for court_id in ["ca2", "ca9"]:
+                self.get_acms_auth_object(court_id)
 
     def _do_additional_request(self, r: requests.Response) -> bool:
         """Check if we should do an additional request to PACER, sometimes

--- a/tests/network/test_PacerAuthTest.py
+++ b/tests/network/test_PacerAuthTest.py
@@ -21,8 +21,8 @@ class PacerAuthTest(unittest.TestCase):
                     "NextGenCSO", None, domain=".uscourts.gov", path="/"
                 )
             )
-            self.assertIsNotNone(self.session.acms_user_data)
-            self.assertIsNotNone(self.session.acms_tokens)
+            self.assertEqual(self.session.acms_user_data, {})
+            self.assertEqual(self.session.acms_tokens, {})
         except PacerLoginException:
             self.fail("Could not log into PACER")
 


### PR DESCRIPTION
This PR updates the `PacerSession` class to make ACMS authentication optional via a new `get_acms_tokens` flag, which is disabled by default.

We're disabling ACMS authentication by default because, even though it works in testing environments, it appears to be unreliable in production. When enabled, it may also interfere with non-ACMS reports. Turning it off by default will help us debug the issue more effectively while avoiding disruptions to normal operations in production.