### PR TITLE
fix(visuper_p): update adaptation to new HTML tags in scraper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Changes:
 -
 
 Fixes:
--
+- Fix `visuper_p` adaptation to new html tags #1489
 
 ## Current
 

--- a/juriscraper/opinions/united_states/territories/visuper_p.py
+++ b/juriscraper/opinions/united_states/territories/visuper_p.py
@@ -1,6 +1,12 @@
 # Scraper for Superior Court of the Virgin Islands (published)
 # CourtID: visuper_p
 
+# History:
+#   2023-12-11: Created - Garza
+#   2024-01-15: Updated - Rossi
+#   2025-07-09: Fixed - luism
+
+
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
@@ -18,7 +24,7 @@ class Site(OpinionSiteLinear):
 
         :return: None
         """
-        row_xpath = ".//tbody//tr[.//a[text() and not(@title='Summary')]]"
+        row_xpath = ".//table[@id='rfp-table']//tbody//tr[.//a[text() and not(@title='Summary')]]"
         for row in self.html.xpath(row_xpath):
             (
                 case_name,


### PR DESCRIPTION
This pull request addresses a bug fix and updates the scraper for the Superior Court of the Virgin Islands (`visuper_p.py`). The changes ensure compatibility with updated HTML tags and improve documentation for historical updates to the scraper.