### PR TITLE
feat(pacer): Tweaks ACMS regex to support http in addition to https

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Features:
 - Add error handling for scrapers with expected results #1447
 
 Changes:
--
+- Expanded ACMS URL matching to support both HTTP and HTTPS protocols.
 
 Fixes:
 - Fix `visuper_p` adaptation to new html tags #1489

--- a/juriscraper/pacer/http.py
+++ b/juriscraper/pacer/http.py
@@ -21,7 +21,7 @@ requests.packages.urllib3.disable_warnings(exceptions.InsecureRequestWarning)
 # Compile the regex pattern once for efficiency.
 # This pattern captures the court_id (e.g., 'ca9', 'ca2') from the URL.
 ACMS_URL_PATTERN = re.compile(
-    r"https://(ca\d+)-showdoc(services)?\.azurewebsites\.us/.*"
+    r"https?://(ca\d+)-showdoc(services)?\.azurewebsites\.us/.*"
 )
 
 


### PR DESCRIPTION
The existing regex only matched URLs starting with https. This PR updates the pattern to also match http, improving compatibility with environments that may not enforce HTTPS (like our proxy). The change preserves `court_id` extraction.

