### PR TITLE
feat(pacer): Ensure ACMS user data is loaded before fetching attachments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ The following changes are not yet released, but are code complete:
 
 Features:
 - Add error handling for scrapers with expected results #1447
+- Add a check to verify ACMS user data is loaded before querying attachment pages #1495
 
 Changes:
 - Expanded ACMS URL matching to support both HTTP and HTTPS protocols.

--- a/juriscraper/pacer/acms_attachment_page.py
+++ b/juriscraper/pacer/acms_attachment_page.py
@@ -95,6 +95,13 @@ class ACMSAttachmentPage(BaseReport):
         :param entry_id: The unique identifier of the specific docket entry to
                          retrieve.
         """
+        # Ensure ACMS user data is available before fetching attachments.
+        # Attachment requests include user-specific data in the request body,
+        # so the session must have the necessary authentication data
+        # initialized beforehand.
+        if not self.session.acms_user_data:
+            self.session.get_acms_auth_object(self.court_id)
+
         # Fetch Docket Entry Details
         docket_info = self.api_client.get_docket_entries(case_id)
 


### PR DESCRIPTION
This PR adds a check to ensure ACMS user data is loaded before querying attachment pages. Since ACMS attachment  requests require user-specific authentication data in their `body`, this change verifies that the session includes the necessary ACMS credentials and loads them if missing.