### PR TITLE
update download URLs to point to the correct media datastore

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ Changes:
 - Update `lactapp_1` scraper, site has changed #1357
 
 Fixes:
--
+- Fix `ca9` download URLs #1515
 
 ## Current
 

--- a/juriscraper/oral_args/united_states/federal_appellate/ca9.py
+++ b/juriscraper/oral_args/united_states/federal_appellate/ca9.py
@@ -22,7 +22,7 @@ class Site(OralArgumentSiteLinear):
 
         self.court_id = self.__module__
         self.table = "media"
-        self.base_url = "https://www.ca9.uscourts.gov/"
+        self.base_url = "https://www.ca9.uscourts.gov/datastore/media/"
         self.expected_content_types = [
             "application/octet-stream; charset=UTF-8"
         ]

--- a/tests/examples/oral_args/united_states/ca9_example.compare.json
+++ b/tests/examples/oral_args/united_states/ca9_example.compare.json
@@ -2,7 +2,7 @@
   {
     "case_dates": "2024-08-16",
     "case_names": "Keith McIver v. Metropolitan Life Insurance Company",
-    "download_urls": "https://www.ca9.uscourts.gov/2024/08/16/23-55306.mp3",
+    "download_urls": "https://www.ca9.uscourts.gov/datastore/media/2024/08/16/23-55306.mp3",
     "blocked_statuses": false,
     "docket_numbers": "23-55306",
     "judges": "BADE, FORREST, Curiel",
@@ -11,7 +11,7 @@
   {
     "case_dates": "2020-06-11",
     "case_names": "Kristopher Zimmerman v. Isidro Baca",
-    "download_urls": "https://www.ca9.uscourts.gov/2020/06/12/18-16886.mp3",
+    "download_urls": "https://www.ca9.uscourts.gov/datastore/media/2020/06/12/18-16886.mp3",
     "blocked_statuses": false,
     "docket_numbers": "18-16886",
     "judges": "M. SMITH, Jr., HURWITZ, EZRA",
@@ -20,7 +20,7 @@
   {
     "case_dates": "2019-12-06",
     "case_names": "Ralph Coleman v. Edmund Brown, Jr.",
-    "download_urls": "https://www.ca9.uscourts.gov/2019/12/06/18-16445.mp3",
+    "download_urls": "https://www.ca9.uscourts.gov/datastore/media/2019/12/06/18-16445.mp3",
     "blocked_statuses": false,
     "docket_numbers": "18-16445",
     "judges": "SILER, BYBEE, R. NELSON",
@@ -29,7 +29,7 @@
   {
     "case_dates": "2013-03-04",
     "case_names": "Jamal Shakir v. Edward Alameida, Jr.",
-    "download_urls": "https://www.ca9.uscourts.gov/2013/03/04/11-55009.wma",
+    "download_urls": "https://www.ca9.uscourts.gov/datastore/media/2013/03/04/11-55009.wma",
     "blocked_statuses": false,
     "docket_numbers": "11-55009",
     "judges": "Kennelly, PAEZ, WATFORD",
@@ -38,7 +38,7 @@
   {
     "case_dates": "2012-10-11",
     "case_names": "United States v. Jose Leon",
-    "download_urls": "https://www.ca9.uscourts.gov/2012/10/11/11-50090.wma",
+    "download_urls": "https://www.ca9.uscourts.gov/datastore/media/2012/10/11/11-50090.wma",
     "blocked_statuses": false,
     "docket_numbers": "11-50090",
     "judges": "Ebel, WARDLAW, NGUYEN",
@@ -47,7 +47,7 @@
   {
     "case_dates": "2010-08-10",
     "case_names": "United States v. Robert O\"Donnell",
-    "download_urls": "https://www.ca9.uscourts.gov/2010/08/10/09-10156.wma",
+    "download_urls": "https://www.ca9.uscourts.gov/datastore/media/2010/08/10/09-10156.wma",
     "blocked_statuses": false,
     "docket_numbers": "09-10156",
     "judges": "GRABER, CALLAHAN, BEA",
@@ -56,7 +56,7 @@
   {
     "case_dates": "2010-01-13",
     "case_names": "United States v. Jose Valencia-Barragan",
-    "download_urls": "https://www.ca9.uscourts.gov/2010/01/13/09-50018.wma",
+    "download_urls": "https://www.ca9.uscourts.gov/datastore/media/2010/01/13/09-50018.wma",
     "blocked_statuses": false,
     "docket_numbers": "09-50018",
     "judges": "GOODWIN, CANBY, FISHER",
@@ -65,7 +65,7 @@
   {
     "case_dates": "2007-03-06",
     "case_names": "United States v. Pardee",
-    "download_urls": "https://www.ca9.uscourts.gov/2007/03/06/06-30374.mp3",
+    "download_urls": "https://www.ca9.uscourts.gov/datastore/media/2007/03/06/06-30374.mp3",
     "blocked_statuses": false,
     "docket_numbers": "06-30374",
     "judges": "O\"SCANNLAIN, TASHIMA, BERZON",
@@ -74,7 +74,7 @@
   {
     "case_dates": "2005-12-06",
     "case_names": "Isham v. Barnhart",
-    "download_urls": "https://www.ca9.uscourts.gov/2005/12/06/04-36047.mp3",
+    "download_urls": "https://www.ca9.uscourts.gov/datastore/media/2005/12/06/04-36047.mp3",
     "blocked_statuses": false,
     "docket_numbers": "04-36047",
     "judges": "D.W. NELSON, O\"SCANNLAIN, BURNS",
@@ -83,7 +83,7 @@
   {
     "case_dates": "2004-03-04",
     "case_names": "United States v. RUELAS",
-    "download_urls": "https://www.ca9.uscourts.gov/2004/03/04/02-50600.mp3",
+    "download_urls": "https://www.ca9.uscourts.gov/datastore/media/2004/03/04/02-50600.mp3",
     "blocked_statuses": false,
     "docket_numbers": "02-50600",
     "judges": "KLEINFELD, WARDLAW, BERZON",


### PR DESCRIPTION
This pull request addresses updates to the `ca9` scraper and fixes download URL formatting issues for oral argument recordings.

this PR addresses -- #1515