### PR TITLE
fix(mont): enhance error handling for missing documents by adding sup…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ Changes:
 -
 
 Fixes:
--
+- Add new validation to `cleanup_content` to ensure that the content is not an error page #1520
 
 ## Current
 

--- a/juriscraper/opinions/united_states/state/mont.py
+++ b/juriscraper/opinions/united_states/state/mont.py
@@ -106,9 +106,9 @@ class Site(OpinionSiteLinear):
         :param content: the downloaded content; maybe a string or PDF bytes
         :return: the downloaded content, unchanged
         """
-        if (
-            isinstance(content, str)
-            and "No document found with CTrack ID" in content[:1000]
+        if isinstance(content, str) and (
+            "No document found with CTrack ID" in content[:1000]
+            or "Your support ID is" in content[:1000]
         ):
             raise InvalidDocumentError(content)
 


### PR DESCRIPTION
This pull request introduces a new validation to the `cleanup_content` function to better detect error pages in the downloaded content. The main improvement is the addition of a check for the "Your support ID is" error message, which helps prevent processing invalid documents.

Error handling improvements:

* Added a check in `cleanup_content` (in `juriscraper/opinions/united_states/state/mont.py`) to raise `InvalidDocumentError` if the content contains "Your support ID is" within the first 1000 characters, in addition to the existing check for "No document found with CTrack ID".
* Documented the new validation in the `CHANGES.md` file under Fixes.…port ID check

this PR addresses -- #1520