### PR TITLE
fix: remove should_have_results flag to prevent false positives

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Changes:
 -
 
 Fixes:
--
+- remove should_have_results flag from `wis` `mass` to prevent false positives #1513
 
 ## Current
 

--- a/juriscraper/opinions/united_states/state/mass.py
+++ b/juriscraper/opinions/united_states/state/mass.py
@@ -43,7 +43,6 @@ class Site(OpinionSiteLinear):
         self.method = "POST"
         self.status = "Published"
         self.expected_content_types = ["text/html"]
-        self.should_have_results = True
         self.days_interval = 30
         self.make_backscrape_iterable(kwargs)
 

--- a/juriscraper/opinions/united_states/state/wis.py
+++ b/juriscraper/opinions/united_states/state/wis.py
@@ -19,7 +19,6 @@ class Site(OpinionSiteLinear):
         self.set_url()
         self.cite_regex = r"20\d{2}\sWI\s\d+"
         self.make_backscrape_iterable(kwargs)
-        self.should_have_results = True
 
     def set_url(
         self, start: Optional[date] = None, end: Optional[date] = None


### PR DESCRIPTION
This pull request removes the `should_have_results` flag from the Wisconsin (`wis`) and Massachusetts (`mass`) state opinion scrapers. This change is intended to prevent false positives during result checks.

his PR addresses -- #1513