### PR TITLE
fix(colo): Wrap content in html structure

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Changes:
 -
 
 Fixes:
--
+- Forces proper html structure for `colo` #1538
 
 ## Current
 

--- a/juriscraper/opinions/united_states/state/coloctapp.py
+++ b/juriscraper/opinions/united_states/state/coloctapp.py
@@ -7,6 +7,7 @@ History:
     - 2023-01-05: Updated by William E. Palin
     - 2023-11-04: Updated by Honey K. Joule
     - 2023-11-19: Updated by William E. Palin
+    - 2025-08-11: Add cleanup_content method, quevon24
 """
 
 from juriscraper.opinions.united_states.state import colo
@@ -19,3 +20,8 @@ class Site(colo.Site):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.expected_content_types = ["application/pdf"]
+
+    @staticmethod
+    def cleanup_content(content):
+        """Return raw pdf content"""
+        return content


### PR DESCRIPTION
Implement the cleanup_content() method in `colo` scraper to:

- Force proper HTML structure
- Ensures python-magic always detects HTML
- Allows using strip_bad_html_tags_insecure() from juriscraper to remove unwanted elements
- Maintains content integrity while standardizing output
- It also implements cleanup_content method in `coloctapp` to return raw pdf content

I used these query to detect bad opinions from `colo` and `coloctapp`, we need to remove them and run the backscraper:


Colo:
```
SELECT 
    "search_opinion"."id", 
    "search_opinion"."cluster_id", 
    "search_opinion"."download_url", 
    "search_opinion"."local_path", 
    "search_opinioncluster"."date_filed",
    "search_opinioncluster"."case_name"
FROM "search_opinion" 
INNER JOIN "search_opinioncluster" ON ("search_opinion"."cluster_id" = "search_opinioncluster"."id") 
INNER JOIN "search_docket" ON ("search_opinioncluster"."docket_id" = "search_docket"."id") 
WHERE (
    "search_docket"."court_id" = 'colo' 
    AND "search_opinion"."download_url"::text LIKE '%content' 
    AND "search_opinion"."local_path"::text LIKE '%.txt'
)
ORDER BY "search_opinioncluster"."date_filed"

```

Coloctapp:

```
SELECT 
    "search_opinion"."id", 
    "search_opinion"."cluster_id", 
    "search_opinion"."download_url", 
    "search_opinion"."local_path", 
    "search_opinioncluster"."date_filed",
    "search_opinioncluster"."case_name"
FROM "search_opinion" 
INNER JOIN "search_opinioncluster" ON ("search_opinion"."cluster_id" = "search_opinioncluster"."id") 
INNER JOIN "search_docket" ON ("search_opinioncluster"."docket_id" = "search_docket"."id") 
WHERE (
    "search_docket"."court_id" = 'coloctapp' 
    AND "search_opinion"."download_url"::text LIKE '%content' 
    AND "search_opinion"."local_path"::text LIKE '%.txt'
)
ORDER BY "search_opinioncluster"."date_filed"

```