### PR TITLE
feat(acms): implements PDF download method

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ The following changes are not yet released, but are code complete:
 
 Features:
 - Add scotus_docket_report to parse SCOTUS JSON dockets
+- Add support for downloading documents from the ACMS court API.
 
 Changes:
 -

--- a/juriscraper/lib/network_utils.py
+++ b/juriscraper/lib/network_utils.py
@@ -339,6 +339,6 @@ class AcmsApiClient:
             break
 
         # Step 3: Retrieve the merged PDF by its file ID
-        response = self.session.get(f"{get_pdf_path}/?fileGuid={pdf_id}")
+        response = self.session.get(f"{get_pdf_path}?fileGuid={pdf_id}")
         response.raise_for_status()
         return response

--- a/juriscraper/lib/network_utils.py
+++ b/juriscraper/lib/network_utils.py
@@ -329,6 +329,7 @@ class AcmsApiClient:
         # Step 2: Poll until the merge job is completed
         while True:
             response = self.session.get(status_url)
+            response.raise_for_status()
             data = response.json()
             status = data["runtimeStatus"].lower()
             if status != "completed":
@@ -339,4 +340,5 @@ class AcmsApiClient:
 
         # Step 3: Retrieve the merged PDF by its file ID
         response = self.session.get(f"{get_pdf_path}/?fileGuid={pdf_id}")
+        response.raise_for_status()
         return response

--- a/juriscraper/lib/network_utils.py
+++ b/juriscraper/lib/network_utils.py
@@ -291,8 +291,8 @@ class AcmsApiClient:
         document_id: str,
         page_count: int,
         document_url: str,
-        max_attempts: int = 60,
-        poll_interval: float = 2.0,
+        max_attempts: int = 90,
+        poll_interval: float = 1.0,
     ):
         """
         Requests generation and download of a merged PDF from the remote API.

--- a/juriscraper/lib/network_utils.py
+++ b/juriscraper/lib/network_utils.py
@@ -53,6 +53,8 @@ class AcmsApiClient:
     CASE_DETAILS_ENDPOINT = "CaseDetailsByCaseId/{case_id}"
     DOCKET_ENTRIES_ENDPOINT = "DocketEntriesByCaseId/{case_id}"
     ATTACHMENTS_ENDPOINT = "DocketEntryDocumentsByDocketId/{entry_id}"
+    MERGE_PDF_ENDPOINT = "MergePDFFiles/"
+    GET_PDF_ENDPOINT = "GetMergedFile/"
 
     def __init__(self, session: Session, court_id: str):
         self.session = session
@@ -283,3 +285,58 @@ class AcmsApiClient:
             self._map_docket_entry_document(attachment)
             for attachment in raw_attachments
         ]
+
+    def download_pdf(
+        self, document_id: str, page_count: int, document_url: str
+    ):
+        """
+        Requests generation and download of a merged PDF from the remote API.
+
+        This method sends a request to merge a document, polls the status
+        of the operation until it is completed, and then retrieves the PDF file
+        from the API.
+
+        :param document_id: identifier of the document in the ACMS system.
+        :param page_count: number of pages in the document.
+        :param document_url: The URL where the source document can be accessed.
+        :return: The HTTP response containing the merged PDF file.
+        """
+        # API endpoints for merge and retrieval
+        merge_pdf_path = f"{self.base_url}{self.MERGE_PDF_ENDPOINT}"
+        get_pdf_path = f"{self.base_url}{self.GET_PDF_ENDPOINT}"
+
+        # Request body specifying the document to merge
+        body = {
+            "header": True,
+            "mergeScope": "External",
+            "pagination": False,
+            "docketEntryDocuments": [
+                {
+                    "acms_docketdocumentdetailsid": document_id,
+                    "acms_documenturl": document_url,
+                    "acms_pagecount": page_count,
+                }
+            ],
+        }
+        # Step 1: Request PDF merge operation
+        response = self.session.post(merge_pdf_path, json=body)
+        response.raise_for_status()
+        data = response.json()
+
+        # Extract URL to check merge job status
+        status_url = data["statusQueryGetUri"]
+
+        # Step 2: Poll until the merge job is completed
+        while True:
+            response = self.session.get(status_url)
+            data = response.json()
+            status = data["runtimeStatus"].lower()
+            if status != "completed":
+                # Job still running, keep polling
+                continue
+            pdf_id = data["output"]
+            break
+
+        # Step 3: Retrieve the merged PDF by its file ID
+        response = self.session.get(f"{get_pdf_path}/?fileGuid={pdf_id}")
+        return response

--- a/juriscraper/pacer/acms_docket.py
+++ b/juriscraper/pacer/acms_docket.py
@@ -82,7 +82,7 @@ class ACMSDocketReport(AppellateDocketReport):
         attachment_list = self.api_client.get_attachments(
             entry_id, False, False
         )
-        if not len(attachment_list):
+        if not attachment_list:
             return None, "No documents found for the given entry."
 
         # Case: multiple documents found but no document ID provided

--- a/juriscraper/pacer/acms_docket.py
+++ b/juriscraper/pacer/acms_docket.py
@@ -3,6 +3,9 @@ import pprint
 import re
 import sys
 from collections import OrderedDict
+from typing import Optional
+
+from requests import Response
 
 from juriscraper.lib.html_utils import strip_bad_html_tags_insecure
 from juriscraper.lib.log_tools import make_default_logger
@@ -54,6 +57,62 @@ class ACMSDocketReport(AppellateDocketReport):
             "caseDetails": case_data,
             "docketInfo": entry_details,
         }
+
+    def download_pdf(
+        self, entry_id: str, doc_id: str
+    ) -> tuple[Optional[Response], str]:
+        """
+        Downloads a PDF for a given docket entry and document ID.
+
+        This method retrieves the list of documents associated with the given
+        entry, validates the provided document ID, and then requests the PDF
+        download from the API client.
+
+        :param entry_id: The identifier of the docket entry.
+        :param doc_id: The identifier of the document within the entry.
+                    If not provided and only one document exists,
+                    that document is used by default.
+        :return: A tuple containing:
+                - Response object if the PDF download was successful, otherwise
+                 None.
+                - An error message string if an issue occurred, otherwise an
+                 empty string.
+        """
+        # Fetch all documents for given entry
+        attachment_list = self.api_client.get_attachments(
+            entry_id, False, False
+        )
+        if not len(attachment_list):
+            return None, "No documents found for the given entry."
+
+        # Case: multiple documents found but no document ID provided
+        if not doc_id and len(attachment_list) > 1:
+            error_message = (
+                "Multiple documents found for this entry. Please "
+                "provide a document ID."
+            )
+            return None, error_message
+
+        # Determine which document data to use
+        if not doc_id:
+            doc_data = attachment_list[0]
+        else:
+            doc_data = next(
+                filter(
+                    lambda v: v["docketDocumentDetailsId"] == doc_id,
+                    attachment_list,
+                ),
+                None,
+            )
+            if not doc_data:
+                return None, f"Document ID '{doc_id}' not found in this entry."
+
+        r = self.api_client.download_pdf(
+            doc_data["docketDocumentDetailsId"],
+            doc_data["pageCount"],
+            doc_data["documentUrl"],
+        )
+        return r, ""
 
     @property
     def metadata(self):


### PR DESCRIPTION
This PR introduces support for requesting PDFs from the ACMS court API and adds helper methods to validate and retrieve files.

**Key changes:** 

- `AcmsApiClient.download_pdf`:
  - Initiates a PDF merge request with the court API.
  - Polls the status until completion.
  - Retrieves and returns the merged PDF.

- `ACMSDocketReport.download_pdf`:
  - Retrieves document list for a given entry.
  - Handles cases where no document is returned by the API.
  - Handle cases when no `doc_id` is provided and the API returns multiple documents.
  - Checks that a provided `doc_id` exists in the entry before downloading.
  - Downloads the selected document via the API.

----

### Additional Notes:

My initial assumption was that we could handle download requests with just the data we store in CourtListener. It turns out that the court API requires the ACMS document URL(`e.g., https://ca9.sharepoint.com/...`), which isn't in our database.

To solve this, the `ACMSDocketReport.download_pdf` method must perform an additional API call to get the required URL. Once we have the URL, we can combine it with the document ID and page count to complete the download request.