### PR TITLE
feat(sd): extract lower court information from scraped text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ Features:
 - Add scotus_docket_report_htm to parse SCOTUS HTM dockets
 
 Changes:
--
+- Retrieve lower court information in `sd` #1569
 
 Fixes:
 -

--- a/juriscraper/opinions/united_states/state/sd.py
+++ b/juriscraper/opinions/united_states/state/sd.py
@@ -216,6 +216,7 @@ class Site(OpinionSiteLinear):
             lower_court = re.sub(
                 r"\s+", " ", match.group("lower_court")
             ).strip()
-            metadata["Docket"] = {"appeal_from_str": titlecase(lower_court)}
+            # Update Docket dict instead of overwriting
+            metadata.setdefault("Docket", {})["appeal_from_str"] = titlecase(lower_court)
 
         return metadata

--- a/juriscraper/opinions/united_states/state/sd.py
+++ b/juriscraper/opinions/united_states/state/sd.py
@@ -5,6 +5,7 @@
 # - 2014-08-05: Updated URL by mlr
 # - 2021-12-28: Updated by flooie
 # - 2024-04-11: grossir, Merge backscraper and scraper; implement dynamic backscraper
+# - 2025-09-10: luism, Extract lower_court info from text
 
 import re
 from datetime import datetime
@@ -202,5 +203,19 @@ class Site(OpinionSiteLinear):
                     metadata["OpinionCluster"]["disposition"] = disp
                 else:
                     metadata["OpinionCluster"] = {"disposition": disp}
+
+        lower_court_regex = re.compile(
+            r"""
+                     APPEAL\s+FROM\s+THE\s+
+                    (?P<lower_court>[^.]+?)
+                    (?=\s*(?:\.|\n\s*\n|,\s+SOUTH\s+DAKOTA))
+                    """,
+            re.X,
+        )
+        if match := lower_court_regex.search(scraped_text):
+            lower_court = re.sub(
+                r"\s+", " ", match.group("lower_court")
+            ).strip()
+            metadata["Docket"] = {"appeal_from_str": titlecase(lower_court)}
 
         return metadata

--- a/juriscraper/opinions/united_states/state/sd.py
+++ b/juriscraper/opinions/united_states/state/sd.py
@@ -217,6 +217,8 @@ class Site(OpinionSiteLinear):
                 r"\s+", " ", match.group("lower_court")
             ).strip()
             # Update Docket dict instead of overwriting
-            metadata.setdefault("Docket", {})["appeal_from_str"] = titlecase(lower_court)
+            metadata.setdefault("Docket", {})["appeal_from_str"] = titlecase(
+                lower_court
+            )
 
         return metadata

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -116,9 +116,12 @@ class ScraperExtractFromText(unittest.TestCase):
         "juriscraper.opinions.united_states.state.sd": [
             (
                 # https://www.courtlistener.com/opinion/9456271/mcgee-v-spencer-quarries-inc/pdf/
-                """#29901-aff in pt & rev in pt-PJD & SRJ\n2023 S.D. 66\nIN THE SUPREME COURT""",
+                """\n#29901-aff in pt & rev in pt-PJD & SRJ\n2023 S.D. 66\nIN THE SUPREME COURT\nOF THE\nSTATE OF SOUTH DAKOTA\n* * * *\nAUSTIN MCGEE, Plaintiff and Appellee,\nv.\nSPENCER QUARRIES, INC.,\na South Dakota Corporation, Defendant,\nand\nSOUTH DAKOTA DEPARTMENT OF\nTRANSPORTATION; KENT GATES,\nas an employee of the South Dakota\nDepartment of Transportation; and KRIS\nROYALTY, as an employee of the South\nDakota Department of Transportation, Defendants and Appellants.\n* * * *\nAPPEAL FROM THE CIRCUIT COURT OF\nTHE FIRST JUDICIAL CIRCUIT\nBRULE COUNTY, SOUTH DAKOTA\n* * * *\nTHE HONORABLE BRUCE V. ANDERSON\nJudge\n* * * *\n""",
                 {
-                    "Docket": {"docket_number": "29901"},
+                    "Docket": {
+                        "docket_number": "29901",
+                        "appeal_from_str": "Circuit Court of the First Judicial Circuit Brule County"
+                    },
                     "OpinionCluster": {
                         "disposition": "Affirmed in part and reversed in part",
                         "judges": "Patricia J. DeVaney, Steven R. Jensen",

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -120,7 +120,7 @@ class ScraperExtractFromText(unittest.TestCase):
                 {
                     "Docket": {
                         "docket_number": "29901",
-                        "appeal_from_str": "Circuit Court of the First Judicial Circuit Brule County"
+                        "appeal_from_str": "Circuit Court of the First Judicial Circuit Brule County",
                     },
                     "OpinionCluster": {
                         "disposition": "Affirmed in part and reversed in part",


### PR DESCRIPTION
This pull request enhances the South Dakota (`sd`) scraper by adding extraction of lower court information from opinion text.

this PR addresses in part -- #1569