### PR TITLE
feat(utah): add lower court extraction functionality for Utah opinions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,7 +19,7 @@ Features:
 - Add scotus_docket_report_htm to parse SCOTUS HTM dockets
 
 Changes:
--
+- Retrieve lower court information in `utah` #1569
 
 Fixes:
 -

--- a/juriscraper/opinions/united_states/state/utah.py
+++ b/juriscraper/opinions/united_states/state/utah.py
@@ -1,7 +1,8 @@
 import re
 
-from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 from juriscraper.AbstractSite import logger
+from juriscraper.OpinionSiteLinear import OpinionSiteLinear
+
 
 class Site(OpinionSiteLinear):
     def __init__(self, *args, **kwargs):
@@ -16,11 +17,11 @@ class Site(OpinionSiteLinear):
             "//div[@id='content']//p[a[contains(@href, '.pdf')]]"
         ):
             texts = row.xpath("text()")
-            if any('superseded' in t.lower() for t in texts):
+            if any("superseded" in t.lower() for t in texts):
                 # Superseding opinions are published in their own rows
                 logger.info("Skipping row with superseded opinion %s", texts)
                 continue
-            
+
             # pick longest text; if not, HTML comments may cause wrong indexing
             text = sorted(texts)[-1]
             neutral_cite_match = re.search(r"\d{4} UT( App)? \d{1,}", text)

--- a/juriscraper/opinions/united_states/state/utah.py
+++ b/juriscraper/opinions/united_states/state/utah.py
@@ -61,7 +61,7 @@ class Site(OpinionSiteLinear):
             (?P<lower_court>(?:[^\S\r\n]*\S.*(?:\n|$))+?)
             [^\S\r\n]*the\s+Honorable\s+(?P<lower_court_judge>.*?)(?:\s+No\.)
             """,
-            re.MULTILINE | re.VERBOSE | re.IGNORECASE
+            re.MULTILINE | re.VERBOSE | re.IGNORECASE,
         )
 
         if match := pattern.search(scraped_text):
@@ -76,7 +76,7 @@ class Site(OpinionSiteLinear):
                 },
                 "OriginatingCourtInformation": {
                     "assigned_to_str": lower_court_judge,
-                }
+                },
             }
 
         return {}

--- a/juriscraper/opinions/united_states/state/utah.py
+++ b/juriscraper/opinions/united_states/state/utah.py
@@ -1,8 +1,7 @@
 import re
 
-from juriscraper.AbstractSite import logger
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
-
+from juriscraper.AbstractSite import logger
 
 class Site(OpinionSiteLinear):
     def __init__(self, *args, **kwargs):
@@ -16,13 +15,14 @@ class Site(OpinionSiteLinear):
         for row in self.html.xpath(
             "//div[@id='content']//p[a[contains(@href, '.pdf')]]"
         ):
-            if row.xpath("br"):
-                # Superseded opinions
-                logger.info("Skipping row %s", row.text_content())
+            texts = row.xpath("text()")
+            if any('superseded' in t.lower() for t in texts):
+                # Superseding opinions are published in their own rows
+                logger.info("Skipping row with superseded opinion %s", texts)
                 continue
-
+            
             # pick longest text; if not, HTML comments may cause wrong indexing
-            text = sorted(row.xpath("text()"))[-1]
+            text = sorted(texts)[-1]
             neutral_cite_match = re.search(r"\d{4} UT( App)? \d{1,}", text)
             citation = neutral_cite_match.group(0)
 

--- a/juriscraper/opinions/united_states/state/utah.py
+++ b/juriscraper/opinions/united_states/state/utah.py
@@ -58,8 +58,8 @@ class Site(OpinionSiteLinear):
             |On\s+Certiorari\s+to\s+the\s+Utah\s+Court\s+of\s+Appeals)
 
             \s*\n+
-            (?P<lower_court>(?:[^\S\r\n]*\S.*(?:\n|$))+?)
-            [^\S\r\n]*the\s+Honorable\s+(?P<lower_court_judge>.*?)(?:\s+No\.)
+            (?P<lower_court>([^\S\r\n]*\S.*(?:\n|$))+?)
+            [^\S\r\n]*the\s+Honorable\s+(?P<lower_court_judge>.*?)(\s+No\.)\s*(?P<lower_court_number>\S+)
             """,
             re.MULTILINE | re.VERBOSE | re.IGNORECASE,
         )
@@ -69,6 +69,7 @@ class Site(OpinionSiteLinear):
                 r"\s+", " ", match.group("lower_court")
             ).strip()
             lower_court_judge = match.group("lower_court_judge").strip()
+            lower_court_number = match.group("lower_court_number").strip()
 
             return {
                 "Docket": {
@@ -76,6 +77,7 @@ class Site(OpinionSiteLinear):
                 },
                 "OriginatingCourtInformation": {
                     "assigned_to_str": lower_court_judge,
+                    "docket_number": lower_court_number
                 },
             }
 

--- a/juriscraper/opinions/united_states/state/utah.py
+++ b/juriscraper/opinions/united_states/state/utah.py
@@ -77,7 +77,7 @@ class Site(OpinionSiteLinear):
                 },
                 "OriginatingCourtInformation": {
                     "assigned_to_str": lower_court_judge,
-                    "docket_number": lower_court_number
+                    "docket_number": lower_court_number,
                 },
             }
 

--- a/juriscraper/opinions/united_states/state/utahctapp.py
+++ b/juriscraper/opinions/united_states/state/utahctapp.py
@@ -1,7 +1,10 @@
+from juriscraper.OpinionSite import OpinionSite
 from juriscraper.opinions.united_states.state import utah
 
 
 class Site(utah.Site):
+    extract_from_text = OpinionSite.extract_from_text
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.url = "https://legacy.utcourts.gov/opinions/appopin/"

--- a/juriscraper/opinions/united_states/state/utahctapp.py
+++ b/juriscraper/opinions/united_states/state/utahctapp.py
@@ -1,5 +1,5 @@
-from juriscraper.OpinionSite import OpinionSite
 from juriscraper.opinions.united_states.state import utah
+from juriscraper.OpinionSite import OpinionSite
 
 
 class Site(utah.Site):

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -969,6 +969,19 @@ class ScraperExtractFromText(unittest.TestCase):
                 },
             ),
         ],
+        "juriscraper.opinions.united_states.state.utah": [
+            (
+                "\nThis opinion is subject to revision before final\n                     publication in the Pacific Reporter\n                                2025 UT 17\n\n\n                                   IN THE\n\n      SUPREME COURT OF THE STATE OF UTAH\n\n                         UNIVERSITY OF UTAH,\n                             Appellant,\n                                      v.\n                JOHN TULLIS and AMELIA TULLIS,\n        individually and as parents and natural guardians\n                      of P.T., a minor child,\n                            Appellees.\n\n                           No. 20230672\n                       Heard October 25, 2024\n                         Filed June 5, 2025\n\n                On Appeal of Interlocutory Order\n\n              Third District Court, Salt Lake County\n                  The Honorable Adam T. Mow\n                          No. 190907183\n\n\n                                Attorneys∗:\nCarolyn S. Stevens, Amy F. Sorenson, Cameron J. Cutler, Annika\n L. Jones, Salt Lake City, Derek J. Williams, Millcreek, LaMar F.\n      Jost, Clarissa M. Collier, Denver, Colo., for appellant\n    Christine Durham, Deno Himonas, Sarah Smith, Caitlin\nMcKelvie, Cate Vaden, Charles H. Thronson, Michael A. Worel,\nSalt Lake City, Mark R. Yohalem, Los Angeles, Cal., for appellees\n",
+                {
+                    "Docket": {
+                        "appeal_from_str": "Third District Court, Salt Lake County"
+                    },
+                    "OriginatingCourtInformation": {
+                        "assigned_to_str": "Adam T. Mow"
+                    }
+                }
+            ),
+        ],
     }
 
     def test_extract_from_text(self):

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -981,7 +981,7 @@ class ScraperExtractFromText(unittest.TestCase):
                     },
                     "OriginatingCourtInformation": {
                         "assigned_to_str": "Adam T. Mow",
-                        "docket_number": "190907183"
+                        "docket_number": "190907183",
                     },
                 },
             ),

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -978,8 +978,8 @@ class ScraperExtractFromText(unittest.TestCase):
                     },
                     "OriginatingCourtInformation": {
                         "assigned_to_str": "Adam T. Mow"
-                    }
-                }
+                    },
+                },
             ),
         ],
     }

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -977,7 +977,8 @@ class ScraperExtractFromText(unittest.TestCase):
                         "appeal_from_str": "Third District Court, Salt Lake County"
                     },
                     "OriginatingCourtInformation": {
-                        "assigned_to_str": "Adam T. Mow"
+                        "assigned_to_str": "Adam T. Mow",
+                        "docket_number": "190907183"
                     },
                 },
             ),


### PR DESCRIPTION
This pull request enhances the Utah state opinions scraper by adding functionality to extract lower court information from opinion text.

this PR addresses in part -- #1569