### PR TITLE
feat(dc): implement lower court extraction from scraped text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Changes:
 - Retrieve lower court information in `va` #1569
 - Retrieve lower court information in `utah` #1569
 - Retrieve lower court information in `wyo` #1569
+- Retrieve lower court information in `dc` #1569
 
 Fixes:
 - Fix connappct #1580

--- a/juriscraper/opinions/united_states/state/dc.py
+++ b/juriscraper/opinions/united_states/state/dc.py
@@ -3,13 +3,15 @@ CourtID: dc
 Court Short Name: D.C.
 Author: V. David Zvenyach
 Date created:2014-02-21
+History:
+    - 2025-08-29: Update to OpinionSiteLinear and added extract_from_text method to get lower court info, Luis Manzur
 """
 
-from juriscraper.lib.string_utils import convert_date_string
-from juriscraper.OpinionSite import OpinionSite
+from juriscraper.OpinionSiteLinear import OpinionSiteLinear
+import re
 
 
-class Site(OpinionSite):
+class Site(OpinionSiteLinear):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
@@ -20,25 +22,62 @@ class Site(OpinionSite):
         qualifier_has_pdf_link = 'contains(.//td[1]/a/@href, ".pdf")'
         self.base_path = f"//table//tr[{qualifier_no_opinions} and {qualifier_has_pdf_link}]"
         self.should_have_results = True
+        self.status = "Published"
 
-    def _get_docket_numbers(self):
-        path = f"{self.base_path}/td[1]/a"
-        return [cell.text_content().strip() for cell in self.html.xpath(path)]
+    def _process_html(self):
+        """Process the html and extract out the opinions
 
-    def _get_download_urls(self):
-        path = f"{self.base_path}/td[1]/a/@href"
-        return list(self.html.xpath(path))
+        :return: None
+        """
 
-    def _get_case_names(self):
-        path = f"{self.base_path}/td[2]"
-        return [cell.text_content() for cell in self.html.xpath(path)]
+        for row in self.html.xpath(self.base_path):
+            docket = row.xpath("./td[1]/a/text()")[0].strip()
+            url = row.xpath("./td[1]/a/@href")[0].strip()
+            name = row.xpath("./td[2]/text()")[0].strip()
+            date = row.xpath("./td[3]/text()")[0].strip()
+            self.cases.append(
+                {
+                    "name": name,
+                    "date": date,
+                    "docket": docket,
+                    "url": url,
+                }
+            )
 
-    def _get_case_dates(self):
-        path = f"{self.base_path}/td[3]"
-        return [
-            convert_date_string(cell.text_content())
-            for cell in self.html.xpath(path)
-        ]
+    def extract_from_text(self, scraped_text: str) -> dict:
+        """Extract lower court from the scraped text.
 
-    def _get_precedential_statuses(self):
-        return ["Published"] * len(self.case_names)
+        :param scraped_text: The text to extract from.
+        :return: A dictionary with the metadata.
+        """
+
+        court_and_docket_pattern = re.compile(
+            r"""
+            (?:
+               Appeals?\s+from\s+the\s+
+               | On\s+Report\s+and\s+Recommendation\s+of\s+the\s+
+               | On\s+Petition\s+for\s+Review\s+of\s+a\s+Decision(?:\s*\n*\s*|\s+)of\s+the\s+
+               | On\s+Certified\s+Question\s+from\s+the\s+
+               | On\s+Petition\s+for\s+Review\s+of\s+an\s+Order\s+of\s+the\s+
+            )
+            (.*?)
+            \s*\n*\s*\(([^)]+)\)
+            """,
+            re.X | re.DOTALL | re.MULTILINE | re.IGNORECASE,
+        )
+
+        match = court_and_docket_pattern.search(scraped_text)
+        if match:
+            lower_court = re.sub(r"\s+", " ", match.group(1)).strip()
+            lower_court_number = match.group(2).strip()
+
+            return {
+                "Docket": {
+                    "appeal_from_str": lower_court,
+                },
+                "OriginatingCourtInformation": {
+                    "docket_number": lower_court_number,
+                }
+            }
+
+        return {}

--- a/juriscraper/opinions/united_states/state/dc.py
+++ b/juriscraper/opinions/united_states/state/dc.py
@@ -7,8 +7,9 @@ History:
     - 2025-08-29: Update to OpinionSiteLinear and added extract_from_text method to get lower court info, Luis Manzur
 """
 
-from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 import re
+
+from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
 class Site(OpinionSiteLinear):
@@ -77,7 +78,7 @@ class Site(OpinionSiteLinear):
                 },
                 "OriginatingCourtInformation": {
                     "docket_number": lower_court_number,
-                }
+                },
             }
 
         return {}

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -1009,6 +1009,19 @@ class ScraperExtractFromText(unittest.TestCase):
                 },
             ),
         ],
+        "juriscraper.opinions.united_states.state.dc": [
+            (
+                "\nNotice: This opinion is subject to formal revision before publication in the Atlantic\nand Maryland Reporters. Users are requested to notify the Clerk of the Court of\nany formal errors so that corrections may be made before the bound volumes go\nto press.\n\n\n               DISTRICT OF COLUMBIA COURT OF APPEALS\n\n                                  No. 23-CV-0977\n\n                      TYROSHI INVESTMENTS, LLC, APPELLANT,\n\n                                          V.\n\n   U.S. BANK, N.A., SUCCESSOR TRUSTEE TO LASALLE BANK, N.A., APPELLEE.\n\n                           Appeal from the Superior Court\n                            of the District of Columbia\n                               (2020-CA-001727-B)\n\n                        (Hon. Robert R. Rigsby, Trial Judge)\n\n(Argued June 12, 2025                                Decided September 11, 2025)\n\n      Ian G. Thomas, with whom Tracy L. Buck was on the brief, for appellant.\n\n      Melissa O. Martinez for appellee.\n",
+                {
+                    "Docket": {
+                        "appeal_from_str": "Superior Court of the District of Columbia",
+                    },
+                    "OriginatingCourtInformation": {
+                        "docket_number": "2020-CA-001727-B"
+                    }
+                },
+            ),
+        ],
     }
 
     def test_extract_from_text(self):

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -1018,7 +1018,7 @@ class ScraperExtractFromText(unittest.TestCase):
                     },
                     "OriginatingCourtInformation": {
                         "docket_number": "2020-CA-001727-B"
-                    }
+                    },
                 },
             ),
         ],


### PR DESCRIPTION
This pull request updates the DC state court scraper to retrieve lower court information.

this PR addresses in part -- #1590