### PR TITLE
feat(iowa): add lower court extraction functionality to Iowa scrapers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@ Changes:
 - Retrieve lower court information in `cal` scrapers #1569
 - Retrieve lower court information in 'alaska' #1569
 - Add lower court extraction to `federal_appellate` scrapers #1560
+- Add lower court extraction to `iowa` scrapers #1569
 
 
 Fixes:

--- a/juriscraper/opinions/united_states/state/iowa.py
+++ b/juriscraper/opinions/united_states/state/iowa.py
@@ -135,9 +135,10 @@ class Site(OpinionSite):
         pattern = re.compile(
             r"""
             (?:
-               Appeals?\s+from\s+the\s+
+               Appeals?\s+from\s+the\s+(?:report\s+of\s+the\s+)?
               | On\s+review\s+of\s+the\s+report\s+of\s+the\s+
               | On\s+application\s+of\s+the\s+
+              | On\s+review\s+from\s+the\s+
             )
             (?P<lower_court>[^,.]+?)
             (?:,\s*

--- a/juriscraper/opinions/united_states/state/iowa.py
+++ b/juriscraper/opinions/united_states/state/iowa.py
@@ -1,6 +1,7 @@
 # Scraper for Iowa Supreme Court
 # CourtID: iowa
 # Court Short Name: iowa
+import re
 
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.string_utils import convert_date_string
@@ -124,3 +125,45 @@ class Site(OpinionSite):
         path = '//div[contains(./@class, "pagination-next-page")]//a/@href'
         elements = html.xpath(path)
         return elements[0] if elements else False
+
+    def extract_from_text(self, scraped_text: str) -> dict:
+        """Extract lower court from the scraped text.
+
+        :param scraped_text: The text to extract from.
+        :return: A dictionary with the metadata.
+        """
+        pattern = re.compile(
+            r"""
+            (?:
+               Appeals?\s+from\s+the\s+
+              | On\s+review\s+of\s+the\s+report\s+of\s+the\s+
+              | On\s+application\s+of\s+the\s+
+            )
+            (?P<lower_court>[^,.]+?)
+            (?:,\s*
+                (?P<lower_court_judge>[^,]+?)
+                ,\s*judge
+            )?
+            \.
+            """,
+            re.X | re.IGNORECASE,
+        )
+
+        result = {}
+        if match := pattern.search(scraped_text):
+            lower_court = re.sub(
+                r"\s+", " ", match.group("lower_court")
+            ).strip()
+
+            result["Docket"] = {
+                    "appeal_from_str": lower_court,
+                }
+
+            if match.group("lower_court_judge"):
+                lower_court_judge = re.sub(
+                    r"\s+", " ", match.group("lower_court_judge")
+                ).strip()
+
+                result["OriginatingCourtInformation"] = {"assigned_to_str": lower_court_judge}
+
+        return result

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -1359,6 +1359,32 @@ class ScraperExtractFromText(unittest.TestCase):
                 },
             )
         ],
+        "juriscraper.opinions.united_states.state.iowa": [
+            (
+                "                          In the Iowa Supreme Court\n\n                                     No. 23–1122\n\n              Submitted September 11, 2024—Filed October 11, 2024\n                             Amended April 17, 2025\n\n                                    State of Iowa,\n\n                                       Appellee,\n\n                                          vs.\n\n                           Willard Noble Chaiden Miller,\n\n                                      Appellant.\n\n\n         Appeal from the Iowa District Court for Jefferson County, Shawn Showers,\n\njudge.\n\n         A defendant convicted of first-degree murder as a juvenile appeals his\n\nsentence of life imprisonment with the possibility of parole after serving\n\nthirty-five years. Affirmed.\n\n         Christensen, C.J., delivered the opinion of the court, in which all justices\n\njoined.",
+                {
+                    "Docket": {
+                        "appeal_from_str": "Iowa District Court for Jefferson County",
+                    },
+                    "OriginatingCourtInformation": {
+                        "assigned_to_str": "Shawn Showers"
+                    }
+                },
+            )
+        ],
+        "juriscraper.opinions.united_states.state.iowactapp": [
+            (
+                "                          In the Iowa Supreme Court\n\n                                     No. 23–1122\n\n              Submitted September 11, 2024—Filed October 11, 2024\n                             Amended April 17, 2025\n\n                                    State of Iowa,\n\n                                       Appellee,\n\n                                          vs.\n\n                           Willard Noble Chaiden Miller,\n\n                                      Appellant.\n\n\n         Appeal from the Iowa District Court for Jefferson County, Shawn Showers,\n\njudge.\n\n         A defendant convicted of first-degree murder as a juvenile appeals his\n\nsentence of life imprisonment with the possibility of parole after serving\n\nthirty-five years. Affirmed.\n\n         Christensen, C.J., delivered the opinion of the court, in which all justices\n\njoined.",
+                {
+                    "Docket": {
+                        "appeal_from_str": "Iowa District Court for Jefferson County",
+                    },
+                    "OriginatingCourtInformation": {
+                        "assigned_to_str": "Shawn Showers"
+                    }
+                },
+            )
+        ],
     }
 
     def test_extract_from_text(self):


### PR DESCRIPTION
This pull request adds lower court extraction functionality to the Iowa scrapers.

this PR addresses in part -- #1569 