### PR TITLE
feat(ky): add extract_from_text method to retrieve lower court information

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@ Changes:
 
 - Retrieve lower court information in `delaware` scrapers #1569
 - Retrieve lower court information in `idaho` #1569
+- Retrieve lower court information in `ky` #1569
 
 Fixes:
 - Fix connappct #1580

--- a/juriscraper/opinions/united_states/state/ky.py
+++ b/juriscraper/opinions/united_states/state/ky.py
@@ -213,10 +213,12 @@ class Site(OpinionSiteLinear):
             lower_court_number = match.group("lower_court_number")
 
             if lower_court_judge:
-                result.setdefault("OriginatingCourtInformation", {})["assigned_to_str"] = titlecase(
-                    lower_court_judge.strip()
-                )
+                result.setdefault("OriginatingCourtInformation", {})[
+                    "assigned_to_str"
+                ] = titlecase(lower_court_judge.strip())
             if lower_court_number:
-                result.setdefault("OriginatingCourtInformation", {})["docket_number"] = lower_court_number.strip()
+                result.setdefault("OriginatingCourtInformation", {})[
+                    "docket_number"
+                ] = lower_court_number.strip()
 
         return result

--- a/juriscraper/opinions/united_states/state/ky.py
+++ b/juriscraper/opinions/united_states/state/ky.py
@@ -13,6 +13,7 @@ History:
                 to access restrictions.
     2020-08-28: Updated to use new secondary search portal at https://appellatepublic.kycourts.net/
     2024-04-08: Updated to use new opinion search portal, by grossir
+    2025-06-31: Added extract_from_text method to get lower court info, luism
 """
 
 import re
@@ -181,3 +182,41 @@ class Site(OpinionSiteLinear):
         self.set_url(*dates)
         self.html = self._download()
         self._process_html()
+
+    def extract_from_text(self, scraped_text: str) -> dict:
+        """Extract lower court from the scraped text.
+
+        :param scraped_text: The text to extract from.
+        :return: A dictionary with the metadata.
+        """
+        pattern = re.compile(
+            r"""
+            ON\s+(?:APPEAL|REVIEW)\s+FROM\s+(?P<lower_court>[^\n.]+)
+            .*?
+            (?:HONORABLE\s+(?P<lower_court_judge>[\w\s.\-]+),\s*JUDGE.*?)?
+            NOS?\.\s*(?P<lower_court_number>[\w\-]+)
+            """,
+            re.I | re.S | re.X,
+        )
+
+        result = {}
+        if match := pattern.search(scraped_text):
+            lower_court = re.sub(
+                r"\s+", " ", match.group("lower_court")
+            ).strip()
+
+            result["Docket"] = {
+                "appeal_from_str": titlecase(lower_court),
+            }
+
+            lower_court_judge = match.group("lower_court_judge")
+            lower_court_number = match.group("lower_court_number")
+
+            if lower_court_judge:
+                result.setdefault("OriginatingCourtInformation", {})["assigned_to_str"] = titlecase(
+                    lower_court_judge.strip()
+                )
+            if lower_court_number:
+                result.setdefault("OriginatingCourtInformation", {})["docket_number"] = lower_court_number.strip()
+
+        return result

--- a/juriscraper/opinions/united_states/state/ky.py
+++ b/juriscraper/opinions/united_states/state/ky.py
@@ -205,6 +205,10 @@ class Site(OpinionSiteLinear):
                 r"\s+", " ", match.group("lower_court")
             ).strip()
 
+            # Prepend 'Kentucky' if lower_court is 'Court of Appeals'
+            if lower_court.lower() == "court of appeals":
+                lower_court = "Kentucky Court of Appeals"
+
             result["Docket"] = {
                 "appeal_from_str": titlecase(lower_court),
             }

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -1446,7 +1446,7 @@ class ScraperExtractFromText(unittest.TestCase):
                     },
                     "OriginatingCourtInformation": {
                         "docket_number": "19-CR-00158"
-                    }
+                    },
                 },
             )
         ],
@@ -1459,7 +1459,7 @@ class ScraperExtractFromText(unittest.TestCase):
                     },
                     "OriginatingCourtInformation": {
                         "docket_number": "19-CR-00158"
-                    }
+                    },
                 },
             )
         ],

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -1437,6 +1437,32 @@ class ScraperExtractFromText(unittest.TestCase):
                 },
             ),
         ],
+        "juriscraper.opinions.united_states.state.ky": [
+            (
+                "\n                                                   RENDERED: JUNE 20, 2025\n                                                             TO BE PUBLISHED\n\n\n                Supreme Court of Kentucky\n                                 2023-SC-0124-MR\n\n\nEARL K.JOHNSON                                                          APPELLANT\n\n\n                 ON APPEAL FROM LOGAN CIRCUIT COURT\nV.HONORABLE JOE W.HENDRICKS, JR., JUDGE\n                            NO.19-CR-00158\n\n\nCOMMONWEALTH OF KENTUCKY                                                   APPELLEE\n\n\n\n              OPINION OF THE COURT BY JUSTICE THOMPSON\n\n       AFFIRMING IN PART, REVERSING IN PART, AND REMANDING\n\n      Earl K.Johnson was convicted after a jury trial on four counts of\n",
+                {
+                    "Docket": {
+                        "appeal_from_str": "Logan Circuit Court",
+                    },
+                    "OriginatingCourtInformation": {
+                        "docket_number": "19-CR-00158"
+                    }
+                },
+            )
+        ],
+        "juriscraper.opinions.united_states.state.kyctapp": [
+            (
+                "\n                                                   RENDERED: JUNE 20, 2025\n                                                             TO BE PUBLISHED\n\n\n                Supreme Court of Kentucky\n                                 2023-SC-0124-MR\n\n\nEARL K.JOHNSON                                                          APPELLANT\n\n\n                 ON APPEAL FROM LOGAN CIRCUIT COURT\nV.HONORABLE JOE W.HENDRICKS, JR., JUDGE\n                            NO.19-CR-00158\n\n\nCOMMONWEALTH OF KENTUCKY                                                   APPELLEE\n\n\n\n              OPINION OF THE COURT BY JUSTICE THOMPSON\n\n       AFFIRMING IN PART, REVERSING IN PART, AND REMANDING\n\n      Earl K.Johnson was convicted after a jury trial on four counts of\n",
+                {
+                    "Docket": {
+                        "appeal_from_str": "Logan Circuit Court",
+                    },
+                    "OriginatingCourtInformation": {
+                        "docket_number": "19-CR-00158"
+                    }
+                },
+            )
+        ],
     }
 
     def test_extract_from_text(self):


### PR DESCRIPTION
This pull request adds support for extracting lower court information from Kentucky (`ky`)

this PR addresses in part -- #1569 