### PR TITLE
feat(mont): extract lower court information and enhance citation retrieval

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Changes:
 - Retrieve lower court information in `delaware` scrapers #1569
 - Retrieve lower court information in `idaho` #1569
 - Retrieve lower court information in `ky` #1569
+- Retrieve lower court information in `mont` #1569
 
 Fixes:
 - Fix connappct #1580

--- a/juriscraper/opinions/united_states/state/mont.py
+++ b/juriscraper/opinions/united_states/state/mont.py
@@ -84,7 +84,7 @@ class Site(OpinionSiteLinear):
         result = {}
         first_text = scraped_text[:400]
         if match := re.search(self.cite_regex, first_text):
-            result["Citation"] =  match.group(0)
+            result["Citation"] = match.group(0)
 
         lower_court_pattern = re.compile(
             r"""
@@ -93,7 +93,7 @@ class Site(OpinionSiteLinear):
                 (?:.*?No\.\s+(?P<lower_court_docket>[^\n,]+))?
                 (?:.*?Honorable\s+(?P<judge>.+?),\s*Presiding\s*Judge)?
             """,
-            re.X | re.DOTALL
+            re.X | re.DOTALL,
         )
 
         if match := lower_court_pattern.search(scraped_text):
@@ -108,7 +108,9 @@ class Site(OpinionSiteLinear):
                 ] = lower_court_judge
             lower_court_docket = match.group("lower_court_docket")
             if lower_court_docket:
-                result.setdefault("OriginatingCourtInformation", {})["docket_number"] = lower_court_docket
+                result.setdefault("OriginatingCourtInformation", {})[
+                    "docket_number"
+                ] = lower_court_docket
         return result
 
     @staticmethod

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -844,8 +844,8 @@ class ScraperExtractFromText(unittest.TestCase):
                     },
                     "OriginatingCourtInformation": {
                         "assigned_to_str": "John A. Kutzman",
-                        "docket_number": "CDC-22-346"
-                    }
+                        "docket_number": "CDC-22-346",
+                    },
                 },
             )
         ],

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -836,9 +836,16 @@ class ScraperExtractFromText(unittest.TestCase):
         "juriscraper.opinions.united_states.state.mont": [
             (
                 # https://www.courtlistener.com/api/rest/v4/opinions/10801442/
-                "'02/18/2025\n\n\n                                        DA 23-0746\n\n                IN THE SUPREME COURT OF THE STATE OF MONTANA\n\n                                         2025 MT 35\n\n\n\nIN THE MATTER OF THE ESTATE OF:\n\nWARREN DAN EDDLEMAN,",
+                "\n                                                                                        08/26/2025\n\n\n                                         DA 23-0430\n                                                                                     Case Number: DA 23-0430\n\n\n              IN THE SUPREME COURT OF THE STATE OF MONTANA\n\n                                        2025 MT 189\n\n\n\nSTATE OF MONTANA,\n\n              Plaintiff and Appellee,\n\n         v.\n\nJEFFREY SCOTT ANDERSON,\n\n              Defendant and Appellant.\n\n\n\nAPPEAL FROM:          District Court of the Eighth Judicial District,\n                      In and For the County of Cascade, Cause No. CDC-22-346\n                      Honorable John A. Kutzman, Presiding Judge\n\n\nCOUNSEL OF RECORD:\n\n               For Appellant:\n\n                      James M. Siegman, Attorney at Law, Jackson, Mississippi\n\n               For Appellee:\n\n                      Austin Knudsen, Montana Attorney General, Katie F. Schulz,\n                      Assistant Attorney General, Helena, Montana\n\n                      Joshua A. Racki, Cascade County Attorney, Amanda Lofink, Deputy\n                      County Attorney, Great Falls, Montana\n",
                 {
-                    "Citation": "2025 MT 35",
+                    "Citation": "2025 MT 189",
+                    "Docket": {
+                        "appeal_from_str": "District Court of the Eighth Judicial District, In and For the County of Cascade"
+                    },
+                    "OriginatingCourtInformation": {
+                        "assigned_to_str": "John A. Kutzman",
+                        "docket_number": "CDC-22-346"
+                    }
                 },
             )
         ],


### PR DESCRIPTION
This pull request adds support for extracting lower court information in the Montana (`mont`) scraper.

this PR addresses in part -- #1569