### PR TITLE
feat(nd): extract lower court information from text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Changes:
 - Retrieve lower court information in `delaware` scrapers #1569
 - Retrieve lower court information in `idaho` #1569
 - Retrieve lower court information in `ky` #1569
+- Retrieve lower court information in `nd` #1569
 
 Fixes:
 - Fix connappct #1580

--- a/juriscraper/opinions/united_states/state/nd.py
+++ b/juriscraper/opinions/united_states/state/nd.py
@@ -4,6 +4,7 @@
 # Date created: 2019-02-28
 # Updated: 2024-05-08, grossir: to OpinionSiteLinear and new URL
 # Updated: 2025-07-02, luism: get citation from HTML
+# Updated: 2025-09-01, luism: extract lower court information from text
 
 import re
 from datetime import date, datetime
@@ -169,6 +170,19 @@ class Site(OpinionSiteLinear):
                 case_name = reversed_lines[index + 1].strip()
                 break
 
+        lower_court_pattern = re.compile(
+            r"Appeal\s+from\s+the\s+(?P<lower_court>.*?),\s*the\s+Honorable\s+(?P<judge>.+?),\s*Judge",
+            re.DOTALL
+        )
+
+        lower_court = ""
+        lower_court_judge = ""
+        if match := lower_court_pattern.search(scraped_text):
+            lower_court = re.sub(
+                r"\s+", " ", match.group("lower_court")
+            ).strip()
+            lower_court_judge = match.group("judge").strip()
+
         # We only put keys into the objects when they exist
         # Otherwise, we would overwrite existing data with empty values
         metadata.update({"OpinionCluster": {}, "Docket": {}})
@@ -179,6 +193,11 @@ class Site(OpinionSiteLinear):
             metadata["Docket"]["docket_number"] = normalize_dashes(
                 docket_number
             )
+        if lower_court:
+            metadata["Docket"]["appeal_from_str"] = lower_court
+        if lower_court_judge:
+            metadata.update({"OriginatingCourtInformation": {}})
+            metadata["OriginatingCourtInformation"]["assigned_to_str"] = lower_court_judge
 
         return metadata
 

--- a/juriscraper/opinions/united_states/state/nd.py
+++ b/juriscraper/opinions/united_states/state/nd.py
@@ -172,7 +172,7 @@ class Site(OpinionSiteLinear):
 
         lower_court_pattern = re.compile(
             r"Appeal\s+from\s+the\s+(?P<lower_court>.*?),\s*the\s+Honorable\s+(?P<judge>.+?),\s*Judge",
-            re.DOTALL
+            re.DOTALL,
         )
 
         lower_court = ""
@@ -197,7 +197,9 @@ class Site(OpinionSiteLinear):
             metadata["Docket"]["appeal_from_str"] = lower_court
         if lower_court_judge:
             metadata.update({"OriginatingCourtInformation": {}})
-            metadata["OriginatingCourtInformation"]["assigned_to_str"] = lower_court_judge
+            metadata["OriginatingCourtInformation"]["assigned_to_str"] = (
+                lower_court_judge
+            )
 
         return metadata
 

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -488,7 +488,11 @@ class ScraperExtractFromText(unittest.TestCase):
                     "Docket": {
                         "case_name": "Gerszewski v. Rostvet",
                         "docket_number": "Nos. 20230361-20230363",
+                        "appeal_from_str": "District Court of Walsh County, Northeast Judicial District",
                     },
+                    "OriginatingCourtInformation": {
+                        "assigned_to_str": "Barbara L. Whelan"
+                    }
                 },
             ),
         ],

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -492,7 +492,7 @@ class ScraperExtractFromText(unittest.TestCase):
                     },
                     "OriginatingCourtInformation": {
                         "assigned_to_str": "Barbara L. Whelan"
-                    }
+                    },
                 },
             ),
         ],


### PR DESCRIPTION
This pull request adds support for extracting lower court information from North Dakota (`nd`) court opinions.

this PR addresses in part -- #1569