### PR TITLE
feat(nj): implement lower court extraction from scraped text

### DIFF
--- a/juriscraper/opinions/united_states/state/nj.py
+++ b/juriscraper/opinions/united_states/state/nj.py
@@ -60,6 +60,43 @@ class Site(OpinionSiteLinear):
 
             self.cases.append(case)
 
+    def extract_from_text(self, scraped_text: str) -> dict:
+        """Extract lower court from the scraped text.
+
+        :param scraped_text: The text to extract from.
+        :return: A dictionary with the metadata.
+        """
+        pattern = re.compile(
+            r"""
+            (?:
+                On\s+certification\s+to\s+the\s+
+                |On\s+appeal\s+from\s+the\s+
+                |On\s+petitions\s+for\s+review\s+of\s+a\s+decision\s+of\s+the\s+
+            )
+            (?P<lower_court>[^.]+?)
+            (?=\s*[.,])
+            """,
+            re.X,
+        )
+
+        lower_court = ""
+        if match := pattern.search(scraped_text):
+            lower_court = re.sub(
+                r"\s+", " ", match.group("lower_court")
+            ).strip()
+            if lower_court.lower().strip() == "superior court":
+                lower_court = "New Jersey Superior Court"
+
+        if lower_court:
+            return {
+                "Docket": {
+                    "appeal_from_str": titlecase(lower_court),
+                }
+            }
+
+        return {}
+
+
     def _download_backwards(self, dates: tuple[date]) -> None:
         """Make custom date range request
 

--- a/juriscraper/opinions/united_states/state/njtaxct_p.py
+++ b/juriscraper/opinions/united_states/state/njtaxct_p.py
@@ -1,10 +1,12 @@
 from datetime import datetime
 
+from juriscraper.OpinionSite import OpinionSite
 from juriscraper.opinions.united_states.state import nj
 
 
 class Site(nj.Site):
     first_opinion_date = datetime(2017, 5, 25)
+    extract_from_text = OpinionSite.extract_from_text
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/juriscraper/opinions/united_states/state/njtaxct_u.py
+++ b/juriscraper/opinions/united_states/state/njtaxct_u.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from juriscraper.OpinionSite import OpinionSite
 from juriscraper.opinions.united_states.state import nj
 
 
@@ -7,6 +8,7 @@ class Site(nj.Site):
     # there is 1 opinion for datetime(2011, 5, 3),
     # but then none until Feb 2017
     first_opinion_date = datetime(2011, 5, 3)
+    extract_from_text = OpinionSite.extract_from_text
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -1510,6 +1510,36 @@ class ScraperExtractFromText(unittest.TestCase):
                 },
             )
         ],
+        "juriscraper.opinions.united_states.state.nj": [
+            (
+                "\n                                       3\n                SUPREME COURT OF NEW JERSEY\n              A-1 September Term 2024\n                       089673\n\n\n                        M.A., \n\n                Plaintiff-Respondent, \n\n                          v.\n\n                       J.H.M., \n\n                Defendant-Appellant.\n\n         On appeal from the Superior Court, \n                Appellate Division.\n\n       Argued                      Decided\n   January 7, 2025               May 27, 2025",
+                {
+                    "Docket": {
+                        "appeal_from_str": "New Jersey Superior Court",
+                    }
+                },
+            )
+        ],
+        "juriscraper.opinions.united_states.state.njsuperctappdiv_p": [
+            (
+                "\n                                       3\n                SUPREME COURT OF NEW JERSEY\n              A-1 September Term 2024\n                       089673\n\n\n                        M.A., \n\n                Plaintiff-Respondent, \n\n                          v.\n\n                       J.H.M., \n\n                Defendant-Appellant.\n\n         On appeal from the Superior Court, \n                Appellate Division.\n\n       Argued                      Decided\n   January 7, 2025               May 27, 2025",
+                {
+                    "Docket": {
+                        "appeal_from_str": "New Jersey Superior Court",
+                    }
+                },
+            )
+        ],
+        "juriscraper.opinions.united_states.state.njsuperctappdiv_u": [
+            (
+                "\n                                       3\n                SUPREME COURT OF NEW JERSEY\n              A-1 September Term 2024\n                       089673\n\n\n                        M.A., \n\n                Plaintiff-Respondent, \n\n                          v.\n\n                       J.H.M., \n\n                Defendant-Appellant.\n\n         On appeal from the Superior Court, \n                Appellate Division.\n\n       Argued                      Decided\n   January 7, 2025               May 27, 2025",
+                {
+                    "Docket": {
+                        "appeal_from_str": "New Jersey Superior Court",
+                    }
+                },
+            )
+        ],
     }
 
     def test_extract_from_text(self):


### PR DESCRIPTION
This pull request introduces a new method for extracting lower court information from opinion text for New Jersey state court scrapers.

this PR addresses in part -- #1569