### PR TITLE
feat(pa): add lower court extraction from scraped text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@ Changes:
 - Retrieve lower court information in `neb` #1569
 - Retrieve lower court information in `nm` #1569
 - Retrieve lower court information in `or` #1569
+- Retrieve lower court information in `pa` #1569
 
 Fixes:
 - Fix connappct #1580

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -1575,6 +1575,16 @@ class ScraperExtractFromText(unittest.TestCase):
                 },
             )
         ],
+        "juriscraper.opinions.united_states.state.pa": [
+            (
+                "\n                          [J-62-2024] [MO: McCaffery, J.]\n                   IN THE SUPREME COURT OF PENNSYLVANIA\n                               WESTERN DISTRICT\n\n\n IN THE INTEREST OF: S.W., A MINOR               :     No. 14 WAP 2024\n                                                 :\n                                                 :     Appeal from the Order of the\n APPEAL OF: S.W., MINOR, AND                     :     Superior Court entered March 13,\n ALLEGHENY COUNTY OFFICE OF                      :     2024, at No. 22 WDA 2023,\n CHILDREN, YOUTH AND FAMILIES                    :     Vacating and Remanding the\n                                                 :     Order of the Court of Common Pleas\n                                                 :     Allegheny County Juvenile Division\n                                                 :     entered November 8, 2022, at\n                                                 :     No. CP-02-DP-0000729-2020.\n                                                 :\n                                                 :     ARGUED: October 8, 2024\n\n\n                                CONCURRING OPINION\n\n\nJUSTICE BROBSON                                                DECIDED: APRIL 25, 2025\n       I agree with the Majority insofar as it concludes that the General Assembly’s\n",
+                {
+                    "Docket": {
+                        "appeal_from_str": "Pennsylvania Superior Court",
+                    }
+                },
+            )
+        ],
     }
 
     def test_extract_from_text(self):


### PR DESCRIPTION
This pull request adds support for extracting lower court information from Pennsylvania Supreme Court opinions, aligning the `pa` scraper with similar scrapers for other states.

this PR addresses in part -- #1569