### PR TITLE
fix(sample_caller): rename parameter for clarity in download_content call

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Changes:
 -
 
 Fixes:
--
+- fix download_content call in sample_caller #1619
 
 ## Current
 

--- a/sample_caller.py
+++ b/sample_caller.py
@@ -225,7 +225,7 @@ def scrape_court(
 
         try:
             data = site.download_content(
-                download_url, is_doctor_available=extract_content
+                download_url, doctor_is_available=extract_content
             )
         except BadContentError:
             continue


### PR DESCRIPTION
This pull request addresses a bug in the `sample_caller.py` script by correcting the argument name used in a call to the `download_content` method. This change ensures that the function is called with the correct parameter, preventing potential runtime errors.

this PR addresses -- #1619 