### PR TITLE
feat(haw): implement backscraper

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Features:
 -
 
 Changes:
--
+- add backscraper for haw #1583
 
 Fixes:
 - fix download_content call in sample_caller #1619


### PR DESCRIPTION
This pull request adds a backscraper to the Hawaii Supreme Court (`haw`) opinions scraper, enabling historical data collection by iterating over year and month combinations.

this PR addresses -- #1583