### PR TITLE
fix(cal): rename key in OriginatingCourtInformation for accuracy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Changes:
 
 Fixes:
 - fix download_content call in sample_caller #1619
+- fix `cal` rename key in OriginatingCourtInformation for accuracy #1625
 
 ## Current
 

--- a/juriscraper/opinions/united_states/state/cal.py
+++ b/juriscraper/opinions/united_states/state/cal.py
@@ -70,7 +70,7 @@ class Site(OpinionSiteLinear):
                 result["Docket"]["appeal_from_str"] = lower_court
             if lower_court_number:
                 result["OriginatingCourtInformation"] = {}
-                result["OriginatingCourtInformation"]["lower_court_number"] = (
+                result["OriginatingCourtInformation"]["docket_number"] = (
                     lower_court_number
                 )
 

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -1145,7 +1145,7 @@ class ScraperExtractFromText(unittest.TestCase):
                         "appeal_from_str": "First Appellate District, Division Three"
                     },
                     "OriginatingCourtInformation": {
-                        "lower_court_number": "A164483"
+                        "docket_number": "A164483"
                     },
                 },
             ),


### PR DESCRIPTION
This pull request fixes an issue with the naming of a key in the `OriginatingCourtInformation` dictionary to improve accuracy and consistency. The key `lower_court_number` has been renamed to `docket_number` throughout the codebase and associated tests.
