### PR TITLE
fix(state.init): add ncbizct

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Fixes:
 - fix download_content call in sample_caller #1619
 - fix `cal` rename key in OriginatingCourtInformation for accuracy #1625
 - fix `texbizct` improve error handling for name and citation extraction from titles #1629
+- add `ncbizct` to init #1631
 
 ## Current
 

--- a/juriscraper/opinions/united_states/state/__init__.py
+++ b/juriscraper/opinions/united_states/state/__init__.py
@@ -97,6 +97,7 @@ __all__ = [
     # "moctapp_western",
     "mont",
     "nc",
+    "ncbizct",
     "ncctapp",
     "neb",
     "nebctapp",


### PR DESCRIPTION
Solves #1631.

Someone had deleted the ncbizct entry on the state.__init__ file, so the scraper was not used in prod