### PR TITLE
fix(guam): update URL for Supreme Court Opinions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Features:
 -
 
 Changes:
--
+- update `guam` domain #1635
 
 Fixes:
 - handle different table structures in `uscgcoca` scraper #1526

--- a/juriscraper/opinions/united_states/territories/guam.py
+++ b/juriscraper/opinions/united_states/territories/guam.py
@@ -21,7 +21,7 @@ class Site(OpinionSiteLinear):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.court_id = self.__module__
-        self.url = "https://guamcourts.org/Supreme-Court-Opinions/Supreme-Court-Opinions.asp"
+        self.url = "https://guamcourts.gov/Supreme-Court-Opinions/Supreme-Court-Opinions.asp"
         self.status = "Published"
 
         self._year = date.today().year


### PR DESCRIPTION
This pull request updates the Guam opinions scraper to use the correct domain.

