### PR TITLE
feat(ny): update cleanup_content method and update sample_caller.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,10 +18,10 @@ Features:
 -
 
 Changes:
--
+- update cleanup_content method for `ny` #1637
 
 Fixes:
--
+- cleanup_content method called twice in sample_caller.py
 
 ## Current
 

--- a/juriscraper/opinions/united_states/state/ny.py
+++ b/juriscraper/opinions/united_states/state/ny.py
@@ -156,12 +156,13 @@ class Site(OpinionSiteLinear):
         if not nh3.is_html(html_str):
             return content
 
-        tree = fromstring(html_str)
-        normalized_html = tostring(tree, encoding="unicode", method="html")
-
         # remove a tags
         allowed = set(nh3.ALLOWED_TAGS)
         allowed.discard("a")
 
-        cleaned = nh3.clean(normalized_html, tags=allowed)
-        return cleaned.encode()
+        cleaned = nh3.clean(html_str, tags=allowed)
+
+        tree = fromstring(cleaned)
+        normalized_html = tostring(tree, encoding="unicode", method="html")
+
+        return normalized_html.encode()

--- a/sample_caller.py
+++ b/sample_caller.py
@@ -233,8 +233,6 @@ def scrape_court(
         if test_hashes:
             check_hashes(data, download_url, site)
 
-        data = site.cleanup_content(data)
-
         filename = item["case_names"].lower().replace(" ", "_")[:40]
 
         data, metadata_from_text = extract_doc_content(


### PR DESCRIPTION
Apparently there was an error updating the cleanup_content method of ny.

It seems the error that the content cannot be extracted due to an incorrect extension continues to occur. (https://freelawproject.sentry.io/issues/6621931274/events/67bd32ca9ef54c46a9d1530620eb5d24/events/)

I validated my results with the output of running this script:

`python sample_caller.py -c juriscraper.opinions.united_states.state.nysupct --extract-content --backscrape --backscrape-start=2025/09/20 --backscrape-end=2025/09/20 --save-responses --limit-per-scrape 15`

But it seems there was an error, the `sample_caller.py` script works correctly as it runs the `cleanup_content` method twice, which is incorrect, it runs inside `download_content` in AbstractSite but does it again after it has fetched and cleaned the content. When executing the method a second time on the content without normalizing it, it ended up normalizing it by wrapping it within a div and adding paragraphs to text. e.g., 

- First cleanup_content output: 
`\n\nCastro v Delisa (2025 NY Slip Op 51531(U))\n\n\n\n\n[*1]\n<table>...</table>`
- Second cleanup_content output using first output: 
```
<div>
<p>Castro v Delisa (2025 NY Slip Op 51531(U))\n\n\n\n\n[*1]</p>
<table>...</table>
</div>
```

So it worked for `sample_caller.py` but not for a normal execution of the scraper, since there the `cleanup_content` method is only called once.

This PR fixes the problem that `sample_caller` executes the `cleanup_content` method twice and also fixes the `cleanup_content` to first remove tags and then normalize the html to be correctly identified as html by magika.
