### PR TITLE
refactor(tests): remove unnecessary print statements from test cases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@ Changes:
 
 Fixes:
 - fix `mich` and `michctapp` bad docket numbers #1648
+- remove unnecessary print statements from test cases
 
 ## Current
 

--- a/tests/local/test_ScraperExtractFromTextTest.py
+++ b/tests/local/test_ScraperExtractFromTextTest.py
@@ -1661,8 +1661,6 @@ class ScraperExtractFromText(unittest.TestCase):
                 )
             )
             for test_case in test_cases:
-                print(site.extract_from_text(test_case[0]))
-                print(test_case[1])
                 self.assertEqual(
                     site.extract_from_text(test_case[0]), test_case[1]
                 )


### PR DESCRIPTION
This pull request focuses on cleaning up the test code by removing unnecessary print statements, which helps keep the test output clean and focused on actual test results.
