### PR TITLE
feat(acms): Adds helper to normalize attachment numbers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ The following changes are not yet released, but are code complete:
 * Add scrapers for Texas Supreme Court, Court of Criminal Appeals, and Courts of Appeal
 
 Features:
--
+- Adds helper to normalize attachment numbers for ACMS uploads #1744
 
 Changes:
 -

--- a/juriscraper/pacer/acms_attachment_page.py
+++ b/juriscraper/pacer/acms_attachment_page.py
@@ -69,6 +69,30 @@ class ACMSAttachmentPage(BaseReport):
         # Extract description before format extension
         return parts[-1].split(".")[0]
 
+    def _parse_attachment_number(self, value: str) -> int:
+        """
+        Parse an ACMS attachment number into its integer form.
+
+        Based on observed ACMS data, attachment numbers are represented as
+        either:
+            - A single integer (e.g., "2")
+            - A dotted notation where the attachment number appears after the
+          dot (e.g., "3.1", "3.2")
+
+        This helper encapsulates the normalization logic so we can work
+        with a consistent integer representation regardless of the input
+        format.
+
+        Examples:
+            '2'   -> 2
+            '3.1' -> 1
+            '3.2' -> 2
+        """
+        if "." in value:
+            _, attachment = value.split(".", 1)
+            return int(attachment)
+        return int(value)
+
     def check_validity(self, parsed_json: dict) -> None:
         """Place sanity checks here to make sure that the returned json is
         valid and not an error page or some other kind of problem.
@@ -178,7 +202,9 @@ class ACMSAttachmentPage(BaseReport):
         for row in self._acms_json["docketEntryDocuments"]:
             result["attachments"].append(
                 {
-                    "attachment_number": int(row["documentNumber"]),
+                    "attachment_number": self._parse_attachment_number(
+                        row["documentNumber"]
+                    ),
                     "description": self._clean_attachment_description(
                         row["name"]
                     ),

--- a/tests/examples/pacer/appellate_attachment_pages/acms/ca2-25-2936-014.compare.json
+++ b/tests/examples/pacer/appellate_attachment_pages/acms/ca2-25-2936-014.compare.json
@@ -1,0 +1,121 @@
+{
+  "caseDetails": {
+    "caseId": "58b3d35f-b781-4164-b7c6-26f068ad2e86",
+    "caseNumber": "25-2936",
+    "originatingCaseNumber": "1:24-cr-365-1",
+    "caseFormType": "Appeal",
+    "name": "United States of America v. Adams",
+    "caseOpened": "2025-11-18T00:00:00",
+    "aNumber": null,
+    "receivedDate": "2025-11-18T15:40:36Z",
+    "decisionDate": null,
+    "partyAttorneyList": "<table width='100%'><tr><td width='30%' style='padding-bottom: 20px; white-space: normal; overflow-wrap: break-word;'> UNITED STATES OF AMERICA<br>&nbsp;&nbsp;&nbsp;&nbsp;Appellee </td><td style='padding-bottom: 20px;'><div style='margin-bottom: 10px'>Patrick Ryan Moroney, -<br>Direct: 212-637-2330<br>[US Attorney]<br>United States Attorney's Office for the Southern District of New York<br>One St. Andrew's Plaza<br>New York, NY 10007</div><div style='margin-bottom: 10px'>Alexandra S. Messiter, -<br>Direct: 212-637-2544<br>[US Attorney]<br>United States Attorney's Office for the Southern District of New York<br>26 Federal Plaza<br>New York, NY 10278</div><div style='margin-bottom: 10px'>Nathan Rehn, -<br>Direct: 212-637-2354<br>[US Attorney]<br>United States Attorney's Office for the Southern District of New York<br>26 Federal Plaza<br>37th Floor<br>New York, NY 10278</div></td></tr><tr><td width='30%' style='padding-bottom: 20px; white-space: normal; overflow-wrap: break-word;'> KAREEM ADAMS<br>&nbsp;&nbsp;&nbsp;&nbsp;Defendant - Appellant </td><td style='padding-bottom: 20px;'><div style='margin-bottom: 10px'>Elizabeth Latif, -<br>Direct: 860-996-1723<br>[CJA Appointment]<br>Law Offices of Elizabeth A. Latif PLLC<br>1022 Boulevard<br>Suite 272<br>West Hartford, CT 06119</div><div style='margin-bottom: 10px'>Sarah M. Sacks, -<br><strong>Terminated:</strong> 12/09/2025<br>Direct: 212-684-1230<br>[CJA Appointment]<br>Epstein Sacks PLLC<br>100 Lafayette Street<br>Suite 502<br>Suite 502<br>New York, NY 10023</div></td></tr></table>",
+    "shortCaption": "United States of America,<br />\r\n<br />\r\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Appellee,<br />\r\n<br />\r\n&nbsp;&nbsp; v.<br />\r\n<br />\r\nKareem Adams,<br />\r\n<br />\r\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Defendant - Appellant.",
+    "court": {
+      "name": "SDNY (NEW YORK CITY)",
+      "abbreviatedName": "SDNY (NEW YORK CITY)"
+    },
+    "caseType": "Criminal",
+    "caseSubType": "Direct Criminal",
+    "caseSubSubType": null,
+    "districtCourtName": null,
+    "feeStatus": "IFP Granted",
+    "byteCount": 1964,
+    "originatingCasesInformation": [
+      {
+        "sequenceNumber": 1,
+        "originCaseNumber": "1:24-cr-365-1",
+        "pacerDocketUrl": "https://ecf.nysd.uscourts.gov/cgi-bin/DktRpt.pl?caseNumber=1:24-cr-365-1",
+        "dateFiled": "2024-06-06T00:00:00",
+        "judgmentDate": "2025-11-12T00:00:00",
+        "dateJudgmentEod": "2025-11-12T00:00:00",
+        "dateNoaReceivedCoa": "2025-11-18T00:00:00",
+        "noticeOfAppealFiled": "2025-11-18T00:00:00",
+        "abbreviatedName": "SDNY (NEW YORK CITY)",
+        "originatingCasePeople": [
+          {
+            "firstName": "George",
+            "middleName": "B.",
+            "lastName": "Daniels",
+            "jobTitle": "Senior District Judge",
+            "roleName": "Trial Judge",
+            "fullName": "George B. Daniels, Senior District Judge"
+          }
+        ]
+      }
+    ],
+    "natureOfSuit": null,
+    "associatedCases": []
+  },
+  "docketEntry": {
+    "endDate": "2025-12-05T00:00:00",
+    "endDateFormatted": "12/5/2025",
+    "entryNumber": 14,
+    "docketEntryText": "<p>MOTION, to be relieved as counsel, on behalf of Appellant Kareem Adams, FILED.&nbsp;Service date 12/05/2025 by ACMS. [Entered: 12/05/2025 05:00 PM]</p>",
+    "docketEntryId": "4feeb0c6-25d2-f011-8544-001dd808439e",
+    "createdOn": "2025-12-05T22:00:15Z",
+    "documentCount": 3,
+    "pageCount": 4,
+    "fileSize": 1031,
+    "allDocumentsReady": true,
+    "restrictedPartyFilingDocketEntry": false,
+    "restrictedDocsAvailable": false,
+    "selected": false
+  },
+  "docketEntryDocuments": [
+    {
+      "docketDocumentDetailsId": "4c232279-24d2-f011-ad8e-001dd804bd4c",
+      "name": "25-2936 014-01 - Motion FILED - T-1080 Form.pdf",
+      "documentUrl": "https://ca02.sharepoint.com/sites/ACMS-001/Docket/25-2936 - 014 - Motion FILED/25-2936 014-01 - Motion FILED - T-1080 Form.pdf",
+      "caseFilingDocumentUrl": "https://ca02.sharepoint.com/sites/ACMS-001/CaseFiling/25-2936 - 014 - Motion FILED/25-2936 014-01 - Motion FILED - T-1080 Form.pdf",
+      "documentPermission": "Public",
+      "pageCount": 1,
+      "fileSize": 319,
+      "createdOn": "2025-12-05T21:50:55Z",
+      "billablePages": 1,
+      "cost": 0.1,
+      "documentNumber": "14.1",
+      "searchValue": "Case: 25-2936, Document: 14.1",
+      "docketEntryCreatedOn": "2025-12-05T22:00:15Z",
+      "searchTransaction": "Case: 25-2936, Document: 14.1",
+      "pacerBillingDescription": null,
+      "selected": true
+    },
+    {
+      "docketDocumentDetailsId": "ceb42e88-24d2-f011-ad8e-001dd804bd4c",
+      "name": "25-2936 014-02 - Motion FILED - Affidavit.pdf",
+      "documentUrl": "https://ca02.sharepoint.com/sites/ACMS-001/Docket/25-2936 - 014 - Motion FILED/25-2936 014-02 - Motion FILED - Affidavit.pdf",
+      "caseFilingDocumentUrl": "https://ca02.sharepoint.com/sites/ACMS-001/CaseFiling/25-2936 - 014 - Motion FILED/25-2936 014-02 - Motion FILED - Affidavit.pdf",
+      "documentPermission": "Public",
+      "pageCount": 2,
+      "fileSize": 512,
+      "createdOn": "2025-12-05T21:51:20Z",
+      "billablePages": 2,
+      "cost": 0.2,
+      "documentNumber": "14.2",
+      "searchValue": "Case: 25-2936, Document: 14.2",
+      "docketEntryCreatedOn": "2025-12-05T22:00:15Z",
+      "searchTransaction": "Case: 25-2936, Document: 14.2",
+      "pacerBillingDescription": null,
+      "selected": true
+    },
+    {
+      "docketDocumentDetailsId": "ba1fb5b9-25d2-f011-ad8e-001dd804bd4c",
+      "name": "25-2936 014-03 - Motion FILED - Service.pdf",
+      "documentUrl": "https://ca02.sharepoint.com/sites/ACMS-001/Docket/25-2936 - 014 - Motion FILED/25-2936 014-03 - Motion FILED - Service.pdf",
+      "caseFilingDocumentUrl": "https://ca02.sharepoint.com/sites/ACMS-001/CaseFiling/25-2936 - 014 - Motion FILED/25-2936 014-03 - Motion FILED - Service.pdf",
+      "documentPermission": "Public",
+      "pageCount": 1,
+      "fileSize": 200,
+      "createdOn": "2025-12-05T21:59:53Z",
+      "billablePages": 1,
+      "cost": 0.1,
+      "documentNumber": "14.3",
+      "searchValue": "Case: 25-2936, Document: 14.3",
+      "docketEntryCreatedOn": "2025-12-05T22:00:15Z",
+      "searchTransaction": "Case: 25-2936, Document: 14.3",
+      "pacerBillingDescription": null,
+      "selected": true
+    }
+  ]
+}

--- a/tests/examples/pacer/appellate_attachment_pages/acms/ca2-25-2936-014.json
+++ b/tests/examples/pacer/appellate_attachment_pages/acms/ca2-25-2936-014.json
@@ -1,0 +1,43 @@
+{
+  "pacer_doc_id": "4feeb0c6-25d2-f011-8544-001dd808439e",
+  "pacer_case_id": "58b3d35f-b781-4164-b7c6-26f068ad2e86",
+  "entry_number": 14,
+  "description": "MOTION, to be relieved as counsel, on behalf of Appellant Kareem Adams, FILED. Service date 12/05/2025 by ACMS. [Entered: 12/05/2025 05:00 PM]",
+  "date_filed": "2025-12-05",
+  "date_end": "2025-12-05",
+  "attachments": [
+    {
+      "attachment_number": 1,
+      "description": "T-1080 Form",
+      "page_count": 1,
+      "pacer_doc_id": "4feeb0c6-25d2-f011-8544-001dd808439e",
+      "acms_document_guid": "4c232279-24d2-f011-ad8e-001dd804bd4c",
+      "cost": 0.1,
+      "date_filed": "2025-12-05",
+      "permission": "Public",
+      "file_size": 319
+    },
+    {
+      "attachment_number": 2,
+      "description": "Affidavit",
+      "page_count": 2,
+      "pacer_doc_id": "4feeb0c6-25d2-f011-8544-001dd808439e",
+      "acms_document_guid": "ceb42e88-24d2-f011-ad8e-001dd804bd4c",
+      "cost": 0.2,
+      "date_filed": "2025-12-05",
+      "permission": "Public",
+      "file_size": 512
+    },
+    {
+      "attachment_number": 3,
+      "description": "Service",
+      "page_count": 1,
+      "pacer_doc_id": "4feeb0c6-25d2-f011-8544-001dd808439e",
+      "acms_document_guid": "ba1fb5b9-25d2-f011-ad8e-001dd804bd4c",
+      "cost": 0.1,
+      "date_filed": "2025-12-05",
+      "permission": "Public",
+      "file_size": 200
+    }
+  ]
+}

--- a/tests/examples/pacer/appellate_attachment_pages/acms/ca9-25-6348-004.compare.json
+++ b/tests/examples/pacer/appellate_attachment_pages/acms/ca9-25-6348-004.compare.json
@@ -1,0 +1,103 @@
+{
+  "caseDetails": {
+    "caseId": "393c4b0f-44e6-47d8-b4a3-bec74aaae012",
+    "caseNumber": "25-6348",
+    "originatingCaseNumber": "3:25-mc-80278-SK",
+    "caseFormType": "Appeal",
+    "name": "Stebbins v. Unknown Party",
+    "caseOpened": "2025-10-08T00:00:00",
+    "aNumber": null,
+    "receivedDate": "2025-10-08T12:03:15Z",
+    "decisionDate": null,
+    "partyAttorneyList": "<table width='100%'><tr><td width='30%' style='padding-bottom: 20px; white-space: normal; overflow-wrap: break-word;'> DAVID ANTHONY STEBBINS<br>&nbsp;&nbsp;&nbsp;&nbsp;Petitioner - Appellant </td><td style='padding-bottom: 20px;'><div>Mr. David Anthony Stebbins<br>[Pro Se]<br>Direct: 870-212-4947<br>Email: acerthorn@yahoo.com<br>123 W Ridge Avenue<br>Apt. D<br>Harrison, AR 72601</div><div><p>&nbsp;</p></div></td></tr><tr><td width='30%' style='padding-bottom: 20px; white-space: normal; overflow-wrap: break-word;'> UNKNOWN PARTY<br>&nbsp;&nbsp;&nbsp;&nbsp;Respondent - Appellee </td><td style='padding-bottom: 20px;'></td></tr></table>",
+    "shortCaption": "Mr. DAVID ANTHONY STEBBINS,<br />\r\n<br />\r\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Petitioner - Appellant,<br />\r\n<br />\r\n&nbsp;&nbsp; v.<br />\r\n<br />\r\nUNKNOWN PARTY,<br />\r\n<br />\r\n&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; Respondent - Appellee.",
+    "court": {
+      "name": "San Francisco, Northern California",
+      "abbreviatedName": "Northern District of California"
+    },
+    "caseType": "Civil",
+    "caseSubType": "Private",
+    "caseSubSubType": null,
+    "districtCourtName": null,
+    "feeStatus": "IFP Pending in COA",
+    "byteCount": 1069,
+    "originatingCasesInformation": [
+      {
+        "sequenceNumber": 1,
+        "originCaseNumber": "3:25-mc-80278-SK",
+        "pacerDocketUrl": "https://ecf.cand.uscourts.gov/cgi-bin/DktRpt.pl?caseNumber=3:25-mc-80278-SK",
+        "dateFiled": "2025-09-15T00:00:00",
+        "judgmentDate": "2025-09-30T00:00:00",
+        "dateJudgmentEod": "2025-09-30T00:00:00",
+        "dateNoaReceivedCoa": "2025-10-06T00:00:00",
+        "noticeOfAppealFiled": "2025-10-06T00:00:00",
+        "abbreviatedName": "Northern District of California",
+        "originatingCasePeople": [
+          {
+            "firstName": "Sallie",
+            "middleName": "",
+            "lastName": "Kim",
+            "jobTitle": "Magistrate Judge",
+            "roleName": "Trial Judge",
+            "fullName": "Sallie Kim, Magistrate Judge"
+          }
+        ]
+      }
+    ],
+    "natureOfSuit": "3890 Other Statutory Actions",
+    "associatedCases": []
+  },
+  "docketEntry": {
+    "endDate": "2025-10-30T00:00:00",
+    "endDateFormatted": "10/30/2025",
+    "entryNumber": 4,
+    "docketEntryText": "<p><strong>ORDER FILED.</strong> It appears that this appeal may be frivolous. If the appeal is frivolous, the court will deny permission to proceed in forma pauperis and dismiss the appeal. See 28 U.S.C. § 1915(e)(2).<br>\nWithin 35 days, appellant must: (1) file a statement explaining why the appeal is not frivolous, OR (2) file a motion to voluntarily dismiss the appeal, see Fed. R. App. P. 42(b).<br>\nIf appellant files a statement explaining why the appeal is not frivolous, or any other response other than a motion to dismiss, the court will determine whether the appeal is frivolous. If it is frivolous, the appeal will be dismissed. If it is not frivolous, the appeal will proceed.<br>\nBriefing is stayed.<br>\nIf appellant does not respond to this order, the court may dismiss this appeal without further notice.<br>\nThe clerk will serve on appellant: (1) a form motion to voluntarily dismiss the appeal, and (2) a form statement that the appeal should go forward. [Entered: 10/30/2025 09:47 AM]</p>",
+    "docketEntryId": "32630b21-b0b5-f011-bbd3-001dd80b194b",
+    "createdOn": "2025-10-30T16:47:36Z",
+    "documentCount": 2,
+    "pageCount": 6,
+    "fileSize": 352,
+    "allDocumentsReady": true,
+    "restrictedPartyFilingDocketEntry": false,
+    "restrictedDocsAvailable": false,
+    "selected": false
+  },
+  "docketEntryDocuments": [
+    {
+      "docketDocumentDetailsId": "bca0e4b4-afb5-f011-bbd3-001dd80b194b",
+      "name": "25-6348 004-01 - Order - Order to Show Cause (OSC) - Order.pdf",
+      "documentUrl": "https://ca9.sharepoint.com/sites/ACMS/Docket/25-6348 - 004 - Order - Order to Show Cause (OSC)/25-6348 004-01 - Order - Order to Show Cause (OSC) - Order.pdf",
+      "caseFilingDocumentUrl": "https://ca9.sharepoint.com/sites/ACMS/CaseFiling/25-6348 - 004 - Order - Order to Show Cause (OSC)/25-6348 004-01 - Order - Order to Show Cause (OSC) - Order.pdf",
+      "documentPermission": "Public",
+      "pageCount": 2,
+      "fileSize": 224,
+      "createdOn": "2025-10-30T16:44:36Z",
+      "billablePages": 2,
+      "cost": 0.2,
+      "documentNumber": "4.1",
+      "searchValue": "Case: 25-6348, Document: 4.1",
+      "docketEntryCreatedOn": "2025-10-30T16:47:36Z",
+      "searchTransaction": "Case: 25-6348, Document: 4.1",
+      "pacerBillingDescription": null,
+      "selected": true
+    },
+    {
+      "docketDocumentDetailsId": "67d1e9cc-afb5-f011-bbd3-001dd80b194b",
+      "name": "25-6348 004-02 - Order - Order to Show Cause (OSC) - Order.pdf",
+      "documentUrl": "https://ca9.sharepoint.com/sites/ACMS/Docket/25-6348 - 004 - Order - Order to Show Cause (OSC)/25-6348 004-02 - Order - Order to Show Cause (OSC) - Order.pdf",
+      "caseFilingDocumentUrl": "https://ca9.sharepoint.com/sites/ACMS/CaseFiling/25-6348 - 004 - Order - Order to Show Cause (OSC)/25-6348 004-02 - Order - Order to Show Cause (OSC) - Order.pdf",
+      "documentPermission": "Public",
+      "pageCount": 4,
+      "fileSize": 128,
+      "createdOn": "2025-10-30T16:45:14Z",
+      "billablePages": 4,
+      "cost": 0.4,
+      "documentNumber": "4.2",
+      "searchValue": "Case: 25-6348, Document: 4.2",
+      "docketEntryCreatedOn": "2025-10-30T16:47:36Z",
+      "searchTransaction": "Case: 25-6348, Document: 4.2",
+      "pacerBillingDescription": null,
+      "selected": true
+    }
+  ]
+}

--- a/tests/examples/pacer/appellate_attachment_pages/acms/ca9-25-6348-004.json
+++ b/tests/examples/pacer/appellate_attachment_pages/acms/ca9-25-6348-004.json
@@ -1,0 +1,32 @@
+{
+  "pacer_doc_id": "32630b21-b0b5-f011-bbd3-001dd80b194b",
+  "pacer_case_id": "393c4b0f-44e6-47d8-b4a3-bec74aaae012",
+  "entry_number": 4,
+  "description": "ORDER FILED. It appears that this appeal may be frivolous. If the appeal is frivolous, the court will deny permission to proceed in forma pauperis and dismiss the appeal. See 28 U.S.C. \u00a7 1915(e)(2).\nWithin 35 days, appellant must: (1) file a statement explaining why the appeal is not frivolous, OR (2) file a motion to voluntarily dismiss the appeal, see Fed. R. App. P. 42(b).\nIf appellant files a statement explaining why the appeal is not frivolous, or any other response other than a motion to dismiss, the court will determine whether the appeal is frivolous. If it is frivolous, the appeal will be dismissed. If it is not frivolous, the appeal will proceed.\nBriefing is stayed.\nIf appellant does not respond to this order, the court may dismiss this appeal without further notice.\nThe clerk will serve on appellant: (1) a form motion to voluntarily dismiss the appeal, and (2) a form statement that the appeal should go forward. [Entered: 10/30/2025 09:47 AM]",
+  "date_filed": "2025-10-30",
+  "date_end": "2025-10-30",
+  "attachments": [
+    {
+      "attachment_number": 1,
+      "description": "25-6348 004-01 - Order - Order to Show Cause (OSC) - Order.pdf",
+      "page_count": 2,
+      "pacer_doc_id": "32630b21-b0b5-f011-bbd3-001dd80b194b",
+      "acms_document_guid": "bca0e4b4-afb5-f011-bbd3-001dd80b194b",
+      "cost": 0.2,
+      "date_filed": "2025-10-30",
+      "permission": "Public",
+      "file_size": 224
+    },
+    {
+      "attachment_number": 2,
+      "description": "25-6348 004-02 - Order - Order to Show Cause (OSC) - Order.pdf",
+      "page_count": 4,
+      "pacer_doc_id": "32630b21-b0b5-f011-bbd3-001dd80b194b",
+      "acms_document_guid": "67d1e9cc-afb5-f011-bbd3-001dd80b194b",
+      "cost": 0.4,
+      "date_filed": "2025-10-30",
+      "permission": "Public",
+      "file_size": 128
+    }
+  ]
+}


### PR DESCRIPTION
This PR introduces a new helper function to normalize ACMS attachment numbers.

Recent changes in the ACMS website have altered how attachment numbers are represented, they're using now dotted notation (e.g., "3.1", "3.2"). The upcoming version of the RECAP extension will need this normalization logic to correctly handle attachment uploads. 

This helper is designed to preserve backwards compatibility by continuing to support the previous attachment number format. This approach ensures we can safely handle both legacy and newer formats without breaking the parser.

This PR also adds examples from CA2 and CA9 to validate and test the new parsing logic.