### PR TITLE
version bump v2.8.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,17 @@ Features:
 -
 
 Changes:
+-
+
+Fixes:
+-
+
+## 2.8.2 - 2026-03-02
+
+Features:
+-
+
+Changes:
 - OpinionSite can now return a "content" key holding downloaded content #873
 
 Fixes:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires = [
 
 [project]
 name = "juriscraper"
-version = "2.8.1"
+version = "2.8.2"
 description = "An API to scrape American court websites for metadata."
 readme = "README.rst"
 keywords = [ "scraping", "legal", "pacer" ]

--- a/uv.lock
+++ b/uv.lock
@@ -307,7 +307,7 @@ wheels = [
 
 [[package]]
 name = "juriscraper"
-version = "2.8.1"
+version = "2.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "certifi", version = "2025.4.26", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
## Summary
- Bump version from 2.8.1 to 2.8.2
- Move "Coming up" entries to new release section in CHANGES.md
- Sync lockfile with `uv sync`