### PR TITLE
fix(idaho): correct content types and reduce scrape window

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Changes:
 
 Fixes:
 - Fix `nmariana` neutral citations to use spaces instead of dashes (e.g. `2022 MP 09` instead of `2022-MP-09`) so eyecite/reporters-db can parse them. #1947
+- Fix `idaho` scrapers expected_content_types attribute and reduce regular scrape page_size #1949
 
 ## 3.0.16 - 2026-05-04
 

--- a/juriscraper/opinions/united_states/state/idaho_civil.py
+++ b/juriscraper/opinions/united_states/state/idaho_civil.py
@@ -35,7 +35,10 @@ class Site(OpinionSiteLinear):
     is_per_curiam = False
 
     # API caps server-side at 100; daily scrape only needs the first page
-    page_size = 100
+    # Since every scrape makes `page_size` secondary requests, let's limit
+    # this value according to the expected volume. Published opinions will
+    # have a smaller volume
+    page_size = 10
     days_interval = 30
     first_opinion_date = datetime(2010, 1, 1)
 
@@ -169,6 +172,7 @@ class Site(OpinionSiteLinear):
         self._back_start = start
         self._back_done = False
         cursor = ""
+        self.page_size = 100  # set page size to max
 
         while not self._back_done:
             self.url = self._build_list_url("DESC", cursor)

--- a/juriscraper/opinions/united_states/state/idahoctapp_u.py
+++ b/juriscraper/opinions/united_states/state/idahoctapp_u.py
@@ -4,3 +4,4 @@ from juriscraper.opinions.united_states.state import idaho_civil
 class Site(idaho_civil.Site):
     category = "ICA Unpublished"
     default_status = "Unpublished"
+    page_size = 20

--- a/juriscraper/opinions/united_states/state/idahoctapp_u_per_curiam.py
+++ b/juriscraper/opinions/united_states/state/idahoctapp_u_per_curiam.py
@@ -5,3 +5,4 @@ class Site(idaho_civil.Site):
     category = "ICA Unpublished Per Curiam"
     default_status = "Unpublished"
     is_per_curiam = True
+    page_size = 15


### PR DESCRIPTION
Fixes #1949

Content types was incorrectly set to JSON, so all document downloads were failing

Also, reduce regular scrape page_size, since it executed 1 + page_size requests on each hourly scrape