### PR TITLE
fix(idaho): delete content types to defaul to pdf

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,7 +22,7 @@ Changes:
 -
 
 Fixes:
--
+- Fix `idaho` scrapers expected_content_types attribute #1949
 
 ## 3.0.17 - 2026-05-06
 

--- a/juriscraper/opinions/united_states/state/idaho_civil.py
+++ b/juriscraper/opinions/united_states/state/idaho_civil.py
@@ -47,7 +47,6 @@ class Site(OpinionSiteLinear):
         self.court_id = self.__module__
         self.status = self.default_status
         self.url = self._build_list_url("DESC")
-        self.expected_content_types = ["application/json"]
         self.should_have_results = True
         self._back_start: date | None = None
         self._back_done = False


### PR DESCRIPTION
Should have been solved in #1950, but seems like I didnt commit the change