### PR TITLE
fix(nj): use needs_special_headers and browser user agent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,10 @@ Changes:
 -
 
 Fixes:
--
+- New Jersey opinion scrapers (`nj`, `njsuperctappdiv_p`, `njsuperctappdiv_u`,
+  `njtaxct_p`, `njtaxct_u`) were 403'd by the Imperva WAF on njcourts.gov.
+  Set a browser User-Agent and `needs_special_headers = True` so both the
+  index pages and the opinion PDFs download. #1965
 
 ## 3.0.19 - 2026-05-19
 

--- a/juriscraper/opinions/united_states/state/nj.py
+++ b/juriscraper/opinions/united_states/state/nj.py
@@ -20,6 +20,13 @@ class Site(OpinionSiteLinear):
         self.status = "Published"
         self.make_backscrape_iterable(kwargs)
         self.should_have_results = True
+        # Imperva WAF blocks the default UA on both the index pages and the
+        # opinion PDFs, so the override must also apply to content downloads.
+        self.needs_special_headers = True
+        self.request["headers"]["User-Agent"] = (
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
+        )
 
     def _process_html(self) -> None:
         """Process the html and extract out the opinions


### PR DESCRIPTION
Fixes #1965

Scraper was blocked due to our user agent

(I needed a US VPN to test this)