### PR TITLE
fix(or): add 1 second sleep on each detail request

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,7 @@ Fixes:
   `njtaxct_p`, `njtaxct_u`) were 403'd by the Imperva WAF on njcourts.gov.
   Set a browser User-Agent and `needs_special_headers = True` so both the
   index pages and the opinion PDFs download. #1965
+- Add a sleep to fullfil Oregon courts required crawl delay #1968
 
 ## 3.0.19 - 2026-05-19
 

--- a/juriscraper/opinions/united_states/state/or.py
+++ b/juriscraper/opinions/united_states/state/or.py
@@ -6,6 +6,7 @@ History:
  - 2025-09-23: add lower court extraction, luism
 """
 
+import asyncio
 import re
 from datetime import datetime, timedelta
 
@@ -28,7 +29,12 @@ class Site(OpinionSiteLinear):
         self.make_backscrape_iterable(kwargs)
 
     async def _process_html(self):
-        for row in self.html["items"]:
+        for i, row in enumerate(self.html["items"]):
+            # Honor robots.txt Crawl-Delay: 1 advertised by
+            # cdm17027.contentdm.oclc.org. # 1968
+            if i and not self.test_mode_enabled():
+                await asyncio.sleep(1)
+
             docket, name, citation, date = (
                 x["value"] for x in row["metadataFields"]
             )


### PR DESCRIPTION
Fixes #1968

or scrapers have been failing with a ReadError from the server closing the connection. This seems to be related to rate limiting. The site's robots.txt has a "Crawl-Delay:1" setting, which we are now fulfilling