### PR TITLE
fix(ny): preserve html document envelope in cleanup_content

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,8 @@ Changes:
 -
 
 Fixes:
--
+- `ny.Site.cleanup_content` wraps output in an html document envelope so
+  doctor doesn't misclassify cleaned pages as `text/plain`. #1971
 
 ## 3.0.20 - 2026-05-21
 

--- a/juriscraper/opinions/united_states/state/ny.py
+++ b/juriscraper/opinions/united_states/state/ny.py
@@ -232,9 +232,16 @@ class Site(OpinionSiteLinear):
         cleaned = nh3.clean(html_str, tags=allowed)
 
         tree = fromstring(cleaned)
-        normalized_html = tostring(tree, encoding="unicode", method="html")
+        normalized_html = str(
+            tostring(tree, encoding="unicode", method="html")
+        )
 
-        return normalized_html.encode()
+        # nh3.clean strips <!DOCTYPE>/<html>/<body> (not in nh3.ALLOWED_TAGS),
+        # which makes downstream content-based detectors (magika via doctor)
+        # misclassify the result as text/plain and skip the HTML extractor.
+        return (
+            f"<!DOCTYPE html><html><body>{normalized_html}</body></html>"
+        ).encode()
 
     @staticmethod
     def clean_docket_match(match: re.Match) -> str:


### PR DESCRIPTION
## Summary

Fixes #1971.

`Site.cleanup_content` in `juriscraper/opinions/united_states/state/ny.py` now wraps the post-`nh3.clean` / lxml-roundtripped fragment in `<!DOCTYPE html><html><body>...</body></html>` before returning.

`nh3.ALLOWED_TAGS` does not include `html`, `head`, or `body`, so `nh3.clean(html_str, tags=allowed)` was stripping the document envelope and leaving downstream content-based detectors (Magika via the FLP `doctor` microservice) to classify the result as `text/plain`. As a consequence `doctor`'s `/extract/doc/text/` dispatched to `extract_from_txt` instead of `extract_from_html`, and `juriscraper.lib.microservices_utils.test_for_meta_redirections` silently skipped meta-refresh handling on cleaned NY pages.

Re-adding a minimal document envelope restores the `.html` classification without changing what `nh3.clean` is meant to sanitize.