### PR TITLE
fix(minn): respect robots.txt and handle captcha page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Changes:
 
 Fixes:
 - `guam`: scrape current-year opinions from the new page; the legacy endpoint stopped getting updated mid-year and missed the newest opinions. Backscraping still uses the legacy endpoint for 2025 and prior #2004
+- `minn`/`minnctapp_p`/`minnctapp_u`: mn.gov is fronted by Radware Bot Manager, which served a captcha page when the back-to-back scrapers tripped its rate limit. The captcha page has no results, so opinions were silently dropped (`minnctapp` stuck since April 7). Now adds a pre-request delay to respect the site's rate limit, only scrapes within the `Visit-time: 0000-1200` GMT window allowed by robots.txt (aborts the run otherwise), and raises `BotChallengeError` if a captcha page is still served instead of failing silently. Also, scrapers are no longer listed one after the other in `state.__init__.__all__` which will make them execute separately #2006
 
 
 ## 3.0.25 - 2026-06-15

--- a/juriscraper/lib/exceptions.py
+++ b/juriscraper/lib/exceptions.py
@@ -130,3 +130,14 @@ class MergingError(AutoLoggingException):
     """Raised when metadata merging finds different values"""
 
     logging_level = logging.ERROR
+
+
+class BotChallengeError(AutoLoggingException):
+    """Raised when the source serves a bot/captcha challenge page instead
+    of the expected content (e.g. Radware Bot Manager, Cloudflare).
+
+    Raising loudly prevents silently ingesting zero results, which would
+    otherwise look like a successful scrape with no new opinions.
+    """
+
+    logging_level = logging.ERROR

--- a/juriscraper/opinions/united_states/state/__init__.py
+++ b/juriscraper/opinions/united_states/state/__init__.py
@@ -86,14 +86,14 @@ __all__ = [
     # court's website.
     "me",
     "mesuperct",
-    # separting minn scrapers to prevent hitting rate limits
+    # separating minn scrapers to prevent hitting rate limits
     "minn",
     "mich",
     "michctapp",
     "minnag",
     "miss",
     "missctapp",
-    # separting minn scrapers to prevent hitting rate limits
+    # separating minn scrapers to prevent hitting rate limits
     "minnctapp_p",
     # These courts are uploaded via portal by amazing volunteers.
     # "mo",
@@ -104,7 +104,7 @@ __all__ = [
     "nc",
     "ncbizct",
     "ncctapp",
-    # separting minn scrapers to prevent hitting rate limits
+    # separating minn scrapers to prevent hitting rate limits
     "minnctapp_u",
     "neb",
     "nebctapp",

--- a/juriscraper/opinions/united_states/state/__init__.py
+++ b/juriscraper/opinions/united_states/state/__init__.py
@@ -86,14 +86,15 @@ __all__ = [
     # court's website.
     "me",
     "mesuperct",
+    # separting minn scrapers to prevent hitting rate limits
+    "minn",
     "mich",
     "michctapp",
-    "minn",
     "minnag",
-    "minnctapp_p",
-    "minnctapp_u",
     "miss",
     "missctapp",
+    # separting minn scrapers to prevent hitting rate limits
+    "minnctapp_p",
     # These courts are uploaded via portal by amazing volunteers.
     # "mo",
     # "moctapp_eastern",
@@ -103,6 +104,8 @@ __all__ = [
     "nc",
     "ncbizct",
     "ncctapp",
+    # separting minn scrapers to prevent hitting rate limits
+    "minnctapp_u",
     "neb",
     "nebctapp",
     "nd",

--- a/juriscraper/opinions/united_states/state/minn.py
+++ b/juriscraper/opinions/united_states/state/minn.py
@@ -9,10 +9,12 @@
 # 2024-08-09: update and implement backscraper, grossir
 
 import re
-from datetime import date
+from datetime import date, datetime, timezone
 from urllib.parse import urljoin
 
 from juriscraper.AbstractSite import logger
+from juriscraper.lib.exceptions import BotChallengeError
+from juriscraper.lib.network_utils import add_delay
 from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
@@ -20,6 +22,11 @@ class Site(OpinionSiteLinear):
     court_query = "supct"
     days_interval = 7
     first_opinion_date = date(1998, 1, 1)
+
+    base_url = "https://mn.gov/law-library/search/"
+    # Seconds to wait before querying, to space out the shared-source scrapers
+    # and respect the site's `Request-rate` (see robots.txt). See #2006
+    request_delay = 5
 
     def __init__(self, *args, **kwargs):
         kwargs.setdefault("verify", False)
@@ -30,12 +37,13 @@ class Site(OpinionSiteLinear):
         if self.court_query == "ctapun":
             self.status = "Unpublished"
 
-        self.url = "https://mn.gov/law-library/search/"
+        self.url = self.base_url
         self.params = self.base_params = {
             "v:sources": "mn-law-library-opinions",
             "query": f" (url:/archive/{self.court_query}) ",
             "sortby": "date",
         }
+
         self.request["headers"] = {
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             "Sec-Fetch-Site": "same-origin",
@@ -55,7 +63,21 @@ class Site(OpinionSiteLinear):
 
         :return: None
         """
+        # parse() issues an initial _download() (no query params). If that was
+        # skipped because we are out of the visit window, self.html is None and
+        # we abort without issuing the query.
+        if self.html is None:
+            return
+
+        # Pause before the actual query to respect the site's rate limit.
+        if not self.test_mode_enabled():
+            await add_delay(self.request_delay, deviation=2)
         self.html = await self._download({"params": self.params})
+
+        if self.html is None:
+            return
+
+        self._check_for_bot_challenge()
 
         # This warning is useful for backscraping
         results_number = self.html.xpath(
@@ -132,3 +154,55 @@ class Site(OpinionSiteLinear):
             }
         )
         self.params = params
+        self.html = await self._download()
+        await self._process_html()
+
+    def _within_visit_window(self) -> bool:
+        """Whether we are inside the crawl window the site's robots.txt allows.
+
+        mn.gov's robots.txt declares ``Visit-time: 0000-1200`` (in GMT), i.e.
+        crawling is only welcome between midnight and noon UTC. Scraping
+        outside that window is part of what gets us flagged by the bot
+        manager. Always True in test mode. See #2006.
+
+        :return: True if the current UTC time is within the allowed window
+        """
+        if self.test_mode_enabled():
+            return True
+        return datetime.now(timezone.utc).hour < 12
+
+    async def _download(self, request_dict=None):
+        """Skip the request entirely when outside the robots.txt visit window.
+
+        Returning None aborts the scrape gracefully: ``parse()`` leaves
+        ``self.html`` as None, ``_process_html`` bails out early, and the run
+        ends with zero results (a warning, not an error) instead of querying
+        the bot-managed endpoint at a disallowed time. See #2006.
+
+        :param request_dict: passed through to the parent downloader
+        :return: the parsed response, or None when outside the visit window
+        """
+        if not self._within_visit_window():
+            logger.warning(
+                "%s: outside the robots.txt visit window (0000-1200 GMT); "
+                "skipping this run",
+                self.court_id,
+            )
+            return None
+        return await super()._download(request_dict)
+
+    def _check_for_bot_challenge(self) -> None:
+        """Raise if the source served a Radware Bot Manager captcha page
+        instead of the search results, so the block surfaces in Sentry
+        rather than being ingested as a successful zero-result scrape.
+
+        :raises BotChallengeError: when a captcha challenge is detected
+        """
+        title = " ".join(self.html.xpath("//title//text()"))
+        if "Bot Manager Captcha" in title or self.html.xpath(
+            "//div[contains(@class, 'h-captcha')]"
+        ):
+            raise BotChallengeError(
+                f"{self.court_id}: blocked by Radware Bot Manager captcha",
+                fingerprint=[f"{self.court_id}-bot-challenge"],
+            )


### PR DESCRIPTION
Fixes #2006

`minnctapp` scrapers are failing currently due to hitting the captcha page.

To prevent this, we will try to respect the robots.txt, with the following steps

1. separate the scrapers in the `__init__` so as to prevent then being executed consecutively

2. add a delay between requests and scrape only during allowed hours following robots.txt (note that this may need adjusting due to non standard value of "Request-rate"

3. fail loudly if a captcha page is encountered