### PR TITLE
Fix SCOTUS docket entry email parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,12 @@ Features:
 -
 
 Changes:
--
+
+- `clean_string` replaces `"\u2013"` with ASCII `"-"`
 
 Fixes:
--
 
+- SCOTUS email docket entry title extraction failure on line breaks in title.
 
 ## 3.0.28 - 2026-06-25
 
@@ -31,6 +32,7 @@ Features:
 - Add Florida scraper
 
 Changes:
+
 - `alaska` and `alaskactapp`: migrated to the Westlaw-hosted "Alaska Case Law
   Service" (https://govt.westlaw.com/akcases), where the court now publishes
   its opinions. Both courts share one search feed and are split by court label.
@@ -39,14 +41,27 @@ Changes:
   expose; their opinions are now covered by `alaska`/`alaskactapp` #2009
 
 Fixes:
-- `nev`/`nevapp`: Nevada's appellate courts moved off their self-hosted C-Track CMS onto Thomson Reuters' cloud "ACIS" portal (`acis.nvcourts.gov`) around June 10, breaking the old `AdvanceOpinions` API. Reworked both scrapers to use the new portal's document-search API, parsing the citation, disposition, author/per curiam and panel out of each docket entry, and building the opinion PDF link directly from the response. Case names are cleaned (case-type parentheticals like "(CIVIL)" dropped, party parentheticals kept) and consolidated "C/W" dockets are appended to the docket number. Adds a paginated backscraper #2010
+
+- `nev`/`nevapp`: Nevada's appellate courts moved off their self-hosted C-Track CMS onto Thomson Reuters' cloud "ACIS"
+  portal (`acis.nvcourts.gov`) around June 10, breaking the old `AdvanceOpinions` API. Reworked both scrapers to use the
+  new portal's document-search API, parsing the citation, disposition, author/per curiam and panel out of each docket
+  entry, and building the opinion PDF link directly from the response. Case names are cleaned (case-type parentheticals
+  like "(CIVIL)" dropped, party parentheticals kept) and consolidated "C/W" dockets are appended to the docket number.
+  Adds a paginated backscraper #2010
 - `Retry` request handler preventing other handlers from awaiting responses
 
 ## 3.0.26 - 2026-06-17
 
 Fixes:
-- `guam`: scrape current-year opinions from the new page; the legacy endpoint stopped getting updated mid-year and missed the newest opinions. Backscraping still uses the legacy endpoint for 2025 and prior #2004
-- `minn`/`minnctapp_p`/`minnctapp_u`: mn.gov is fronted by Radware Bot Manager, which served a captcha page when the back-to-back scrapers tripped its rate limit. The captcha page has no results, so opinions were silently dropped (`minnctapp` stuck since April 7). Now adds a pre-request delay to respect the site's rate limit, only scrapes within the `Visit-time: 0000-1200` GMT window allowed by robots.txt (aborts the run otherwise), and raises `BotChallengeError` if a captcha page is still served instead of failing silently. Also, scrapers are no longer listed one after the other in `state.__init__.__all__` which will make them execute separately #2006
+
+- `guam`: scrape current-year opinions from the new page; the legacy endpoint stopped getting updated mid-year and
+  missed the newest opinions. Backscraping still uses the legacy endpoint for 2025 and prior #2004
+- `minn`/`minnctapp_p`/`minnctapp_u`: mn.gov is fronted by Radware Bot Manager, which served a captcha page when the
+  back-to-back scrapers tripped its rate limit. The captcha page has no results, so opinions were silently dropped (
+  `minnctapp` stuck since April 7). Now adds a pre-request delay to respect the site's rate limit, only scrapes within
+  the `Visit-time: 0000-1200` GMT window allowed by robots.txt (aborts the run otherwise), and raises
+  `BotChallengeError` if a captcha page is still served instead of failing silently. Also, scrapers are no longer listed
+  one after the other in `state.__init__.__all__` which will make them execute separately #2006
 
 ## 3.0.25 - 2026-06-15
 

--- a/juriscraper/lib/string_utils.py
+++ b/juriscraper/lib/string_utils.py
@@ -379,9 +379,6 @@ def clean_string(s):
     # Get rid of weird punctuation
     s = s.replace("*", "").replace("#", "")
 
-    # Convert to ASCII if we can
-    s = s.replace("\u2013", "-")
-
     # Strip bad stuff from the end of lines. Python's strip fails here because
     # we don't know the order of the various punctuation items to be stripped.
     # We split on the v., and handle fixes at either end of plaintiff or

--- a/juriscraper/lib/string_utils.py
+++ b/juriscraper/lib/string_utils.py
@@ -379,6 +379,9 @@ def clean_string(s):
     # Get rid of weird punctuation
     s = s.replace("*", "").replace("#", "")
 
+    # Convert to ASCII if we can
+    s = s.replace("\u2013", "-")
+
     # Strip bad stuff from the end of lines. Python's strip fails here because
     # we don't know the order of the various punctuation items to be stripped.
     # We split on the v., and handle fixes at either end of plaintiff or

--- a/juriscraper/scotus/scotus_email.py
+++ b/juriscraper/scotus/scotus_email.py
@@ -211,7 +211,7 @@ class SCOTUSEmail:
         """
 
         if self.email_type == SCOTUSEmailType.DOCKET_ENTRY:
-            _, followup_parse_result, __ = self._get_first_link_with_filename()
+            _, followup_parse_result, __ = self._first_link_with_filename
             followup_url = followup_parse_result.geturl()
             data = SCOTUSNotificationEmail(
                 docket_number=self._parse_docket_number(),
@@ -382,13 +382,13 @@ class SCOTUSEmail:
 
         :return: Cleaned case name.
         """
-        link, _, __ = self._get_first_link_with_filename()
+        link, _, __ = self._first_link_with_filename
         return harmonize(link.text_content())
 
     # The way things are currently set up, the parser will never be in memory long enough to have a leak worth caring about
-    @functools.cache  # noqa: B019
-    def _get_first_link_with_filename(
-        self,
+    @functools.cached_property
+    def _first_link_with_filename(
+            self,
     ) -> tuple[HtmlElement, ParseResult, dict[str, list[str]]]:
         if self.tree is None:
             raise ValueError("self.tree is None")
@@ -430,7 +430,7 @@ class SCOTUSEmail:
 
         :return: Docket number.
         """
-        _, __, query = self._get_first_link_with_filename()
+        _, __, query = self._first_link_with_filename
         docket_number = Path(query["filename"][0]).stem
         return clean_string(docket_number)
 

--- a/juriscraper/scotus/scotus_email.py
+++ b/juriscraper/scotus/scotus_email.py
@@ -383,7 +383,7 @@ class SCOTUSEmail:
         :return: Cleaned case name.
         """
         link, _, __ = self._get_first_link_with_filename()
-        return harmonize(link.text)
+        return harmonize(link.text_content())
 
     # The way things are currently set up, the parser will never be in memory long enough to have a leak worth caring about
     @functools.cache  # noqa: B019
@@ -392,11 +392,11 @@ class SCOTUSEmail:
     ) -> tuple[HtmlElement, ParseResult, dict[str, list[str]]]:
         if self.tree is None:
             raise ValueError("self.tree is None")
-        links = (
+        links = [
             link
             for link in self.tree.iterfind(".//a")
             if link.get("href") is not None
-        )
+        ]
         if not links:
             raise ValueError("No links found in SCOTUS email body")
         links_with_url = ((link, urlparse(link.get("href"))) for link in links)
@@ -418,13 +418,15 @@ class SCOTUSEmail:
         }
         if len(filenames) > 1:
             logger.error(
-                f'Multiple URLs with unique "filename" query parameter found in SCOTUS email body ({filenames}). Using first.'
+                'Multiple URLs with unique "filename" query parameter found in SCOTUS email body (%s). Using first.',
+                filenames,
             )
         return links_with_filenames[0]
 
     def _parse_docket_number(self) -> str:
-        """Extract the docket number using the `href` attribute from the first
-        `<a>` tag in the email body.
+        """Extract the docket number using the `filename` query parameter of the
+        first `<a>` tag in the email body with an `href` attribute that includes
+        that parameter.
 
         :return: Docket number.
         """

--- a/juriscraper/scotus/scotus_email.py
+++ b/juriscraper/scotus/scotus_email.py
@@ -3,7 +3,7 @@ import pprint
 import re
 import sys
 from datetime import datetime
-from email.message import EmailMessage
+from email.message import Message
 from enum import Enum
 from pathlib import Path
 from typing import TypedDict
@@ -180,7 +180,7 @@ class SCOTUSEmail:
     """Parse SCOTUS docket notification email."""
 
     TITLE_REGEX = re.compile(
-        r"^A new docket entry(?:, \"(.+?)\")? has been added"
+        r"^A new docket entry(?:, \"([^\"]+)\")? has been added"
     )
     DOCKET_ENTRY_SUBJECT_REGEX = re.compile(
         r"^Supreme Court Electronic Filing System$"
@@ -192,7 +192,7 @@ class SCOTUSEmail:
     def __init__(self, court_id: str = "scotus"):
         self.court_id: str = court_id
         self.tree: HtmlElement | None = None
-        self.message: EmailMessage | None = None
+        self.message: Message | None = None
         self.email_type: SCOTUSEmailType = SCOTUSEmailType.INVALID
 
     @property

--- a/juriscraper/scotus/scotus_email.py
+++ b/juriscraper/scotus/scotus_email.py
@@ -1,4 +1,5 @@
 import email
+import functools
 import pprint
 import re
 import sys
@@ -7,7 +8,7 @@ from email.message import Message
 from enum import Enum
 from pathlib import Path
 from typing import TypedDict
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import ParseResult, parse_qs, urlparse
 
 import requests
 from lxml import html
@@ -16,7 +17,11 @@ from lxml.html import HtmlElement
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.email_utils import parse_email_html
 from juriscraper.lib.html_utils import clean_html
-from juriscraper.lib.string_utils import clean_string, harmonize
+from juriscraper.lib.string_utils import (
+    clean_string,
+    harmonize,
+    normalize_dashes,
+)
 from juriscraper.scotus import SCOTUSDocketReportHTML
 
 
@@ -206,7 +211,8 @@ class SCOTUSEmail:
         """
 
         if self.email_type == SCOTUSEmailType.DOCKET_ENTRY:
-            followup_url = self._parse_first_link()
+            _, followup_parse_result, __ = self._get_first_link_with_filename()
+            followup_url = followup_parse_result.geturl()
             data = SCOTUSNotificationEmail(
                 docket_number=self._parse_docket_number(),
                 case_name=self._parse_case_name(),
@@ -368,7 +374,7 @@ class SCOTUSEmail:
         text = self.tree.text_content()
         match = self.TITLE_REGEX.match(text)
 
-        return clean_string(match.group(1) or "")
+        return normalize_dashes(clean_string(match.group(1) or ""))
 
     def _parse_case_name(self) -> str:
         """Extract the case name from the first `<a>` tag in the email body
@@ -376,7 +382,45 @@ class SCOTUSEmail:
 
         :return: Cleaned case name.
         """
-        return harmonize(self.tree.findtext(".//a"))
+        link, _, __ = self._get_first_link_with_filename()
+        return harmonize(link.text)
+
+    # The way things are currently set up, the parser will never be in memory long enough to have a leak worth caring about
+    @functools.cache  # noqa: B019
+    def _get_first_link_with_filename(
+        self,
+    ) -> tuple[HtmlElement, ParseResult, dict[str, list[str]]]:
+        if self.tree is None:
+            raise ValueError("self.tree is None")
+        links = (
+            link
+            for link in self.tree.iterfind(".//a")
+            if link.get("href") is not None
+        )
+        if not links:
+            raise ValueError("No links found in SCOTUS email body")
+        links_with_url = ((link, urlparse(link.get("href"))) for link in links)
+        links_with_query = (
+            (link, url, parse_qs(url.query)) for link, url in links_with_url
+        )
+
+        links_with_filenames = [
+            (link, url, query)
+            for (link, url, query) in links_with_query
+            if "filename" in query
+        ]
+        if not links_with_filenames:
+            raise ValueError(
+                "No URLs with 'filename' query parameter found in SCOTUS email body"
+            )
+        filenames = {
+            query["filename"][0] for (_, _, query) in links_with_filenames
+        }
+        if len(filenames) > 1:
+            logger.error(
+                f'Multiple URLs with unique "filename" query parameter found in SCOTUS email body ({filenames}). Using first.'
+            )
+        return links_with_filenames[0]
 
     def _parse_docket_number(self) -> str:
         """Extract the docket number using the `href` attribute from the first
@@ -384,28 +428,8 @@ class SCOTUSEmail:
 
         :return: Docket number.
         """
-        if self.tree is None:
-            raise ValueError("self.tree is None")
-        links = list(self.tree.iterfind(".//a"))
-        if not links:
-            raise ValueError("No links found in SCOTUS email body")
-        hrefs = [link.get("href") for link in links]
-        urls = [urlparse(href) for href in hrefs if href is not None]
-        if not urls:
-            raise ValueError("No valid URLs found in SCOTUS email body")
-        queries = [parse_qs(url.query) for url in urls]
-        filenames = [
-            query["filename"][0] for query in queries if "filename" in query
-        ]
-        if not filenames:
-            raise ValueError(
-                'No URLs with "filename" query parameter found in SCOTUS email body'
-            )
-        if len(set(filenames)) > 1:
-            logger.error(
-                f'Multiple URLs with unique "filename" query parameter found in SCOTUS email body ({set(filenames)}). Using first.'
-            )
-        docket_number = Path(filenames[0]).stem
+        _, __, query = self._get_first_link_with_filename()
+        docket_number = Path(query["filename"][0]).stem
         return clean_string(docket_number)
 
     def _parse_first_link(self) -> str:

--- a/juriscraper/scotus/scotus_email.py
+++ b/juriscraper/scotus/scotus_email.py
@@ -388,7 +388,7 @@ class SCOTUSEmail:
     # The way things are currently set up, the parser will never be in memory long enough to have a leak worth caring about
     @functools.cached_property
     def _first_link_with_filename(
-            self,
+        self,
     ) -> tuple[HtmlElement, ParseResult, dict[str, list[str]]]:
         if self.tree is None:
             raise ValueError("self.tree is None")

--- a/tests/examples/scotus/email/25-112.eml
+++ b/tests/examples/scotus/email/25-112.eml
@@ -1,0 +1,60 @@
+Return-Path: <0100019f13f8f478-96d2e88f-f1dd-4415-9c00-75e6102d1b59-000000@mail.sc-us.gov>
+Received: from a65-134.smtp-out.amazonses.com (a65-134.smtp-out.amazonses.com [54.240.65.134])
+ by inbound-smtp.us-west-2.amazonaws.com with SMTP id a7bi7gr3jd4b1eqqhg87k1uldq7ipc43dd2dfq81
+ for notifications@scotus.recap.email;
+ Mon, 29 Jun 2026 15:21:51 +0000 (UTC)
+X-SES-Spam-Verdict: PASS
+X-SES-Virus-Verdict: PASS
+Received-SPF: pass (spfCheck: domain of mail.sc-us.gov designates 54.240.65.134 as permitted sender) client-ip=54.240.65.134; envelope-from=0100019f13f8f478-96d2e88f-f1dd-4415-9c00-75e6102d1b59-000000@mail.sc-us.gov; helo=a65-134.smtp-out.amazonses.com;
+Authentication-Results: amazonses.com;
+ spf=pass (spfCheck: domain of mail.sc-us.gov designates 54.240.65.134 as permitted sender) client-ip=54.240.65.134; envelope-from=0100019f13f8f478-96d2e88f-f1dd-4415-9c00-75e6102d1b59-000000@mail.sc-us.gov; helo=a65-134.smtp-out.amazonses.com;
+ dkim=pass header.i=@sc-us.gov;
+ dkim=pass header.i=@amazonses.com;
+ dmarc=pass header.from=sc-us.gov;
+X-SES-RECEIPT: AEFBQUFBQUFBQUFFU2NHMlJaMlRxNXlLdlFWVkxPNmE5TkVSUEt3YXdtWEthbTNCeUYrNkRYcjZxK0ExbUtuZ2VlZTN5WjhNNjE0K1h6VnZlWTdGZnhnRjhqTGJxN0J2eTZKTkY2Q0ZiaXdNOW9QTVdVNGZSNUxSbmt6eGozcWN3SWFLUDNLTlo4VytEQjJqYmE5eEMyKzhTQURqTGs4TDgrRnNaa0ZrU1Fabkc4M3FFaURUQTkvQU15dHVMWDBtekcwY3JFcVNnSHczSjdYdHIwcmVRaHNaNkpheEN4YUZOaVJwQUpESjd3bVJjbDhKb3JlM0poLzlGRXQ4MVlvT1dJQTR0cUFGTjErWS9MNnhYS0x2YWk2MDMzUi9iYmoxcVhwaHdmK2NNTlRXbGtsL21mZloxUTJHMjlDaE5MK3hLd2I1d01LdWR0b3dwbnZzamVrUk54MHMyRnI4aElxZFgveWVOVUNIQWRsb01pYU1iUG9hb0FRPT0=
+X-SES-DKIM-SIGNATURE: a=rsa-sha256; q=dns/txt; b=MNCzidVORNrBJ/1ks6AUPWFHg90EqOwQ6kQ4irypR/I0/xqkDd2pqPhCTeVFr8XF4AZP6HiPiKz8rg0tc6m9gHxvdr2mFE8QEs8EgEp0g3lXtgcF0EsZ48UnuApYNEg8yA7LFm0+QVaAVEC24UbwPTlD/o/vLcnq5GhlfE7XOtI=; c=relaxed/simple; s=hsbnp7p3ensaochzwyq5wwmceodymuwv; d=amazonses.com; t=1782746512; v=1; bh=7DGkKTwjIpfiC6nPEby0drVYXM2l1mOMhNI+sHyNyM4=; h=From:To:Cc:Bcc:Subject:Date:Message-ID:MIME-Version:Content-Type:X-SES-RECEIPT;
+DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple;
+	s=hsnogt5xw3m26s33m3kr6e3qw2bkxxzy; d=sc-us.gov; t=1782746510;
+	h=From:To:Subject:MIME-Version:Content-Type:Content-Transfer-Encoding:Message-ID:Date;
+	bh=7DGkKTwjIpfiC6nPEby0drVYXM2l1mOMhNI+sHyNyM4=;
+	b=RuUUB1hkVkPr7o2h0P8CIV0f9kR+bgXOOihIVmRCrAOWWmi0Y+AtLp8lybkhZgdf
+	Gw6rsxCUUH8LZmAmZCa1j4OEI+HXrCiQNuxYweysZIn01i/eqN+/AzEk5ZJvrGvr+0k
+	Yw+WS8W16YrHStlHMnGqLvQPSteLINPnCZX96tZo=
+DKIM-Signature: v=1; a=rsa-sha256; q=dns/txt; c=relaxed/simple;
+	s=224i4yxa5dv7c2xz3womw6peuasteono; d=amazonses.com; t=1782746510;
+	h=From:To:Subject:MIME-Version:Content-Type:Content-Transfer-Encoding:Message-ID:Date:Feedback-ID;
+	bh=7DGkKTwjIpfiC6nPEby0drVYXM2l1mOMhNI+sHyNyM4=;
+	b=YvE6PBfwrl4kd9nYnYqABarQN0nfEyg/QsOMTSc/WoOV7zd0qNaaA9bVUlTU2Zdy
+	ZRsw4izXcCKyfYOh7ujKNWb6Qex3Q7lgFL+L+nl2W33a1kw68ZXbWUOYZCzATZHVI8I
+	dhxjIZcHXCgw8YmVcXMAQxOf5h0CzsvGh0Yl5AQI=
+From: no-reply@sc-us.gov
+To: notifications@scotus.recap.email
+Subject: Supreme Court Electronic Filing System
+MIME-Version: 1.0
+Content-Type: text/html; charset=UTF-8
+Content-Transfer-Encoding: quoted-printable
+Message-ID: <0100019f13f8f478-96d2e88f-f1dd-4415-9c00-75e6102d1b59-000000@email.amazonses.com>
+Date: Mon, 29 Jun 2026 15:21:50 +0000
+Feedback-ID: ::1.us-east-1.+5GeZMB3eXeyv3WY8brP46tghxJpXFIF9yDDvLuTQrk=:AmazonSES
+X-SES-Outgoing: 2026.06.29-54.240.65.134
+
+A new docket entry, "Judgment VACATED and case REMANDED.  Kagan, J., delive=
+red the <a href =3D 'https://www.supremecourt.gov/opinions/25pdf/25-112_0am=
+4.pdf'>opinion</a> of the Court, in which Roberts, C. J., and Sotomayor, Ka=
+vanaugh, and Jackson, JJ., joined. Jackson, J., filed a concurring opinion,=
+ in which Sotomayor, J., joined. Gorsuch, J., filed an opinion concurring i=
+n the judgment. Alito, J., filed a dissenting opinion, in which Thomas, J.,=
+ joined as to Part I, and in which Barrett,
+J., joined as to Parts II=E2=80=93B, II=E2=80=93C=E2=80=931, and II=E2=80=
+=93C=E2=80=932. Barrett, J., filed a dissenting opinion." has been added fo=
+r <a href=3D'https://www.supremecourt.gov/search.aspx?filename=3D/docket/Do=
+cketFiles/html/Public/25-112.html'>Okello T. Chatrie, Petitioner v. United =
+States</a>. You have been signed up to receive email notifications for No. =
+25-112. <br><br> If you no longer wish to receive email notifications on th=
+is case, please=20
+
+<a href=3D'https://file.supremecourt.gov/Request/NotificationOptOutGet?id=
+=3DCfDJ8LWjh78o-U5EigyPTWy9Bmdq_T3ta4jHn3xafXXPTWzg-EPMPvgtwQSY0S5koyVnW12Y=
+QuBIXjqPtVVbtxBTv-urW89AYOaC-FHaJv0GYPF4ved9kSqI5E_0M4g6q378qmdZVlgcirGiLab=
+PiFAm99TTI6Dn5FRVGt1ecIO5-LGN'>click here</a>.
+

--- a/tests/examples/scotus/email/25-112.json
+++ b/tests/examples/scotus/email/25-112.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "case_name": "opinion",
+    "docket_number": "25-112",
+    "entry_description": "Judgment VACATED and case REMANDED. Kagan, J., delivered the opinion of the Court, in which Roberts, C. J., and Sotomayor, Kavanaugh, and Jackson, JJ., joined. Jackson, J., filed a concurring opinion, in which Sotomayor, J., joined. Gorsuch, J., filed an opinion concurring in the judgment. Alito, J., filed a dissenting opinion, in which Thomas, J., joined as to Part I, and in which Barrett, J., joined as to Parts II-B, II-C-1, and II-C-2. Barrett, J., filed a dissenting opinion."
+  },
+  "email_datetime": "2026-06-29T15:21:50+00:00",
+  "email_type": "docket_entry",
+  "followup_url": "https://www.supremecourt.gov/opinions/25pdf/25-112_0am4.pdf"
+}

--- a/tests/examples/scotus/email/25-112.json
+++ b/tests/examples/scotus/email/25-112.json
@@ -1,10 +1,10 @@
 {
   "data": {
-    "case_name": "opinion",
+    "case_name": "Okello T. Chatrie v. United States",
     "docket_number": "25-112",
     "entry_description": "Judgment VACATED and case REMANDED. Kagan, J., delivered the opinion of the Court, in which Roberts, C. J., and Sotomayor, Kavanaugh, and Jackson, JJ., joined. Jackson, J., filed a concurring opinion, in which Sotomayor, J., joined. Gorsuch, J., filed an opinion concurring in the judgment. Alito, J., filed a dissenting opinion, in which Thomas, J., joined as to Part I, and in which Barrett, J., joined as to Parts II-B, II-C-1, and II-C-2. Barrett, J., filed a dissenting opinion."
   },
   "email_datetime": "2026-06-29T15:21:50+00:00",
   "email_type": "docket_entry",
-  "followup_url": "https://www.supremecourt.gov/opinions/25pdf/25-112_0am4.pdf"
+  "followup_url": "https://www.supremecourt.gov/search.aspx?filename=/docket/DocketFiles/html/Public/25-112.html"
 }

--- a/tests/examples/scotus/email/25-83.json
+++ b/tests/examples/scotus/email/25-83.json
@@ -1,10 +1,10 @@
 {
   "data": {
-    "case_name": "opinion",
+    "case_name": "Adrian Jules v. Andre Balazs Properties",
     "docket_number": "25-83",
     "entry_description": "Adjudged to be AFFIRMED. Sotomayor, J., delivered the opinion for a unanimous Court."
   },
   "email_datetime": "2026-05-14T15:07:12+00:00",
   "email_type": "docket_entry",
-  "followup_url": "https://www.supremecourt.gov/opinions/25pdf/25-83_3e04.pdf"
+  "followup_url": "https://www.supremecourt.gov/search.aspx?filename=/docket/DocketFiles/html/Public/25-83.html"
 }


### PR DESCRIPTION
Fixes #1941

SCOTUS email parser was failing to extract docket entry titles when they contained line breaks. This modifies the title regex to fix that.

Also updates `clean_string` to replace Unicode `"\u2013"` with ASCII `"-"`.