### PR TITLE
fix(florida): Unknown originating court causing noisy logs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,11 +18,12 @@ Features:
 -
 
 Changes:
--
+
+- Map "Unknown court" from Florida ACIS to `FloridaCourtID.UNKNOWN`
+- Downgrade unrecognized court name log from error to warning
 
 Fixes:
 -
-
 
 ## 3.0.29 - 2026-06-26
 
@@ -33,9 +34,9 @@ Changes:
 -
 
 Fixes:
+
 - `Retry` request handler preventing other handlers from awaiting responses
 - Use make_case_name_short for Florida’s case_name_short field
-
 
 ## 3.0.28 - 2026-06-25
 
@@ -44,6 +45,7 @@ Features:
 - Add Florida scraper
 
 Changes:
+
 - `alaska` and `alaskactapp`: migrated to the Westlaw-hosted "Alaska Case Law
   Service" (https://govt.westlaw.com/akcases), where the court now publishes
   its opinions. Both courts share one search feed and are split by court label.
@@ -52,13 +54,26 @@ Changes:
   expose; their opinions are now covered by `alaska`/`alaskactapp` #2009
 
 Fixes:
-- `nev`/`nevapp`: Nevada's appellate courts moved off their self-hosted C-Track CMS onto Thomson Reuters' cloud "ACIS" portal (`acis.nvcourts.gov`) around June 10, breaking the old `AdvanceOpinions` API. Reworked both scrapers to use the new portal's document-search API, parsing the citation, disposition, author/per curiam and panel out of each docket entry, and building the opinion PDF link directly from the response. Case names are cleaned (case-type parentheticals like "(CIVIL)" dropped, party parentheticals kept) and consolidated "C/W" dockets are appended to the docket number. Adds a paginated backscraper #2010
+
+- `nev`/`nevapp`: Nevada's appellate courts moved off their self-hosted C-Track CMS onto Thomson Reuters' cloud "ACIS"
+  portal (`acis.nvcourts.gov`) around June 10, breaking the old `AdvanceOpinions` API. Reworked both scrapers to use the
+  new portal's document-search API, parsing the citation, disposition, author/per curiam and panel out of each docket
+  entry, and building the opinion PDF link directly from the response. Case names are cleaned (case-type parentheticals
+  like "(CIVIL)" dropped, party parentheticals kept) and consolidated "C/W" dockets are appended to the docket number.
+  Adds a paginated backscraper #2010
 
 ## 3.0.26 - 2026-06-17
 
 Fixes:
-- `guam`: scrape current-year opinions from the new page; the legacy endpoint stopped getting updated mid-year and missed the newest opinions. Backscraping still uses the legacy endpoint for 2025 and prior #2004
-- `minn`/`minnctapp_p`/`minnctapp_u`: mn.gov is fronted by Radware Bot Manager, which served a captcha page when the back-to-back scrapers tripped its rate limit. The captcha page has no results, so opinions were silently dropped (`minnctapp` stuck since April 7). Now adds a pre-request delay to respect the site's rate limit, only scrapes within the `Visit-time: 0000-1200` GMT window allowed by robots.txt (aborts the run otherwise), and raises `BotChallengeError` if a captcha page is still served instead of failing silently. Also, scrapers are no longer listed one after the other in `state.__init__.__all__` which will make them execute separately #2006
+
+- `guam`: scrape current-year opinions from the new page; the legacy endpoint stopped getting updated mid-year and
+  missed the newest opinions. Backscraping still uses the legacy endpoint for 2025 and prior #2004
+- `minn`/`minnctapp_p`/`minnctapp_u`: mn.gov is fronted by Radware Bot Manager, which served a captcha page when the
+  back-to-back scrapers tripped its rate limit. The captcha page has no results, so opinions were silently dropped (
+  `minnctapp` stuck since April 7). Now adds a pre-request delay to respect the site's rate limit, only scrapes within
+  the `Visit-time: 0000-1200` GMT window allowed by robots.txt (aborts the run otherwise), and raises
+  `BotChallengeError` if a captcha page is still served instead of failing silently. Also, scrapers are no longer listed
+  one after the other in `state.__init__.__all__` which will make them execute separately #2006
 
 ## 3.0.25 - 2026-06-15
 

--- a/juriscraper/state/florida/cases.py
+++ b/juriscraper/state/florida/cases.py
@@ -155,8 +155,10 @@ def florida_originating_court_id_validator(i: str) -> FloridaCourtID:
             return FloridaCourtID.US_COA
         case "division of administrative hearings":
             return FloridaCourtID.DOAH
+        case "unknown court":
+            return FloridaCourtID.UNKNOWN
         case _:
-            logger.error("Unrecognized Florida court name: %s", court_name)
+            logger.warning("Unrecognized Florida court name: %s", court_name)
             return FloridaCourtID.UNASSIGNED
 
 

--- a/tests/examples/state/florida/cases/scrape-page-57.compare.json
+++ b/tests/examples/state/florida/cases/scrape-page-57.compare.json
@@ -1,0 +1,902 @@
+{
+  "_embedded": {
+    "results": [
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "c99ca5e5-0d01-47ef-a17a-5a5406cbb0e6",
+          "caseNumber": "SC1960-63960",
+          "caseTitle": "JONES ( JOHN ROBERT ) VS STATE",
+          "closedFlag": true,
+          "caseClassification": "Mandatory Review - Notice of Appeal - Statutory/Constitutional Invalidity",
+          "caseClassificationID": "1000027",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-15T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "AS-284"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "1f79f4a3-6614-48f0-b999-530596afe11e",
+          "caseNumber": "SC1960-63959",
+          "caseTitle": "ARTMAN VS NATIONAL PEN CORP .",
+          "closedFlag": true,
+          "caseClassification": "Mandatory Review - Notice of Appeal - Statutory/Constitutional Invalidity",
+          "caseClassificationID": "1000027",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-15T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "AK-124"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "e303b21c-2ab6-4c7e-9050-bf5f10e3d586",
+          "caseNumber": "SC1960-63957",
+          "caseTitle": "WILLIAM RILEY JENT VS STATE OF FLORIDA",
+          "closedFlag": true,
+          "caseClassification": "Mandatory Review - Death Penalty Appeal - Migration",
+          "caseClassificationID": "1000298",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-15T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Circuit Court for the Sixth Judicial Circuit, Pasco County",
+              "originatingCaseNumber": "79-847"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "f5c78544-b30b-4293-9593-aa34ea75a40a",
+          "caseNumber": "SC1960-63962",
+          "caseTitle": "RULES - CRIM . PROC . - S",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Rules - Amendment to Rules-Misc",
+          "caseClassificationID": "1000304",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-15T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "350e6abc-1fa1-4025-8cba-bc3a1a99b48d",
+          "caseNumber": "SC1960-63976",
+          "caseTitle": "PLANES VS PLANES",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-968"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "5ffb736d-a5bd-4217-9497-9b9b29a9f299",
+          "caseNumber": "SC1960-63967",
+          "caseTitle": "RODIN VS GOLDEN",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "83-457"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "26b6088a-ee15-4f78-82e6-93c14473dbc8",
+          "caseNumber": "SC1960-63975",
+          "caseTitle": "SHAMAS VS RITTER",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-1266"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "e88d5807-5067-4e1c-b92c-2c3d65e1c887",
+          "caseNumber": "SC1960-63988",
+          "caseTitle": "TUCKER VS STATE",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Constitutional Construction",
+          "caseClassificationID": "1000033",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "AT-382"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "56ac146a-83f1-41ac-9eab-c3a5f128370c",
+          "caseNumber": "SC1960-63963",
+          "caseTitle": "BATCHELOR VS HERSEY",
+          "closedFlag": true,
+          "caseClassification": "Mandatory Review - Notice of Appeal - Statutory/Constitutional Invalidity",
+          "caseClassificationID": "1000027",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-1110"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "f14d83f7-770b-4b9c-b0ae-96336a34997d",
+          "caseNumber": "SC1960-63982",
+          "caseTitle": "BARREIRO VS STATE",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Class of Constitutional Officer",
+          "caseClassificationID": "1000034",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "83-504"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "a6ce170b-ab76-4042-b001-090af96d776d",
+          "caseNumber": "SC1960-63965",
+          "caseTitle": "FLORIDA BAR RE : GLUCK",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Florida Bar - Migration",
+          "caseClassificationID": "1000302",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "71c1d199-d2b4-4a2f-96a0-5a99d99e8583",
+          "caseNumber": "SC1960-63968",
+          "caseTitle": "YEAGER VS PROVOST",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-2166"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "52a4245c-40f9-4a47-86aa-77740751d70b",
+          "caseNumber": "SC1960-63978",
+          "caseTitle": "IN RE : FORFEITURE OF CES",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-906"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "ddabf192-bb69-4445-ae8b-6abfb38d0fce",
+          "caseNumber": "SC1960-63970",
+          "caseTitle": "MILLER VS STATE",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-65"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "c5cac2ba-fcf3-4c1d-aea9-297cc34a442d",
+          "caseNumber": "SC1960-63969",
+          "caseTitle": "CAMPER VS STATE",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-1869"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "ffc28a73-466f-4175-91cb-b4b22a0673ea",
+          "caseNumber": "SC1960-63980",
+          "caseTitle": "GRUDER VS GRUDER",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-2613"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "d517d3a0-1f37-44bb-8bed-1f0bd1aaa341",
+          "caseNumber": "SC1960-63977",
+          "caseTitle": "ILLES VS HAGER",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "83-43"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "273754f6-4739-4f39-aa1c-353efa80a57c",
+          "caseNumber": "SC1960-63973",
+          "caseTitle": "STATE VS MEYERS",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-1277"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "39ed9abb-5da6-4b6a-bf8b-11349cfadd49",
+          "caseNumber": "SC1960-63979",
+          "caseTitle": "EBERWEIN VS CORAL PINE CONDOMIN . ONE",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-545"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "d736d6ff-274e-4d16-a59b-2d82e455a5e7",
+          "caseNumber": "SC1960-63983",
+          "caseTitle": "HOLLYWOOD , INC . VS BROWARD COUNTY",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Constitutional Construction",
+          "caseClassificationID": "1000033",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "81-700"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "e9636f56-6ab3-4ee7-b886-d95841d22e2e",
+          "caseNumber": "SC1960-63981",
+          "caseTitle": "J . P . W . , A CHILD VS STATE",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Certified Great Public Importance",
+          "caseClassificationID": "1000036",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "81-963"
+            },
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-349"
+            },
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-350"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "ba0c63cb-d8da-420b-831e-71d7ae34ad5b",
+          "caseNumber": "SC1960-63974",
+          "caseTitle": "A . O . , A JUVENILE VS STATE",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Certified Great Public Importance",
+          "caseClassificationID": "1000036",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-869"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "7a31585a-e9b0-47dd-9af7-a6b874361d92",
+          "caseNumber": "SC1960-63972",
+          "caseTitle": "STATE VS CARTER",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-925"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "a65cc5fe-4413-4d6e-b191-5b86a68aaaf3",
+          "caseNumber": "SC1960-63964",
+          "caseTitle": "FLORIDA BAR VS CRUZ",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Florida Bar - Migration",
+          "caseClassificationID": "1000302",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "28d28661-3165-4c8c-97d3-f7bc2869577a",
+          "caseNumber": "SC1960-63966",
+          "caseTitle": "FLORIDA BAR RE : WHITCOMB",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Florida Bar - Migration",
+          "caseClassificationID": "1000302",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "ed07183a-97e5-482a-bf10-479ba2cc35bb",
+          "caseNumber": "SC1960-63971",
+          "caseTitle": "ABSTRACT CORP . VS FERNANDEZ CO .",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-18T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-1021"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "a9776b8e-ddd8-4799-a61b-8a9ad6790901",
+          "caseNumber": "SC1960-63990",
+          "caseTitle": "TUCKER VS WAINWRIGHT",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Writ - Mandamus",
+          "caseClassificationID": "1000044",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-19T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "49d57da8-63e1-4c80-97dc-d2d2a6a87721",
+          "caseNumber": "SC1960-63985",
+          "caseTitle": "BEAMON VS MASSEY",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Writ - Habeas Corpus",
+          "caseClassificationID": "1000043",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-19T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "f3de8a35-4d29-4918-b183-6abaa260b26a",
+          "caseNumber": "SC1960-63984",
+          "caseTitle": "CITY NATIONAL BANK OF MIA VS PURDY , ET",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Writ - Prohibition",
+          "caseClassificationID": "1000045",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-19T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "e94dbeaf-c50b-449c-8a32-bb9a0e77cb24",
+          "caseNumber": "SC1960-63986",
+          "caseTitle": "POWELL VS STATE",
+          "closedFlag": true,
+          "caseClassification": "Mandatory Review - Notice of Appeal - Statutory/Constitutional Invalidity",
+          "caseClassificationID": "1000027",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-19T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "83-887"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "038fed18-3e1f-4fee-93c6-754a9b62e882",
+          "caseNumber": "SC1960-63989",
+          "caseTitle": "DEPT . OF REVENUE VS LINEAS AEREAS COSTAR",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice of Appeal - Certified Judgment of Trial Court",
+          "caseClassificationID": "1000041",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-19T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "AT-305"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "d2973604-790f-4752-b641-f8a66825c6eb",
+          "caseNumber": "SC1960-63987",
+          "caseTitle": "BROWARD COUNTY VS POPIEL",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-19T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "AO-438"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "a439c80d-d220-4bd9-a95f-6ddf27c8bdcf",
+          "caseNumber": "SC1960-63992",
+          "caseTitle": "KELLER BUILDING PRODUCTS VS SHULTZ",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-20T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "A0-157"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "7830e0a4-35d6-45c7-90be-fef9515bf394",
+          "caseNumber": "SC1960-63995",
+          "caseTitle": "FLORIDA BAR VS ROCHA",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Florida Bar - Migration",
+          "caseClassificationID": "1000302",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-20T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "330cc87f-e87a-46ac-9760-3a67c62f8e87",
+          "caseNumber": "SC1960-63991",
+          "caseTitle": "STATE VS JENKINS",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-20T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "AN-266"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "90429a0c-3156-49bc-b8c6-55b62d477f01",
+          "caseNumber": "SC1960-63993",
+          "caseTitle": "FLORIDA BAR VS DONALDSON",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Florida Bar - Migration",
+          "caseClassificationID": "1000302",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-20T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "fcb9cc17-6591-45ac-bbd4-221dfbc26ea0",
+          "caseNumber": "SC1960-63994",
+          "caseTitle": "FLORIDA BAR VS FINKELSTEIN",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Florida Bar - Migration",
+          "caseClassificationID": "1000302",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-20T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "7eb263f7-0d49-4816-ad59-bce3ac1f0fdd",
+          "caseNumber": "SC1960-63997",
+          "caseTitle": "TURNER VS STATE",
+          "closedFlag": true,
+          "caseClassification": "Mandatory Review - Notice of Appeal - Statutory/Constitutional Invalidity",
+          "caseClassificationID": "1000027",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-21T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-1879"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "9571fa9b-74ba-4662-b130-7bff3baab75a",
+          "caseNumber": "SC1960-64000",
+          "caseTitle": "FLORIDA BAR RE : FENNEN",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Florida Bar - Migration",
+          "caseClassificationID": "1000302",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-21T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "34541f86-9ad6-4004-a26e-004438c80f46",
+          "caseNumber": "SC1960-63999",
+          "caseTitle": "PLATEL VS MUSZYNSKI",
+          "closedFlag": true,
+          "caseClassification": "Mandatory Review - Notice of Appeal - Statutory/Constitutional Invalidity",
+          "caseClassificationID": "1000027",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-21T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-1416"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "7e930aad-a987-4a7c-a78a-44e2aa827e36",
+          "caseNumber": "SC1960-64002",
+          "caseTitle": "WASTE MANAGEMENT , INC . VS LANE",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-21T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "81-1654; 81-1746"
+            },
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "81-849; 81-850"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "2a9c093d-8a58-4089-99e8-5f0bb69a0065",
+          "caseNumber": "SC1960-63996",
+          "caseTitle": "Rose v. State of Florida",
+          "closedFlag": true,
+          "caseClassification": "Mandatory Review - Death Penalty Appeal - Resentencing",
+          "caseClassificationID": "1000002",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-21T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Circuit Court for the Seventeenth Judicial Circuit, Broward County",
+              "originatingCaseNumber": "76-5036 CF"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "5fa94db0-65fe-4601-8824-86e416ca7d8c",
+          "caseNumber": "SC1960-63998",
+          "caseTitle": "WEISSMAN VS CHILDS",
+          "closedFlag": true,
+          "caseClassification": "Mandatory Review - Notice of Appeal - Statutory/Constitutional Invalidity",
+          "caseClassificationID": "1000027",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-21T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-1448"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "7208434b-e075-40fa-aa0b-72838744d0a4",
+          "caseNumber": "SC1960-64001",
+          "caseTitle": "CARTER VS CITY OF STUART",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Certified Great Public Importance",
+          "caseClassificationID": "1000036",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-21T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-125"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "e75829d9-0fac-4f24-8993-21fb3a4d7d27",
+          "caseNumber": "SC1960-64005",
+          "caseTitle": "TILCON CONSTRUC . & PLANT VS ALSTON",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-22T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-1894"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "cea65227-72fb-4a84-bfaf-d11525f7a64b",
+          "caseNumber": "SC1960-64007",
+          "caseTitle": "JONES ( EARL JEROME ) VS STATE",
+          "closedFlag": true,
+          "caseClassification": "Original Proceedings - Writ - Mandamus",
+          "caseClassificationID": "1000044",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-22T04:00:00.000+00:00"
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "f6a9f980-a609-4bc7-bb06-087a42a37794",
+          "caseNumber": "SC1960-64010",
+          "caseTitle": "KRASNOSKY VS MEREDITH",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-22T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "AP-207"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "c5b62801-ad1d-4aa2-af48-362aeb219a33",
+          "caseNumber": "SC1960-64004",
+          "caseTitle": "TYSON VS EDWARDS",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-22T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "81-949"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "ec871bfc-6051-4844-bf0f-00a49a87f2f6",
+          "caseNumber": "SC1960-64006",
+          "caseTitle": "MARANO VS CELOTEX CORPORATION , ET",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Statutory Validity",
+          "caseClassificationID": "1000032",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-22T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "82-1283"
+            }
+          ]
+        }
+      },
+      {
+        "caseHeader": {
+          "caseInstanceUUID": "e3509326-0c4d-4700-a137-131470bd8105",
+          "caseNumber": "SC1960-64008",
+          "caseTitle": "WALKER VS DUGGER",
+          "closedFlag": true,
+          "caseClassification": "Discretionary Review - Notice to Invoke - Direct Conflict of Decisions",
+          "caseClassificationID": "1000035",
+          "courtID": "1",
+          "courtAbbreviation": "Supreme Court of Florida",
+          "filedDate": "1983-07-22T04:00:00.000+00:00",
+          "originatingCourtCases": [
+            {
+              "originatingCourtName": "Unknown Court",
+              "originatingCaseNumber": "AS-59"
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "page": {
+    "size": 50,
+    "totalElements": 8372,
+    "totalPages": 168,
+    "number": 57
+  }
+}

--- a/tests/examples/state/florida/cases/scrape-page-57.json
+++ b/tests/examples/state/florida/cases/scrape-page-57.json
@@ -1,0 +1,1745 @@
+[
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "JONES ( JOHN ROBERT ) v. STATE",
+    "case_name_full": "JONES ( JOHN ROBERT ) v. STATE",
+    "case_name_short": "",
+    "case_uuid": "c99ca5e5-0d01-47ef-a17a-5a5406cbb0e6",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000027,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-15",
+    "datetime_filed": "1983-07-15T04:00:00Z",
+    "docket_number": "SC1960-63960",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Mandatory Review",
+      "Notice of Appeal",
+      "Statutory/Constitutional Invalidity"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "AS-284",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "ARTMAN v. NATIONAL PEN CORP .",
+    "case_name_full": "ARTMAN v. NATIONAL PEN CORP .",
+    "case_name_short": "",
+    "case_uuid": "1f79f4a3-6614-48f0-b999-530596afe11e",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000027,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-15",
+    "datetime_filed": "1983-07-15T04:00:00Z",
+    "docket_number": "SC1960-63959",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Mandatory Review",
+      "Notice of Appeal",
+      "Statutory/Constitutional Invalidity"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "AK-124",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "WILLIAM RILEY JENT v. STATE OF FLORIDA",
+    "case_name_full": "WILLIAM RILEY JENT v. STATE OF FLORIDA",
+    "case_name_short": "",
+    "case_uuid": "e303b21c-2ab6-4c7e-9050-bf5f10e3d586",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000298,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-15",
+    "datetime_filed": "1983-07-15T04:00:00Z",
+    "docket_number": "SC1960-63957",
+    "docket_type": "death_appeal",
+    "docket_type_raw": [
+      "Mandatory Review",
+      "Death Penalty Appeal",
+      "Migration"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "79-847",
+        "court_id": "flcrct",
+        "court_name": "Circuit Court for the Sixth Judicial Circuit, Pasco County"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "RULES - CRIM . PROC . - S",
+    "case_name_full": "RULES - CRIM . PROC . - S",
+    "case_name_short": "",
+    "case_uuid": "f5c78544-b30b-4293-9593-aa34ea75a40a",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000304,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-15",
+    "datetime_filed": "1983-07-15T04:00:00Z",
+    "docket_number": "SC1960-63962",
+    "docket_type": "unknown",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Rules",
+      "Amendment to Rules-Misc"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "PLANES v. PLANES",
+    "case_name_full": "PLANES v. PLANES",
+    "case_name_short": "PLANES VS PLANES",
+    "case_uuid": "350e6abc-1fa1-4025-8cba-bc3a1a99b48d",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63976",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-968",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "RODIN v. GOLDEN",
+    "case_name_full": "RODIN v. GOLDEN",
+    "case_name_short": "RODIN VS GOLDEN",
+    "case_uuid": "5ffb736d-a5bd-4217-9497-9b9b29a9f299",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63967",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "83-457",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "SHAMAS v. RITTER",
+    "case_name_full": "SHAMAS v. RITTER",
+    "case_name_short": "SHAMAS VS RITTER",
+    "case_uuid": "26b6088a-ee15-4f78-82e6-93c14473dbc8",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63975",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-1266",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "TUCKER v. STATE",
+    "case_name_full": "TUCKER v. STATE",
+    "case_name_short": "TUCKER VS STATE",
+    "case_uuid": "e88d5807-5067-4e1c-b92c-2c3d65e1c887",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000033,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63988",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Constitutional Construction"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "AT-382",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "BATCHELOR v. HERSEY",
+    "case_name_full": "BATCHELOR v. HERSEY",
+    "case_name_short": "BATCHELOR VS HERSEY",
+    "case_uuid": "56ac146a-83f1-41ac-9eab-c3a5f128370c",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000027,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63963",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Mandatory Review",
+      "Notice of Appeal",
+      "Statutory/Constitutional Invalidity"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-1110",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "BARREIRO v. STATE",
+    "case_name_full": "BARREIRO v. STATE",
+    "case_name_short": "BARREIRO VS STATE",
+    "case_uuid": "f14d83f7-770b-4b9c-b0ae-96336a34997d",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000034,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63982",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Class of Constitutional Officer"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "83-504",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "FLORIDA BAR RE : GLUCK",
+    "case_name_full": "FLORIDA BAR RE : GLUCK",
+    "case_name_short": "",
+    "case_uuid": "a6ce170b-ab76-4042-b001-090af96d776d",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000302,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63965",
+    "docket_type": "bar",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Florida Bar",
+      "Migration"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "YEAGER v. PROVOST",
+    "case_name_full": "YEAGER v. PROVOST",
+    "case_name_short": "YEAGER VS PROVOST",
+    "case_uuid": "71c1d199-d2b4-4a2f-96a0-5a99d99e8583",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63968",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-2166",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "IN RE : FORFEITURE OF CES",
+    "case_name_full": "IN RE : FORFEITURE OF CES",
+    "case_name_short": "",
+    "case_uuid": "52a4245c-40f9-4a47-86aa-77740751d70b",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63978",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-906",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "MILLER v. STATE",
+    "case_name_full": "MILLER v. STATE",
+    "case_name_short": "MILLER VS STATE",
+    "case_uuid": "ddabf192-bb69-4445-ae8b-6abfb38d0fce",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63970",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-65",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "CAMPER v. STATE",
+    "case_name_full": "CAMPER v. STATE",
+    "case_name_short": "CAMPER VS STATE",
+    "case_uuid": "c5cac2ba-fcf3-4c1d-aea9-297cc34a442d",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63969",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-1869",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "GRUDER v. GRUDER",
+    "case_name_full": "GRUDER v. GRUDER",
+    "case_name_short": "GRUDER VS GRUDER",
+    "case_uuid": "ffc28a73-466f-4175-91cb-b4b22a0673ea",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63980",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-2613",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "ILLES v. HAGER",
+    "case_name_full": "ILLES v. HAGER",
+    "case_name_short": "ILLES VS HAGER",
+    "case_uuid": "d517d3a0-1f37-44bb-8bed-1f0bd1aaa341",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63977",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "83-43",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "STATE v. MEYERS",
+    "case_name_full": "STATE v. MEYERS",
+    "case_name_short": "STATE VS MEYERS",
+    "case_uuid": "273754f6-4739-4f39-aa1c-353efa80a57c",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63973",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-1277",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "EBERWEIN v. CORAL PINE CONDOMIN . ONE",
+    "case_name_full": "EBERWEIN v. CORAL PINE CONDOMIN . ONE",
+    "case_name_short": "",
+    "case_uuid": "39ed9abb-5da6-4b6a-bf8b-11349cfadd49",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63979",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-545",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "HOLLYWOOD , INC . v. BROWARD COUNTY",
+    "case_name_full": "HOLLYWOOD , INC . v. BROWARD COUNTY",
+    "case_name_short": "",
+    "case_uuid": "d736d6ff-274e-4d16-a59b-2d82e455a5e7",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000033,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63983",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Constitutional Construction"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "81-700",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "J . P . W . , A CHILD v. STATE",
+    "case_name_full": "J . P . W . , A CHILD v. STATE",
+    "case_name_short": "",
+    "case_uuid": "e9636f56-6ab3-4ee7-b886-d95841d22e2e",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000036,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63981",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Certified Great Public Importance"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "81-963",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      },
+      {
+        "case_number": "82-349",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      },
+      {
+        "case_number": "82-350",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "A . O . , A JUVENILE v. STATE",
+    "case_name_full": "A . O . , A JUVENILE v. STATE",
+    "case_name_short": "",
+    "case_uuid": "ba0c63cb-d8da-420b-831e-71d7ae34ad5b",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000036,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63974",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Certified Great Public Importance"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-869",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "STATE v. CARTER",
+    "case_name_full": "STATE v. CARTER",
+    "case_name_short": "STATE VS CARTER",
+    "case_uuid": "7a31585a-e9b0-47dd-9af7-a6b874361d92",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63972",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-925",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "FLORIDA BAR v. CRUZ",
+    "case_name_full": "FLORIDA BAR v. CRUZ",
+    "case_name_short": "",
+    "case_uuid": "a65cc5fe-4413-4d6e-b191-5b86a68aaaf3",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000302,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63964",
+    "docket_type": "bar",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Florida Bar",
+      "Migration"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "FLORIDA BAR RE : WHITCOMB",
+    "case_name_full": "FLORIDA BAR RE : WHITCOMB",
+    "case_name_short": "",
+    "case_uuid": "28d28661-3165-4c8c-97d3-f7bc2869577a",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000302,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63966",
+    "docket_type": "bar",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Florida Bar",
+      "Migration"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "ABSTRACT CORP . v. FERNANDEZ CO .",
+    "case_name_full": "ABSTRACT CORP . v. FERNANDEZ CO .",
+    "case_name_short": "",
+    "case_uuid": "ed07183a-97e5-482a-bf10-479ba2cc35bb",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-18",
+    "datetime_filed": "1983-07-18T04:00:00Z",
+    "docket_number": "SC1960-63971",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-1021",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "TUCKER v. WAINWRIGHT",
+    "case_name_full": "TUCKER v. WAINWRIGHT",
+    "case_name_short": "TUCKER VS WAINWRIGHT",
+    "case_uuid": "a9776b8e-ddd8-4799-a61b-8a9ad6790901",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000044,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-19",
+    "datetime_filed": "1983-07-19T04:00:00Z",
+    "docket_number": "SC1960-63990",
+    "docket_type": "order",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Writ",
+      "Mandamus"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "BEAMON v. MASSEY",
+    "case_name_full": "BEAMON v. MASSEY",
+    "case_name_short": "BEAMON VS MASSEY",
+    "case_uuid": "49d57da8-63e1-4c80-97dc-d2d2a6a87721",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000043,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-19",
+    "datetime_filed": "1983-07-19T04:00:00Z",
+    "docket_number": "SC1960-63985",
+    "docket_type": "order",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Writ",
+      "Habeas Corpus"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "CITY NATIONAL BANK OF MIA v. PURDY , ET",
+    "case_name_full": "CITY NATIONAL BANK OF MIA v. PURDY , ET",
+    "case_name_short": "",
+    "case_uuid": "f3de8a35-4d29-4918-b183-6abaa260b26a",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000045,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-19",
+    "datetime_filed": "1983-07-19T04:00:00Z",
+    "docket_number": "SC1960-63984",
+    "docket_type": "order",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Writ",
+      "Prohibition"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "POWELL v. STATE",
+    "case_name_full": "POWELL v. STATE",
+    "case_name_short": "POWELL VS STATE",
+    "case_uuid": "e94dbeaf-c50b-449c-8a32-bb9a0e77cb24",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000027,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-19",
+    "datetime_filed": "1983-07-19T04:00:00Z",
+    "docket_number": "SC1960-63986",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Mandatory Review",
+      "Notice of Appeal",
+      "Statutory/Constitutional Invalidity"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "83-887",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "DEPT . OF REVENUE v. LINEAS AEREAS COSTAR",
+    "case_name_full": "DEPT . OF REVENUE v. LINEAS AEREAS COSTAR",
+    "case_name_short": "",
+    "case_uuid": "038fed18-3e1f-4fee-93c6-754a9b62e882",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000041,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-19",
+    "datetime_filed": "1983-07-19T04:00:00Z",
+    "docket_number": "SC1960-63989",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice of Appeal",
+      "Certified Judgment of Trial Court"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "AT-305",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "BROWARD COUNTY v. POPIEL",
+    "case_name_full": "BROWARD COUNTY v. POPIEL",
+    "case_name_short": "",
+    "case_uuid": "d2973604-790f-4752-b641-f8a66825c6eb",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-19",
+    "datetime_filed": "1983-07-19T04:00:00Z",
+    "docket_number": "SC1960-63987",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "AO-438",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "KELLER BUILDING PRODUCTS v. SHULTZ",
+    "case_name_full": "KELLER BUILDING PRODUCTS v. SHULTZ",
+    "case_name_short": "",
+    "case_uuid": "a439c80d-d220-4bd9-a95f-6ddf27c8bdcf",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-20",
+    "datetime_filed": "1983-07-20T04:00:00Z",
+    "docket_number": "SC1960-63992",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "A0-157",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "FLORIDA BAR v. ROCHA",
+    "case_name_full": "FLORIDA BAR v. ROCHA",
+    "case_name_short": "",
+    "case_uuid": "7830e0a4-35d6-45c7-90be-fef9515bf394",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000302,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-20",
+    "datetime_filed": "1983-07-20T04:00:00Z",
+    "docket_number": "SC1960-63995",
+    "docket_type": "bar",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Florida Bar",
+      "Migration"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "STATE v. JENKINS",
+    "case_name_full": "STATE v. JENKINS",
+    "case_name_short": "STATE VS JENKINS",
+    "case_uuid": "330cc87f-e87a-46ac-9760-3a67c62f8e87",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-20",
+    "datetime_filed": "1983-07-20T04:00:00Z",
+    "docket_number": "SC1960-63991",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "AN-266",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "FLORIDA BAR v. DONALDSON",
+    "case_name_full": "FLORIDA BAR v. DONALDSON",
+    "case_name_short": "",
+    "case_uuid": "90429a0c-3156-49bc-b8c6-55b62d477f01",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000302,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-20",
+    "datetime_filed": "1983-07-20T04:00:00Z",
+    "docket_number": "SC1960-63993",
+    "docket_type": "bar",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Florida Bar",
+      "Migration"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "FLORIDA BAR v. FINKELSTEIN",
+    "case_name_full": "FLORIDA BAR v. FINKELSTEIN",
+    "case_name_short": "",
+    "case_uuid": "fcb9cc17-6591-45ac-bbd4-221dfbc26ea0",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000302,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-20",
+    "datetime_filed": "1983-07-20T04:00:00Z",
+    "docket_number": "SC1960-63994",
+    "docket_type": "bar",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Florida Bar",
+      "Migration"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "TURNER v. STATE",
+    "case_name_full": "TURNER v. STATE",
+    "case_name_short": "TURNER VS STATE",
+    "case_uuid": "7eb263f7-0d49-4816-ad59-bce3ac1f0fdd",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000027,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-21",
+    "datetime_filed": "1983-07-21T04:00:00Z",
+    "docket_number": "SC1960-63997",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Mandatory Review",
+      "Notice of Appeal",
+      "Statutory/Constitutional Invalidity"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-1879",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "FLORIDA BAR RE : FENNEN",
+    "case_name_full": "FLORIDA BAR RE : FENNEN",
+    "case_name_short": "",
+    "case_uuid": "9571fa9b-74ba-4662-b130-7bff3baab75a",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000302,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-21",
+    "datetime_filed": "1983-07-21T04:00:00Z",
+    "docket_number": "SC1960-64000",
+    "docket_type": "bar",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Florida Bar",
+      "Migration"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "PLATEL v. MUSZYNSKI",
+    "case_name_full": "PLATEL v. MUSZYNSKI",
+    "case_name_short": "PLATEL VS MUSZYNSKI",
+    "case_uuid": "34541f86-9ad6-4004-a26e-004438c80f46",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000027,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-21",
+    "datetime_filed": "1983-07-21T04:00:00Z",
+    "docket_number": "SC1960-63999",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Mandatory Review",
+      "Notice of Appeal",
+      "Statutory/Constitutional Invalidity"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-1416",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "WASTE MANAGEMENT , INC . v. LANE",
+    "case_name_full": "WASTE MANAGEMENT , INC . v. LANE",
+    "case_name_short": "",
+    "case_uuid": "7e930aad-a987-4a7c-a78a-44e2aa827e36",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-21",
+    "datetime_filed": "1983-07-21T04:00:00Z",
+    "docket_number": "SC1960-64002",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "81-1654; 81-1746",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      },
+      {
+        "case_number": "81-849; 81-850",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "Rose v. State of Florida",
+    "case_name_full": "Rose v. State of Florida",
+    "case_name_short": "Rose",
+    "case_uuid": "2a9c093d-8a58-4089-99e8-5f0bb69a0065",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000002,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-21",
+    "datetime_filed": "1983-07-21T04:00:00Z",
+    "docket_number": "SC1960-63996",
+    "docket_type": "death_appeal",
+    "docket_type_raw": [
+      "Mandatory Review",
+      "Death Penalty Appeal",
+      "Resentencing"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "76-5036 CF",
+        "court_id": "flcrct",
+        "court_name": "Circuit Court for the Seventeenth Judicial Circuit, Broward County"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "WEISSMAN v. CHILDS",
+    "case_name_full": "WEISSMAN v. CHILDS",
+    "case_name_short": "WEISSMAN VS CHILDS",
+    "case_uuid": "5fa94db0-65fe-4601-8824-86e416ca7d8c",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000027,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-21",
+    "datetime_filed": "1983-07-21T04:00:00Z",
+    "docket_number": "SC1960-63998",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Mandatory Review",
+      "Notice of Appeal",
+      "Statutory/Constitutional Invalidity"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-1448",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "CARTER v. CITY OF STUART",
+    "case_name_full": "CARTER v. CITY OF STUART",
+    "case_name_short": "",
+    "case_uuid": "7208434b-e075-40fa-aa0b-72838744d0a4",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000036,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-21",
+    "datetime_filed": "1983-07-21T04:00:00Z",
+    "docket_number": "SC1960-64001",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Certified Great Public Importance"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-125",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "TILCON CONSTRUC . & PLANT v. ALSTON",
+    "case_name_full": "TILCON CONSTRUC . & PLANT v. ALSTON",
+    "case_name_short": "",
+    "case_uuid": "e75829d9-0fac-4f24-8993-21fb3a4d7d27",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-22",
+    "datetime_filed": "1983-07-22T04:00:00Z",
+    "docket_number": "SC1960-64005",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-1894",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "JONES ( EARL JEROME ) v. STATE",
+    "case_name_full": "JONES ( EARL JEROME ) v. STATE",
+    "case_name_short": "",
+    "case_uuid": "cea65227-72fb-4a84-bfaf-d11525f7a64b",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000044,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-22",
+    "datetime_filed": "1983-07-22T04:00:00Z",
+    "docket_number": "SC1960-64007",
+    "docket_type": "order",
+    "docket_type_raw": [
+      "Original Proceedings",
+      "Writ",
+      "Mandamus"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "KRASNOSKY v. MEREDITH",
+    "case_name_full": "KRASNOSKY v. MEREDITH",
+    "case_name_short": "KRASNOSKY VS MEREDITH",
+    "case_uuid": "f6a9f980-a609-4bc7-bb06-087a42a37794",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-22",
+    "datetime_filed": "1983-07-22T04:00:00Z",
+    "docket_number": "SC1960-64010",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "AP-207",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "TYSON v. EDWARDS",
+    "case_name_full": "TYSON v. EDWARDS",
+    "case_name_short": "TYSON VS EDWARDS",
+    "case_uuid": "c5b62801-ad1d-4aa2-af48-362aeb219a33",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-22",
+    "datetime_filed": "1983-07-22T04:00:00Z",
+    "docket_number": "SC1960-64004",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "81-949",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "MARANO v. CELOTEX CORPORATION , ET",
+    "case_name_full": "MARANO v. CELOTEX CORPORATION , ET",
+    "case_name_short": "",
+    "case_uuid": "ec871bfc-6051-4844-bf0f-00a49a87f2f6",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000032,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-22",
+    "datetime_filed": "1983-07-22T04:00:00Z",
+    "docket_number": "SC1960-64006",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Statutory Validity"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "82-1283",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  },
+  {
+    "arguments": [],
+    "case_group_flag": null,
+    "case_name": "WALKER v. DUGGER",
+    "case_name_full": "WALKER v. DUGGER",
+    "case_name_short": "WALKER VS DUGGER",
+    "case_uuid": "e3509326-0c4d-4700-a137-131470bd8105",
+    "class_group_type": "",
+    "class_group_type_id": 0,
+    "classification_id": 1000035,
+    "closed_flag": true,
+    "court_abbreviation": "Supreme Court of Florida",
+    "court_id": "flsc",
+    "date_filed": "1983-07-22",
+    "datetime_filed": "1983-07-22T04:00:00Z",
+    "docket_number": "SC1960-64008",
+    "docket_type": "notice",
+    "docket_type_raw": [
+      "Discretionary Review",
+      "Notice to Invoke",
+      "Direct Conflict of Decisions"
+    ],
+    "entries": [],
+    "location": "",
+    "location_id": 0,
+    "originating_cases": [
+      {
+        "case_number": "AS-59",
+        "court_id": "flunknown",
+        "court_name": "Unknown Court"
+      }
+    ],
+    "panel_flag": null,
+    "parties": [],
+    "transfers": []
+  }
+]


### PR DESCRIPTION
Maps "Unknown court" originating court name from ACIS to `FloridaCourtID.UNKNOWN`.

Downgrades log for unrecognized court name to a warning to cut down on noise.