### PR TITLE
fix(free_documents): remove `miwb` from excluded courts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,7 +34,7 @@ Changes:
 - Downgrade unrecognized court name log from error to warning
 
 Fixes:
--
+- Remove `miwb` from free documents excluded courts #2029
 
 ## 3.0.29 - 2026-06-26
 

--- a/juriscraper/pacer/free_documents.py
+++ b/juriscraper/pacer/free_documents.py
@@ -34,7 +34,7 @@ logger = make_default_logger()
 class FreeOpinionReport(BaseReport):
     """An object for querying and parsing the free opinion report."""
 
-    EXCLUDED_COURT_IDS = ["casb", "innb", "miwb", "ohsb"]
+    EXCLUDED_COURT_IDS = ["casb", "innb", "ohsb"]
     VALID_SORT_PARAMS = ("date_filed", "case_number")
 
     def __init__(self, court_id, pacer_session=None):


### PR DESCRIPTION
Fixes #2029

The "Written Opinion Report" is now working for that court