### PR TITLE
fix(florida): Parsing issues found during initial scraper run

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,8 @@ Changes:
 -
 
 Fixes:
--
+
+- Minor Florida parsing issues found during scraper run
 
 ## 3.0.30 - 2026-06-29
 
@@ -34,6 +35,7 @@ Changes:
 - Downgrade unrecognized court name log from error to warning
 
 Fixes:
+
 - Remove `miwb` from free documents excluded courts #2029
 
 ## 3.0.29 - 2026-06-26

--- a/juriscraper/state/florida/cases.py
+++ b/juriscraper/state/florida/cases.py
@@ -151,6 +151,8 @@ def florida_originating_court_id_validator(i: str) -> FloridaCourtID:
             return FloridaCourtID.FIFTH_COA
         case "6th district court of appeal":
             return FloridaCourtID.SIXTH_COA
+        case "supreme court of florida":
+            return FloridaCourtID.SUPREME_COURT
         case "uscoa":
             return FloridaCourtID.US_COA
         case "division of administrative hearings":
@@ -180,7 +182,9 @@ class FloridaOriginatingCase(BaseModel):
             florida_originating_court_id_validator, json_schema_input_type=str
         ),
     ] = Field(validation_alias="originatingCourtName")
-    case_number: str = Field(validation_alias="originatingCaseNumber")
+    case_number: str = Field(
+        validation_alias="originatingCaseNumber", default=""
+    )
 
 
 def florida_external_id_to_js_id_validator(i: str) -> str:


### PR DESCRIPTION
Per findings from https://github.com/freelawproject/courtlistener/issues/7432

Adds empty string default for originating case numbers.

Adds support for Supreme Court as originating court.