### PR TITLE
Fall back to a user-writable default log location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ Changes:
 
 Fixes:
 
+- `lib.log_tools`: the default log location now falls back to `~/.cache/juriscraper/debug.log` (created on demand) when `/var/log/juriscraper` is not writable, so importing a scraper no longer prints a warning and drops to stderr on machines without that directory. Honors `JURISCRAPER_LOG` and the writable `/var/log/juriscraper` path unchanged.
 - Minor Florida parsing issues found during scraper run
 
 ## 3.0.30 - 2026-06-29

--- a/juriscraper/lib/log_tools.py
+++ b/juriscraper/lib/log_tools.py
@@ -4,9 +4,28 @@ import os
 import sys
 import traceback
 
-LOG_FILENAME = os.environ.get(
-    "JURISCRAPER_LOG", "/var/log/juriscraper/debug.log"
-)
+SYSTEM_LOG_DIR = "/var/log/juriscraper"
+
+
+def default_log_location():
+    """Pick a log path that is likely to be writable.
+
+    Order of preference: the JURISCRAPER_LOG environment variable, the
+    traditional /var/log/juriscraper location when that directory is
+    writable (typical on provisioned servers), and finally a per-user
+    cache directory that make_default_logger can create.
+    """
+    env_path = os.environ.get("JURISCRAPER_LOG")
+    if env_path:
+        return env_path
+    if os.access(SYSTEM_LOG_DIR, os.W_OK):
+        return os.path.join(SYSTEM_LOG_DIR, "debug.log")
+    return os.path.join(
+        os.path.expanduser("~"), ".cache", "juriscraper", "debug.log"
+    )
+
+
+LOG_FILENAME = default_log_location()
 
 
 def errprint(*args, **kwargs):
@@ -25,6 +44,9 @@ def make_default_logger(file_path=LOG_FILENAME):
         logger.setLevel(logging.DEBUG)
         # Create a handler and attach it to the logger
         try:
+            log_dir = os.path.dirname(file_path)
+            if log_dir and not os.path.isdir(log_dir):
+                os.makedirs(log_dir, exist_ok=True)
             handler = logging.handlers.RotatingFileHandler(
                 file_path, maxBytes=5120000, backupCount=7
             )

--- a/tests/local/test_LogToolsTest.py
+++ b/tests/local/test_LogToolsTest.py
@@ -1,0 +1,69 @@
+import logging
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from juriscraper.lib import log_tools
+
+
+class LogToolsTest(unittest.TestCase):
+    """Tests for default log location fallback and logger creation."""
+
+    def test_env_var_takes_precedence(self):
+        with mock.patch.dict(
+            os.environ, {"JURISCRAPER_LOG": "/tmp/custom.log"}
+        ):
+            self.assertEqual(
+                log_tools.default_log_location(), "/tmp/custom.log"
+            )
+
+    def test_system_dir_used_when_writable(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JURISCRAPER_LOG", None)
+            with mock.patch(
+                "juriscraper.lib.log_tools.os.access", return_value=True
+            ):
+                self.assertEqual(
+                    log_tools.default_log_location(),
+                    os.path.join(log_tools.SYSTEM_LOG_DIR, "debug.log"),
+                )
+
+    def test_falls_back_to_user_cache_dir(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("JURISCRAPER_LOG", None)
+            with mock.patch(
+                "juriscraper.lib.log_tools.os.access", return_value=False
+            ):
+                expected = os.path.join(
+                    os.path.expanduser("~"),
+                    ".cache",
+                    "juriscraper",
+                    "debug.log",
+                )
+                self.assertEqual(log_tools.default_log_location(), expected)
+
+    def test_make_default_logger_creates_missing_directory(self):
+        logger = logging.getLogger("juriscraper.lib.log_tools")
+        saved_handlers = logger.handlers[:]
+        logger.handlers.clear()
+        try:
+            with tempfile.TemporaryDirectory() as tmp:
+                file_path = os.path.join(tmp, "nested", "debug.log")
+                result = log_tools.make_default_logger(file_path)
+                self.assertTrue(os.path.isdir(os.path.dirname(file_path)))
+                self.assertTrue(
+                    any(
+                        isinstance(h, logging.handlers.RotatingFileHandler)
+                        for h in result.handlers
+                    )
+                )
+        finally:
+            for handler in logger.handlers:
+                handler.close()
+            logger.handlers.clear()
+            logger.handlers.extend(saved_handlers)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

`make_default_logger` defaults `LOG_FILENAME` to `/var/log/juriscraper/debug.log`. That directory rarely exists on a developer machine, so simply importing any scraper prints:

```
Warning: No such file or directory: /var/log/juriscraper/debug.log. Have you created the directory for the log?
Juriscraper will continue to run, and all logs will be sent to stderr.
```

and logging silently drops to stderr.

## Fix

Choose the default log path in this order:

1. `JURISCRAPER_LOG` if set (unchanged);
2. `/var/log/juriscraper/debug.log` when that directory is writable (unchanged behavior on provisioned servers);
3. otherwise `~/.cache/juriscraper/debug.log`, and `make_default_logger` creates the parent directory on demand.

Server deployments that rely on `/var/log/juriscraper` are unaffected; developer machines get working file logging with no warning.

## Tests

Adds `tests/local/test_LogToolsTest.py` covering the three fallback branches and the on-demand directory creation. The full local suite passes (146 tests / 1,690 subtests).