### PR TITLE
fix(ohio): make __EVENTVALIDATION optional in search POST

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,8 @@ Changes:
 - `guam`: move legacy `get_items` type to a class attribute for subclass reuse. Did this for `superctguam`
 
 Fixes:
--
+
+- Fix Ohio scrapers by making `__EVENTVALIDATION` optional #2032
 
 ## 3.0.31 - 2026-07-09
 

--- a/juriscraper/opinions/united_states/state/ohio.py
+++ b/juriscraper/opinions/united_states/state/ohio.py
@@ -9,6 +9,7 @@ History:
  - 2015-07-31: Redone by mlr to use ghost driver. Alas, their site used to be
                great, but now it's terribly frustrating.
  - 2021-12-28: Remove selenium by flooie
+ - 2026-07-11: Make __EVENTVALIDATION optional; site stopped emitting it
 """
 
 from datetime import date
@@ -104,7 +105,6 @@ class Site(OpinionSiteLinear):
 
         :return: None
         """
-        event_validation = self.html.xpath("//input[@id='__EVENTVALIDATION']")
         view_state = self.html.xpath("//input[@id='__VIEWSTATE']")
         self.parameters = {
             "__VIEWSTATEENCRYPTED": "",
@@ -113,9 +113,16 @@ class Site(OpinionSiteLinear):
             "ctl00$MainContent$ddlDecidedYearMax": f"{self.year}",
             "ctl00$MainContent$ddlCounty": "0",
             "ctl00$MainContent$ddlRowsPerPage": self.rows_per_page,
-            "__EVENTVALIDATION": event_validation[0].get("value"),
             "__VIEWSTATE": view_state[0].get("value"),
         }
+
+        # The site stopped emitting __EVENTVALIDATION around 2026-06-29;
+        # send it only when present so both variants work
+        event_validation = self.html.xpath("//input[@id='__EVENTVALIDATION']")
+        if event_validation:
+            self.parameters["__EVENTVALIDATION"] = event_validation[0].get(
+                "value"
+            )
 
         if page_number:
             self.parameters.update(


### PR DESCRIPTION
Fixes #2032

The Ohio opinion search at supremecourt.ohio.gov stopped emitting the `__EVENTVALIDATION` hidden input around June 29 (ASP.NET event validation appears to have been disabled), so `set_parameters` crashed with `IndexError` for every scraper in the ohio family (`ohio`, `ohioctapp_1`-`12`, `ohioctcl`).

This includes the field in the search POST only when the page provides it, so the scraper works with either variant. Verified live: the search POST succeeds without the field, the results grid is unchanged, and `ohio` / `ohioctapp_8` both parse current opinions (through 7/10/2026). All existing ohio example fixtures parse unchanged.