### PR TITLE
fix(asbca, uscgcoca): update headers to match Chrome 149

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Changes:
 -
 
 Fixes:
--
+- Fix `asbca` and `uscgcoca` headers (Chrome 149) #2043
 
 ## 3.0.32 - 2026-07-14
 

--- a/juriscraper/opinions/united_states/administrative_agency/asbca.py
+++ b/juriscraper/opinions/united_states/administrative_agency/asbca.py
@@ -30,7 +30,7 @@ class Site(OpinionSiteLinear):
             "accept-encoding": "gzip, deflate, br, zstd",
             "accept-language": "en-US,en;q=0.9",
             "priority": "u=0, i",
-            "sec-ch-ua": '"Chromium";v="142", "Not:A-Brand";v="24", "Google Chrome";v="142"',
+            "sec-ch-ua": '"Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24"',
             "sec-ch-ua-mobile": "?0",
             "sec-ch-ua-platform": '"Linux"',
             "sec-fetch-dest": "document",
@@ -38,7 +38,7 @@ class Site(OpinionSiteLinear):
             "sec-fetch-user": "?1",
             "sec-fetch-site": "cross-site",
             "upgrade-insecure-requests": "1",
-            "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
+            "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
         }
         self.needs_special_headers = True
 

--- a/juriscraper/opinions/united_states/federal_special/uscgcoca.py
+++ b/juriscraper/opinions/united_states/federal_special/uscgcoca.py
@@ -30,7 +30,7 @@ class Site(OpinionSiteLinear):
             "accept-encoding": "gzip, deflate, br, zstd",
             "accept-language": "en-US,en;q=0.9",
             "priority": "u=0, i",
-            "sec-ch-ua": '"Chromium";v="134", "Not:A-Brand";v="24", "Google Chrome";v="142"',
+            "sec-ch-ua": '"Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24"',
             "sec-ch-ua-mobile": "?0",
             "sec-ch-ua-platform": '"Linux"',
             "sec-fetch-dest": "document",
@@ -38,7 +38,7 @@ class Site(OpinionSiteLinear):
             "sec-fetch-site": "cross-site",
             "sec-fetch-user": "?1",
             "upgrade-insecure-requests": "1",
-            "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36",
+            "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
         }
         self.needs_special_headers = True
         self.should_have_results = True


### PR DESCRIPTION
Updated `asbca` and `uscgcoca` request headers to Chrome 149 (same approach as #1693 / #1664).

Related to #2043

I tested both scrapers locally with the old headers and they worked. I tested again after this change. As in #1664, this looks like a headers issue rather than an IP block. I can't verify production from here, so I'm opening this PR for you to confirm.

More context:

- **`asbca`**: local scrape and court webpage show the latest date filed as **2026-06-25**; [CourtListener API](https://www.courtlistener.com/api/rest/v4/search/?type=o&court=asbca&order_by=dateFiled%20desc&page_size=3) tops out around **2026-06-12**.
- **`uscgcoca`**: local scrape and court webpage show the latest opinion filed **2026-05-07**; [CourtListener API](https://www.courtlistener.com/api/rest/v4/search/?type=o&court=uscgcoca&order_by=dateFiled%20desc&page_size=3) latest is **2023-05-09**.
