### PR TITLE
feat(free_documents): expose reported_opinion_count on FreeOpinionReport

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,10 @@ Releases are also tagged in git, if that's helpful.
 The following changes are not yet released, but are code complete:
 
 Features:
--
+- `FreeOpinionReport`: expose a `reported_opinion_count` property with PACER's
+  own "Total number of opinions reported" total (summed across queried pages).
+  It's independent of `len(report.data)`, so comparing the two surfaces silent
+  parse gaps (e.g. PACER reports 52 opinions but only 12 rows parse).
 
 Changes:
 -

--- a/juriscraper/pacer/free_documents.py
+++ b/juriscraper/pacer/free_documents.py
@@ -148,16 +148,36 @@ class FreeOpinionReport(BaseReport):
         self.tree.rewrite_links(fix_links_in_lxml_tree, base_href=self.url)
         self.trees.append(self.tree)
 
+    @staticmethod
+    def _get_reported_opinion_count(tree):
+        """PACER's "Total number of opinions reported" value for one page.
+
+        :param tree: a parsed lxml tree for a single result page.
+        :return: the reported opinion count as an int.
+        """
+        return int(
+            tree.xpath(
+                '//b[contains(text(), "Total number of opinions reported")]'
+            )[0].tail
+        )
+
+    @property
+    def reported_opinion_count(self):
+        """Total opinions PACER reported across all queried pages for this scrape.
+
+        This is PACER's own count, independent of how many rows we successfully
+        parsed. Comparing it against ``len(self.data)`` surfaces silent parse
+        gaps.
+        """
+        return sum(
+            self._get_reported_opinion_count(tree) for tree in self.trees
+        )
+
     @property
     def data(self):
         results = []
         for tree in self.trees:
-            opinion_count = int(
-                tree.xpath(
-                    '//b[contains(text(), "Total number of '
-                    'opinions reported")]'
-                )[0].tail
-            )
+            opinion_count = self._get_reported_opinion_count(tree)
             if opinion_count == 0:
                 continue
             rows = tree.xpath("(//table)[1]//tr[position() > 1]")

--- a/tests/local/test_PacerFreeOpinionReportTest.py
+++ b/tests/local/test_PacerFreeOpinionReportTest.py
@@ -19,3 +19,29 @@ class PacerFreeOpinionReportTest(PacerParseTestCase):
             "*.html",
             FreeOpinionReport,
         )
+
+    def test_reported_opinion_count(self):
+        """reported_opinion_count returns PACER's own "Total number of
+        opinions reported", which is independent of how many rows we parse.
+
+        cand_2 is a real example where PACER reports 52 opinions but only 12
+        rows are parsable: exactly the silent gap this count exists to expose.
+        """
+        # (fixture, expected reported count, expected parsed rows)
+        cases = [
+            ("areb_1", 1, 1),
+            ("cacd_1", 2, 2),
+            ("cand_2", 52, 12),
+        ]
+        for fixture, reported, parsed in cases:
+            with self.subTest(fixture=fixture):
+                court = fixture.rsplit("_", 1)[0]
+                report = FreeOpinionReport(court)
+                path = os.path.join(
+                    TESTS_ROOT_EXAMPLES_PACER_FREE_OPINION_REPORT,
+                    f"{fixture}.html",
+                )
+                with open(path, encoding="utf-8") as f:
+                    report._parse_text(f.read())
+                self.assertEqual(report.reported_opinion_count, reported)
+                self.assertEqual(len(report.data), parsed)


### PR DESCRIPTION
Fixes #2054

## What & why

The Written Opinions report HTML contains PACER's own tally — "Total number of opinions reported" — but `FreeOpinionReport` computed it only to skip empty pages and then threw it away. This PR surfaces it as a public `reported_opinion_count` property.

It's independent of `len(report.data)` (the rows we actually parse), so comparing the two lets consumers detect **silent parse gaps**: cases where PACER says there are N opinions but we parse fewer, which usually means the docket-number / case-name / date "repair" logic in `FreeOpinionRow` is failing (e.g. the parser is out of date for that court).

This is groundwork for CourtListener [#7424](https://github.com/freelawproject/courtlistener/issues/7424) / [PR #7446](https://github.com/freelawproject/courtlistener/pull/7446), which will persist the reported count alongside the parsed/ingested counts on `PACERFreeDocumentLog` to make silent gaps queryable.

## Changes

- Factor the existing "Total number of opinions reported" extraction into a static helper `_get_reported_opinion_count(tree)`, reused by `data`.
- Add the `reported_opinion_count` property, summing across all queried pages (`self.trees`), since a scrape can span multiple sub-queries via `day_span`.
- `data`'s shape and behavior are unchanged (still a list; still raises on a malformed page missing the marker, on purpose — silently treating it as "0" would mask the very failures this exists to catch).

## Tests

- Existing `test_free_opinion_report` is unchanged and still green (proves the `data`/fixture shape is intact).
- New `test_reported_opinion_count` asserts reported-vs-parsed across fixtures. The `cand_2` fixture is a real example of the gap: PACER reports **52** opinions but only **12** rows parse.
- Full `tests/local` suite passes (143 tests).
