### PR TITLE
fix(free_documents): tolerate unlinked opinion rows and distinguish truncation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ Changes:
 -
 
 Fixes:
--
+- `FreeOpinionReport`: a single unparsable opinion row (e.g. one whose "Doc. #" cell has no link) no longer aborts the whole report — the row is skipped and logged, and its `pacer_doc_id` is `None`. Also, a page missing the "Total number of opinions reported" banner now raises `ParsingException` instead of a bare `IndexError`, so genuine truncation stops being confused with parse bugs. #2053
 
 ## 3.0.33 - 2026-07-21
 

--- a/juriscraper/pacer/free_documents.py
+++ b/juriscraper/pacer/free_documents.py
@@ -5,7 +5,10 @@ which is free.
 import pprint
 import sys
 
+from lxml.html import tostring
+
 from juriscraper.lib.date_utils import make_date_range_tuples
+from juriscraper.lib.exceptions import ParsingException
 from juriscraper.lib.html_utils import (
     clean_html,
     fix_links_in_lxml_tree,
@@ -154,12 +157,18 @@ class FreeOpinionReport(BaseReport):
 
         :param tree: a parsed lxml tree for a single result page.
         :return: the reported opinion count as an int.
+        :raises ParsingException: if the banner is missing, which usually means
+            the page was truncated (e.g. proxy timeout) or is an unknown layout.
         """
-        return int(
-            tree.xpath(
-                '//b[contains(text(), "Total number of opinions reported")]'
-            )[0].tail
+        banner = tree.xpath(
+            '//b[contains(text(), "Total number of opinions reported")]'
         )
+        if not banner:
+            raise ParsingException(
+                "'Total number of opinions reported' banner not found — page "
+                "truncated or unknown layout."
+            )
+        return int(banner[0].tail)
 
     @property
     def reported_opinion_count(self):
@@ -181,14 +190,28 @@ class FreeOpinionReport(BaseReport):
             if opinion_count == 0:
                 continue
             rows = tree.xpath("(//table)[1]//tr[position() > 1]")
-            for row in rows:
-                if results:
+            for i, row_el in enumerate(rows):
+                try:
                     # If we have results already, pass the previous result to
-                    # the FreeOpinionRow object.
-                    row = FreeOpinionRow(row, results[-1], self.court_id)
-                else:
-                    row = FreeOpinionRow(row, {}, self.court_id)
-                results.append(row.data)
+                    # the FreeOpinionRow object so it can fill in cells the
+                    # report leaves blank when repeated.
+                    last_good_row = results[-1] if results else {}
+                    row = FreeOpinionRow(row_el, last_good_row, self.court_id)
+                    results.append(row.data)
+                except Exception:
+                    # One malformed or unknown-layout row must not abort the
+                    # whole report. Log loudly (with just the offending row,
+                    # not the whole page) so the failure stays diagnosable
+                    # rather than masked as a truncation. See issue #2053.
+                    logger.error(
+                        "Skipping unparsable row %s in %s's written opinion "
+                        "report:\n%s",
+                        i,
+                        self.court_id,
+                        tostring(row_el).decode("utf-8"),
+                        exc_info=True,
+                    )
+                    continue
         logger.info(
             "Parsed %s results from written opinions report at %s",
             len(results),
@@ -411,11 +434,20 @@ class FreeOpinionRow(BaseDocketReport):
             return convert_date_string(s)
 
     def get_pacer_doc_id(self):
-        doc1_url = self.element.xpath("./td[3]//@href")[0]
-        return get_pacer_doc_id_from_doc1_url(doc1_url)
+        hrefs = self.element.xpath("./td[3]//@href")
+        if not hrefs:
+            # e.g. insb: the opinion's own Doc. # cell is plain text; the only
+            # doc1 link in the row lives in the description, for a different
+            # document. There's no doc id to extract, so return None rather
+            # than aborting the whole report.
+            return None
+        return get_pacer_doc_id_from_doc1_url(hrefs[0])
 
     def get_document_number(self):
-        return self.element.xpath("./td[3]//text()")[0]
+        text = self.element.xpath("./td[3]//text()")
+        if not text:
+            return None
+        return text[0]
 
     def get_description(self):
         return self.element.xpath("./td[4]")[0].text_content()

--- a/juriscraper/pacer/free_documents.py
+++ b/juriscraper/pacer/free_documents.py
@@ -185,6 +185,12 @@ class FreeOpinionReport(BaseReport):
     @property
     def data(self):
         results = []
+        # The row immediately above the current one, used to fill in cells the
+        # report leaves blank when a case repeats across consecutive rows. This
+        # must track the *adjacent* row, not results[-1]: after a row is
+        # skipped, results[-1] is an earlier, non-adjacent row, and a blank
+        # continuation row would silently inherit its (wrong) case identity.
+        last_good_row = {}
         for tree in self.trees:
             opinion_count = self._get_reported_opinion_count(tree)
             if opinion_count == 0:
@@ -192,12 +198,8 @@ class FreeOpinionReport(BaseReport):
             rows = tree.xpath("(//table)[1]//tr[position() > 1]")
             for i, row_el in enumerate(rows):
                 try:
-                    # If we have results already, pass the previous result to
-                    # the FreeOpinionRow object so it can fill in cells the
-                    # report leaves blank when repeated.
-                    last_good_row = results[-1] if results else {}
                     row = FreeOpinionRow(row_el, last_good_row, self.court_id)
-                    results.append(row.data)
+                    row_data = row.data
                 except Exception:
                     # One malformed or unknown-layout row must not abort the
                     # whole report. Log loudly (with just the offending row,
@@ -211,7 +213,13 @@ class FreeOpinionReport(BaseReport):
                         tostring(row_el).decode("utf-8"),
                         exc_info=True,
                     )
+                    # Invalidate last_good_row so a blank continuation row that
+                    # follows this skipped row fails loudly (and is skipped too)
+                    # rather than inheriting an unrelated case's identity.
+                    last_good_row = {}
                     continue
+                results.append(row_data)
+                last_good_row = row_data
         logger.info(
             "Parsed %s results from written opinions report at %s",
             len(results),

--- a/tests/examples/pacer/free_opinion_report/insb_1.html
+++ b/tests/examples/pacer/free_opinion_report/insb_1.html
@@ -1,0 +1,112 @@
+<html><head><link rel="shortcut icon"  href="/favicon.ico"/><title>CM/ECF - U.S. Bankruptcy Court:insb</title>
+<script type="text/javascript">document.cookie = "PRTYPE=web; path=/;"</script> <script>var default_base_path = "/"; </script> <link rel="stylesheet" type="text/css" href="/css/default.css"><script type="text/javascript" src="/lib/core.js"></script><script type="text/javascript" src="/lib/DisableAJTALinks.js"></script><script type="text/javascript">if (top!=self) {top.location.replace(location.href);}</script><script>var default_base_path = "/"; </script>
+<SCRIPT LANGUAGE="JavaScript">
+/********************************************************************************************
+  Purpose: To open Procedures Manual page in a new window
+
+  Parameters:
+    tcPmLink: URL of Procedures Manual page
+
+  Return: Always false
+ ********************************************************************************************/
+
+function VisitPmLink(tcPmLink) {
+// Pull up Procedures Manual page in a new window
+
+  if (typeof(oPmWindow) == 'undefined' || oPmWindow.closed ||
+      typeof(cPmLink) == 'undefined' || cPmLink != tcPmLink) {
+                                                 // If window/link have never been activated...
+    cPmLink = tcPmLink;                          // Save URL to prevent duplicate windows
+    oPmWindow = window.open(cPmLink, 'PmLink', 'location=yes,resizable=yes,scrollbars=yes');
+                                                 // Open window with Procedures Manual page
+  }
+  oPmWindow.focus();                             // Make sure Procedures Manual window is on top
+
+// Exit method
+
+  return false;                                  // Prevent processing of HREF from onClick
+}
+</SCRIPT><script type="text/javascript" src="/cgi-bin/menu.pl?id=-1"></script></head><body BGCOLOR=F9F9F9 TEXT=000000 onLoad='SetFocus()'>
+        <div class="noprint">
+        <div id="topmenu" class="yuimenubar"><div class="bd">
+        <img id="cmecfLogo" class="cmecfLogo" src="/graphics/logo-cmecf-sm.png" alt="CM/ECF" title="" onClick="CMECF.MainMenu.showCourtInformation(); return false" />
+        <ul class="first-of-type">
+      
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href='/cgi-bin/iquery.pl'><u>Q</u>uery</a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href='/cgi-bin/DisplayMenu.pl?Reports&id=-1'><u>R</u>eports <div class='spritedownarrow'></div></a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href='/cgi-bin/DisplayMenu.pl?Utilities&id=-1'><u>U</u>tilities <div class='spritedownarrow'></div></a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" onClick="CMECF.MainMenu.showHelpPage(''); return false">Help</a></li>
+<li class="yuimenubaritem"><a class="yuimenubaritemlabel" href='/cgi-bin/login.pl?logout'>Log Out</a></li><li class='yuimenubaritem' id='placeholderForAlertsIcon'></li>
+        </ul></div>
+        <hr class="hrmenuseparator"></div></div>
+        
+      <script type="text/javascript">
+callCreateMenu=function(){
+        var fn = "CMECF.MainMenu.createMenu";
+        if(typeof CMECF.MainMenu.createMenu == 'function') {
+          CMECF.MainMenu.createMenu();
+        }
+                        }
+if (navigator.appVersion.indexOf("MSIE")==-1){window.setTimeout( function(){ callCreateMenu(); }, 1);}else{CMECF.util.Event.addListener(window, "load",  callCreateMenu());}</script> <div id="cmecfMainContent"><input STYLE="display:none" id="cmecfMainContentScroll" value="0"><SCRIPT LANGUAGE="JavaScript">
+		var IsForm = false;
+		var FirstField;
+		function SetFocus() {
+			if(IsForm) {
+				if(FirstField) {
+					var ind = FirstField.indexOf('document.',0);
+					if(ind == 0)
+					{
+						eval(FirstField);
+					}
+					else
+					{
+						var Code = "document.forms[0]."+FirstField+".focus();";
+						eval(Code);
+					}
+				} else {
+					var Cnt = 0;
+					while(document.forms[0].elements[Cnt] != null) {
+						try {
+							if(document.forms[0].elements[Cnt].type != "hidden" &&
+									!document.forms[0].elements[Cnt].disabled &&
+									!document.forms[0].elements[Cnt].readOnly) {
+								document.forms[0].elements[Cnt].focus();
+								break;
+							}
+						}
+						catch(e) {}
+						Cnt += 1;
+					}
+				}
+			}
+			return(true);
+		}
+		</SCRIPT>
+<center><h2>Written Opinions Report</h2>
+<h3 style='margin-top:0;margin-bottom:0'>U.S. Bankruptcy Court -- Southern District of Indiana</h3>
+<h3 style='margin-top:0;margin-bottom:0'>Filed Report Period: 8/20/2009 - 8/20/2009</h3>
+
+        <table border=1 rules=all cellpadding=3  style='margin-left:3px;margin-right:3px'>
+          <tr align=center>
+            <th>Case Number & Name:</th>
+            <th>Date Filed:</th>
+            <th>Doc. #</th>
+            <th>Description:</th></tr>
+<tr valign=top>
+	<td><A HREF='/cgi-bin/DktRpt.pl?500739'>08-50533 French Design Jewelry, Inc. et al v. Downey Creations, LLC et al</A></td>
+	<td>08/20/2009</td>
+	<td align=center>40</td>
+	<td>Findings of Fact and Conclusions of Law on Downey Creations, LLC'S Motion for Partial Summary Judgment(re: Doc # <a href='https://ecf.insb.uscourts.gov/doc1/072012916914'>25</a>). (jhw) Additional attachment(s) added on 8/21/2009 (Davidson, Cathy).</td>
+</tr>
+</table>
+</center>
+<br>&nbsp; <B>Total number of opinions reported:</B> 1<br>
+<center><h3 style='margin-bottom:0'>Selection Criteria for Report</h3>
+<table border=1 rules=all cellpadding=3>
+<tr><td class='label'>Case Number</td><td class='info'>All</td></tr>
+<tr><td class='label'>Office</td><td class='info'>All</td></tr>
+<tr><td class='label'>Filed date</td><td class='info'>8/20/2009 - 8/20/2009</td></tr>
+<tr><td><b>Sort by</b></td><td>Case Number</td></tr>
+</table>
+</center>
+</div></body></html>

--- a/tests/examples/pacer/free_opinion_report/insb_1.json
+++ b/tests/examples/pacer/free_opinion_report/insb_1.json
@@ -1,0 +1,20 @@
+[
+  {
+    "case_name": "French Design Jewelry, Inc. v. Downey Creations, LLC",
+    "cause": "",
+    "court_id": "insb",
+    "date_filed": "2009-08-20",
+    "description": "Findings of Fact and Conclusions of Law on Downey Creations, LLC'S Motion for Partial Summary Judgment(re: Doc # 25). (jhw) Additional attachment(s) added on 8/21/2009 (Davidson, Cathy).",
+    "docket_number": "08-50533",
+    "document_number": "40",
+    "federal_defendant_number": null,
+    "federal_dn_case_type": null,
+    "federal_dn_judge_initials_assigned": null,
+    "federal_dn_judge_initials_referred": null,
+    "federal_dn_office_code": null,
+    "nature_of_suit": "",
+    "pacer_case_id": "500739",
+    "pacer_doc_id": null,
+    "pacer_seq_no": null
+  }
+]

--- a/tests/local/test_PacerFreeOpinionReportTest.py
+++ b/tests/local/test_PacerFreeOpinionReportTest.py
@@ -95,3 +95,53 @@ class PacerFreeOpinionReportTest(PacerParseTestCase):
         log_text = "\n".join(cm.output)
         self.assertIn("Skipping unparsable row", log_text)
         self.assertIn("malformed row with no date cell", log_text)
+
+    def test_skipped_row_does_not_misattribute_continuation(self):
+        """When a case-establishing row is skipped, a following blank
+        continuation row must not silently inherit an earlier, unrelated
+        case's identity. It should be skipped too rather than misattributed.
+        See issue #2053 review.
+        """
+        # Row 1: Case A, complete. Row 2: Case B's establishing row, but with
+        # an empty date cell so get_date_filed raises and it is skipped. Row 3:
+        # Case B's continuation — a blank *case* cell (PACER omits the case name
+        # for consecutive docs of the same case) but a real date, so it depends
+        # entirely on last_good_row for its docket/case identity. Without
+        # invalidating last_good_row on the skip, row 3 would successfully parse
+        # and inherit Case A's identity — a silent misattribution.
+        html = """
+        <html><body>
+        <b>Total number of opinions reported:</b> 3<br>
+        <table>
+          <tr><th>Case</th><th>Date</th><th>Doc</th><th>Description</th></tr>
+          <tr valign=top>
+            <td><a href='/cgi-bin/DktRpt.pl?111'>08-11111 Case A v. Foo</a></td>
+            <td>08/20/2009</td>
+            <td align=center>10</td>
+            <td>Case A description</td>
+          </tr>
+          <tr valign=top>
+            <td><a href='/cgi-bin/DktRpt.pl?222'>08-22222 Case B v. Bar</a></td>
+            <td></td>
+            <td align=center>20</td>
+            <td>Case B first document</td>
+          </tr>
+          <tr valign=top>
+            <td></td>
+            <td>08/21/2009</td>
+            <td align=center>21</td>
+            <td>Case B second document</td>
+          </tr>
+        </table>
+        </body></html>
+        """
+        report = FreeOpinionReport("insb")
+        report._parse_text(html)
+        with self.assertLogs("juriscraper.lib.log_tools", level="ERROR"):
+            data = report.data
+        # Only Case A survives; both Case B rows are skipped (the establishing
+        # row raises, and the continuation row can no longer borrow an identity).
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["docket_number"], "08-11111")
+        # Critically, no row was misattributed to Case A.
+        self.assertEqual([row["docket_number"] for row in data], ["08-11111"])

--- a/tests/local/test_PacerFreeOpinionReportTest.py
+++ b/tests/local/test_PacerFreeOpinionReportTest.py
@@ -1,5 +1,7 @@
 import os
 
+from juriscraper.lib.exceptions import ParsingException
+from juriscraper.lib.html_utils import get_html_parsed_text
 from juriscraper.pacer.free_documents import FreeOpinionReport
 from tests import TESTS_ROOT_EXAMPLES_PACER
 from tests.local.PacerParseTestCase import PacerParseTestCase
@@ -32,6 +34,10 @@ class PacerFreeOpinionReportTest(PacerParseTestCase):
             ("areb_1", 1, 1),
             ("cacd_1", 2, 2),
             ("cand_2", 52, 12),
+            # insb_1: a complete four-column page whose single opinion row has
+            # an unlinked Doc. # cell. It must parse (pacer_doc_id=None) rather
+            # than aborting the whole report. See issue #2053.
+            ("insb_1", 1, 1),
         ]
         for fixture, reported, parsed in cases:
             with self.subTest(fixture=fixture):
@@ -45,3 +51,47 @@ class PacerFreeOpinionReportTest(PacerParseTestCase):
                     report._parse_text(f.read())
                 self.assertEqual(report.reported_opinion_count, reported)
                 self.assertEqual(len(report.data), parsed)
+
+    def test_missing_banner_raises_parsing_exception(self):
+        """A page missing the "Total number of opinions reported" banner
+        (truncation / unknown layout) raises a dedicated ParsingException
+        instead of a bare IndexError, so it stops sharing a Sentry fingerprint
+        with real parse bugs. See issue #2053.
+        """
+        tree = get_html_parsed_text(
+            "<html><body><p>No banner here.</p></body></html>"
+        )
+        with self.assertRaises(ParsingException):
+            FreeOpinionReport._get_reported_opinion_count(tree)
+
+    def test_unparsable_row_is_skipped_not_fatal(self):
+        """A single malformed row must not abort the whole report: it is
+        skipped and logged loudly, while the other rows still parse. See
+        issue #2053.
+        """
+        html = """
+        <html><body>
+        <b>Total number of opinions reported:</b> 2<br>
+        <table>
+          <tr><th>Case</th><th>Date</th><th>Doc</th><th>Description</th></tr>
+          <tr valign=top>
+            <td><a href='/cgi-bin/DktRpt.pl?500739'>08-50533 French Design Jewelry, Inc. v. Downey</a></td>
+            <td>08/20/2009</td>
+            <td align=center>40</td>
+            <td>Findings of Fact (re: Doc # <a href='https://ecf.insb.uscourts.gov/doc1/072012916914'>25</a>)</td>
+          </tr>
+          <tr><td>malformed row with no date cell</td></tr>
+        </table>
+        </body></html>
+        """
+        report = FreeOpinionReport("insb")
+        report._parse_text(html)
+        with self.assertLogs("juriscraper.lib.log_tools", level="ERROR") as cm:
+            data = report.data
+        # The good row survives; the malformed row is dropped.
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["docket_number"], "08-50533")
+        # The skip was logged loudly, naming the offending row.
+        log_text = "\n".join(cm.output)
+        self.assertIn("Skipping unparsable row", log_text)
+        self.assertIn("malformed row with no date cell", log_text)


### PR DESCRIPTION
Fixes #2053

## Problem

`FreeOpinionReport` crashed with a bare `IndexError` in two unrelated situations, and because CourtListener wraps both the same way, they were grouped under one Sentry issue mislabeled as a *"proxy timeout"*:

1. **Truncated / unknown-layout page** — the "Total number of opinions reported" banner is absent, so `_get_reported_opinion_count` indexed an empty list. Plausibly transient.
2. **Valid page, unlinked opinion row** — e.g. insb, filed `08/20/2009`. The page is complete (banner present, count = 1) but the opinion's `Doc. #` cell is plain text with no `<a>` link (the only `doc1` link in the row is in the description, for a *different* document). `get_pacer_doc_id` did `./td[3]//@href[0]` and raised `IndexError`.

Because the row loop had no per-row error handling, case 2 aborted the **entire** report permanently — no retry could ever ingest insb 2009-08-20.

## Changes

- **`get_pacer_doc_id`** returns `None` when the `Doc. #` cell has no `href`, matching the None-on-unlinked convention already used across the other PACER parsers (`docket_report`, `appellate_attachment_page`, etc.). The row is kept with its docket number, case name, date, and `pacer_case_id` intact.
- **`get_document_number`** guards an empty cell.
- **`_get_reported_opinion_count`** raises a descriptive `ParsingException` when the banner is missing, so genuine truncation gets its own Sentry fingerprint instead of a bare `IndexError`.
- **`data`** now skips an unparsable row — logging it loudly at `ERROR` with the offending row's HTML — rather than aborting the whole report. This is defense-in-depth against future unknown row variants, kept diagnosable so it can't be silently masked again.

## Tests

- New `insb_1.html` fixture (the real page from the issue) + auto-generated `insb_1.json`, which parses the row with `pacer_doc_id: null`.
- `test_reported_opinion_count` extended with the insb case.
- `test_missing_banner_raises_parsing_exception` — banner-less page raises `ParsingException`.
- `test_unparsable_row_is_skipped_not_fatal` — a report with one good and one malformed row returns exactly 1 parsed row and logs the skip.

Full local suite: 145 passed. `ruff` clean. No version bump (handled separately).
