### PR TITLE
fix(ny): strip site chrome (Adblock banner, header, footer) from new LRB template pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ Changes:
 -
 
 Fixes:
--
+- `ny.Site.cleanup_content` extracts only the opinion container from the new LRB page template, so site chrome ("disable Adblock" banner, header menus, footer) no longer pollutes opinion content. Covers all NY scrapers. #2058
 
 ## 3.0.33 - 2026-07-21
 

--- a/juriscraper/opinions/united_states/state/ny.py
+++ b/juriscraper/opinions/united_states/state/ny.py
@@ -237,7 +237,15 @@ class Site(OpinionSiteLinear):
         # #2058
         tree = fromstring(html_str)
         if opinion_container := tree.xpath('//main[@id="main"]'):
-            html_str = tostring(opinion_container[0], encoding="unicode")
+            html_str = tostring(
+                opinion_container[0], encoding="unicode", with_tail=False
+            )
+        elif "adblock" in html_str[:5000].lower():
+            logger.warning(
+                "ny: page has new-template site chrome but the "
+                '//main[@id="main"] opinion container was not found; '
+                "chrome will not be stripped"
+            )
 
         # remove a tags
         allowed = set(nh3.ALLOWED_TAGS)

--- a/juriscraper/opinions/united_states/state/ny.py
+++ b/juriscraper/opinions/united_states/state/ny.py
@@ -8,6 +8,7 @@ History:
  2016-05-04: Updated by arderyp to handle typos in docket string format
  2024-09-05: Updated by flooie to deal with block from main website
  2025-10-27: Updated by quevon24 to fix content cleanup
+ 2026-07-29: Updated by grossir to strip site chrome from the new LRB template
 """
 
 import re
@@ -208,14 +209,16 @@ class Site(OpinionSiteLinear):
 
     @staticmethod
     def cleanup_content(content: bytes) -> bytes:
-        """Remove hash altering timestamps to prevent duplicates
+        """Keep only the opinion content, without hash altering elements
 
+        On new-template pages, extracts the opinion container and discards
+        the surrounding site chrome (adblock banner, header, footer).
         Previously we've been more targeted about removing a href's but
         doctor will strip them out anyway so we should just clean our html
         content here.
 
         :param content: downloaded content `r.content`
-        :return: content without hash altering elements
+        :return: opinion content without hash altering elements
         """
         try:
             html_str = content.decode("utf-8")
@@ -224,6 +227,17 @@ class Site(OpinionSiteLinear):
 
         if not nh3.is_html(html_str):
             return content
+
+        # The Law Reporting Bureau page template (since ~April 2026) wraps
+        # the opinion in site chrome: a "disable Adblock" banner that is
+        # hidden client-side but always present in the HTML, header menus,
+        # breadcrumbs and a footer. Keep only the opinion container; older
+        # permanent-format pages have no such container and are cleaned
+        # whole. This must run before nh3, which strips the id attribute.
+        # #2058
+        tree = fromstring(html_str)
+        if opinion_container := tree.xpath('//main[@id="main"]'):
+            html_str = tostring(opinion_container[0], encoding="unicode")
 
         # remove a tags
         allowed = set(nh3.ALLOWED_TAGS)

--- a/juriscraper/opinions/united_states/state/nytrial.py
+++ b/juriscraper/opinions/united_states/state/nytrial.py
@@ -230,7 +230,7 @@ class Site(OpinionSiteLinear):
         return {k: v for k, v in metadata.items() if v}
 
     @staticmethod
-    def cleanup_content(content: str) -> str:
+    def cleanup_content(content: bytes) -> bytes:
         return ny.Site.cleanup_content(content)
 
     def make_backscrape_iterable(self, kwargs) -> None:

--- a/tests/examples/opinions/cleanup_content/ny_current_template.compare.html
+++ b/tests/examples/opinions/cleanup_content/ny_current_template.compare.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html><html><body><div>
+<div>
+<h1>70-35 113th St. Holdings, LLC v Auberge Grand Cent., LLC</h1>
+<p>2026 NY Slip Op 01932</p>
+<p>April 1, 2026</p>
+<p>Appellate Division, Second Department</p>
+<p>Published by New York State Law Reporting Bureau pursuant to Judiciary Law § 431.</p>
+<p>This decision is uncorrected and subject to revision before publication in the Official Reports.</p>
+</div>
+<div>
+<p>70-35 113th St. Holdings, LLC, appellant,</p>
+<p>v</p>
+<p>Auberge Grand Central, LLC, respondent, et al., defendant.</p>
+</div>
+<p>Supreme Court of the State of New York, Appellate Division, Second Judicial Department</p>
+<p>Decided on April 1, 2026</p>
+<p>2020-09425, (Index No. 707503/15)</p>
+<p>Linda Christopher, J.P.</p>
+<p>William G. Ford</p>
+<p>Barry E. Warhit</p>
+<p>Helen Voutsinas, JJ.</p>
+<div>
+<p>Lonuzzi &amp; Woodland, LLP (John Lonuzzi and Horn Appellate Group, Brooklyn, NY [Scott T. Horn], of counsel), for appellant.</p>
+<p>Mintz &amp; Gold LLP, New York, NY (Steven G. Mintz, Scott A. Klein, and Terence W. McCormick of counsel), for respondent.</p>
+</div>
+<span>[*1]</span>
+<p>DECISION &amp; ORDER</p>
+<p>In an action, inter alia, for specific performance of a contract for the sale of real property, the plaintiff appeals from a judgment of the Supreme Court, Queens County (Leonard Livote, J.), dated December 15, 2020. The judgment, insofar as appealed from, after a nonjury trial, is in favor of the defendant Auberge Grand Central, LLC, and against the plaintiff dismissing the complaint insofar as asserted against the defendant Auberge Grand Central, LLC.</p>
+<p>ORDERED that the judgment is affirmed insofar as appealed from, with costs.</p>
+<p>In January 2014, the plaintiff was the successful bidder at a foreclosure auction of the subject real property. The terms of sale dated January 10, 2014, made time of the essence as to the plaintiff. However, the plaintiff did not have sufficient funds and was unable to obtain financing, and thus, was unable to close on the property despite multiple adjournments of the closing date. The defendant Auberge Grand Central, LLC (hereinafter Auberge), which was also the plaintiff in the foreclosure action, was ultimately the successful bidder at a second foreclosure auction held in August 2014. The plaintiff commenced this action for specific performance of the terms of sale for the property or, in the alternative, to recover damages for breach of contract. After a nonjury trial, the Supreme Court issued a judgment, inter alia, in favor of Auberge and against the plaintiff dismissing the complaint insofar as asserted against Auberge. The plaintiff appeals from so much of the judgment as dismissed the complaint insofar as asserted against Auberge.</p>
+<p>The elements of a cause of action for specific performance of a contract for the sale of real property are that the plaintiff substantially performed its contractual obligations and was ready, willing, and able to perform its remaining obligations, that the defendant was able to convey the property, and that there was no adequate remedy at law (<i>see</i> <i>Kugel v Reynolds</i>, 228 AD3d 743, 748; <i>Treasure Is. of Asbury Park Self-Storage, LLC v MBAR Realty, LLC</i>, 216 AD3d 1200, 1203; <i>Rha v Blangiardo</i>, 189 AD3d 1098, 1099). A party seeking specific performance of a contract for the sale of real property is required to establish not only that it was ready, willing, and able to close on the scheduled closing date, but also that the other party was in default (<i>see</i> <i>Treasure Is. of Asbury Park Self-Storage, LLC v MBAR Realty, LLC</i>, 216 AD3d at 1203; <i>141 Park Ave. Realties, Inc. v 141 Park Ave. Holdings, LLC</i>, 216 AD3d 881, 883; <i>Rha v Blangiardo</i>, 189 AD3d at 1099). The decision <span>[*2]</span>whether to grant or deny the remedy of specific performance lies within the sound discretion of the court (<i>see</i> <i>Rha v Blangiardo</i>, 189 AD3d at 1099; <i>Cho v 401-403 57th St. Realty Corp.</i>, 300 AD2d 174, 175).</p>
+<p>When a contract for the sale of real property contains a provision that time is of the essence, the parties are obligated to comply strictly with its terms (<i>see</i> <i>Bank of Am. v Petit</i>, 89 AD3d 652, 653), and the parties bound by that clause must tender performance on the law day unless the time for performance has been extended by mutual agreement (<i>see</i> <i>184 Joralemon, LLC v Brklyn Hts Condos, LLC</i>, 117 AD3d 699, 702). Where time is of the essence, performance on the specific date is a material element of the contract, and failure to perform on that date constitutes a material breach of the contract (<i>see</i> <i>id.</i>; <i>Bank of Am. v Petit</i>, 89 AD3d at 653; <i>Kaiser-Haidri v Battery Place Green, LLC</i>, 85 AD3d 730, 733).</p>
+<p>Here, the Supreme Court properly dismissed the complaint insofar as asserted against Auberge. At trial, the plaintiff failed to establish that it was entitled to specific performance of the terms of sale for the property. Pursuant to the terms of sale, time was made of the essence as to the plaintiff. After four adjournments at the plaintiff's request, the plaintiff and Auberge entered into a written stipulation dated May 5, 2014, under which they agreed that the closing would be adjourned to May 29, 2014, with time being of the essence as to the plaintiff. The evidence at trial demonstrated that the plaintiff did not substantially perform its contractual obligations and was not ready, willing, and able to perform its remaining obligations, as the plaintiff did not appear at the May 29, 2014 closing and did not have the necessary financing in place at that time. Because time was made of the essence in the terms of sale, no separate notice of an intent to declare a default was necessary (<i>cf</i>. <i>Nehmadi v Davis</i>, 63 AD3d 1125; <i>Guippone v Gaias</i>, 13 AD3d 339). Moreover, the plaintiff was collaterally estopped from relitigating the issue of its default in closing, as that issue was raised in an action brought by Wing Fung Chau, on behalf of the plaintiff, and was decided against the plaintiff after a full and fair opportunity to contest that issue in that action (<i>see</i> <i>Simmons v Trans Express Inc.</i>, 37 NY3d 107, 112; <i>Buechel v Bain</i>, 97 NY2d 295, 303; <i>Caminero v Michael Flynn, Esq., PLLC.</i>, 239 AD3d 818). In addition, the plaintiff failed to demonstrate that Auberge was in default under the terms of sale.</p>
+<p>Accordingly, the Supreme Court properly dismissed the complaint insofar as asserted against Auberge.</p>
+<p>CHRISTOPHER, J.P., FORD, WARHIT and VOUTSINAS, JJ., concur.</p>
+<p>ENTER:</p>
+<p>Darrell M. Joseph</p>
+<p>Clerk of the Court</p>
+</div>
+
+		
+		</body></html>

--- a/tests/examples/opinions/cleanup_content/ny_current_template.compare.html
+++ b/tests/examples/opinions/cleanup_content/ny_current_template.compare.html
@@ -38,5 +38,4 @@
 <p>Clerk of the Court</p>
 </div>
 
-		
 		</body></html>

--- a/tests/examples/opinions/cleanup_content/ny_current_template.html
+++ b/tests/examples/opinions/cleanup_content/ny_current_template.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<link href="/reporter/css/style.css" type="text/css" rel="stylesheet" />
+		
+		<title>70-35 113th St. Holdings, LLC v Auberge Grand Cent., LLC - 2026 NY Slip Op 01932</title>
+	</head>
+	<body>
+		<div class="skipcontent">
+    <a href="#main">skip to main content</a>
+</div>
+
+<!-- Adblock Banner -->
+<div id="ab" class="row ab-banner" role="alert">
+    <p>It appears you are using Adblock. Please disable Adblock to best experience our website.</p>
+</div>
+
+<!-- Main Navigation Menu -->
+<div class="header">
+    <header class="flex">
+
+        <div>
+            <img class="nys-logo" src="/reporter/images/nys-logo-white.svg" alt="" />
+        </div>
+
+        <div class="lrb-menu">
+            <span class="title" title="Law Reporting Bureau Home Page"><a href="/reporter/index.shtml#main">Law Reporting <br class="title-break" />Bureau</a> <span id="chevron" class="chevron"></span></span>
+            <span>Thomas J.K. Smith, State Reporter</span>
+
+            <nav id="dropdown">
+                <!--<a id="home" href="/reporter/index.shtml#main">Home</a>-->
+                <a id="decisions" href="/reporter/index.shtml#decisions-heading">Court Decisions</a>
+                <a id="resources" href="/reporter/index.shtml#resources-heading">Resources</a>
+                <a id="about" href="/reporter/index.shtml#about-heading">About</a>
+                <!--<a href="/../bing/reporter/reporter.shtml">Search</a>-->
+            </nav>
+        </div>
+
+        <div class="lrb-logo-container">
+            <img class="lrb-logo" src="/reporter/images/lrb-seal.png" alt="" />
+        </div>
+
+    </header>
+</div>
+<!-- End Main Navigation Menu -->
+
+		
+		<nav aria-label="breadcrumb">
+			<ol class="breadcrumb-container">
+				<li><a href="/reporter/index.shtml">Home</a></li>
+				<li><a href="/reporter/Decisions.shtml">All Court Decisions</a></li>
+				<li>Decisions</li>
+			</ol>
+		</nav>
+		<main id="main" tabindex="-1" class="decision">
+			<div class="current-legal-document">
+<div class="case-info">
+<h1>70-35 113th St. Holdings, LLC v Auberge Grand Cent., LLC</h1>
+<p>2026 NY Slip Op 01932</p>
+<p>April 1, 2026</p>
+<p>Appellate Division, Second Department</p>
+<p>Published by New York State Law Reporting Bureau pursuant to Judiciary Law § 431.</p>
+<p>This decision is uncorrected and subject to revision before publication in the Official Reports.</p>
+</div>
+<div class="parties">
+<p>70-35 113th St. Holdings, LLC, appellant,</p>
+<p class="v">v</p>
+<p>Auberge Grand Central, LLC, respondent, et al., defendant.</p>
+</div>
+<p class="current-legal-small-center">Supreme Court of the State of New York, Appellate Division, Second Judicial Department</p>
+<p class="current-legal-small-center">Decided on April 1, 2026</p>
+<p class="current-legal-small-center">2020-09425, (Index No. 707503/15)</p>
+<p class="current-legal-small-left">Linda Christopher, J.P.</p>
+<p class="current-legal-small-left">William G. Ford</p>
+<p class="current-legal-small-left">Barry E. Warhit</p>
+<p class="current-legal-small-left">Helen Voutsinas, JJ.</p>
+<div class="current-counsel-block">
+<p>Lonuzzi & Woodland, LLP (John Lonuzzi and Horn Appellate Group, Brooklyn, NY [Scott T. Horn], of counsel), for appellant.</p>
+<p>Mintz & Gold LLP, New York, NY (Steven G. Mintz, Scott A. Klein, and Terence W. McCormick of counsel), for respondent.</p>
+</div>
+<span class="page" aria-label="slip opinion page 1">[*1]</span>
+<p>DECISION & ORDER</p>
+<p>In an action, inter alia, for specific performance of a contract for the sale of real property, the plaintiff appeals from a judgment of the Supreme Court, Queens County (Leonard Livote, J.), dated December 15, 2020. The judgment, insofar as appealed from, after a nonjury trial, is in favor of the defendant Auberge Grand Central, LLC, and against the plaintiff dismissing the complaint insofar as asserted against the defendant Auberge Grand Central, LLC.</p>
+<p>ORDERED that the judgment is affirmed insofar as appealed from, with costs.</p>
+<p>In January 2014, the plaintiff was the successful bidder at a foreclosure auction of the subject real property. The terms of sale dated January 10, 2014, made time of the essence as to the plaintiff. However, the plaintiff did not have sufficient funds and was unable to obtain financing, and thus, was unable to close on the property despite multiple adjournments of the closing date. The defendant Auberge Grand Central, LLC (hereinafter Auberge), which was also the plaintiff in the foreclosure action, was ultimately the successful bidder at a second foreclosure auction held in August 2014. The plaintiff commenced this action for specific performance of the terms of sale for the property or, in the alternative, to recover damages for breach of contract. After a nonjury trial, the Supreme Court issued a judgment, inter alia, in favor of Auberge and against the plaintiff dismissing the complaint insofar as asserted against Auberge. The plaintiff appeals from so much of the judgment as dismissed the complaint insofar as asserted against Auberge.</p>
+<p>The elements of a cause of action for specific performance of a contract for the sale of real property are that the plaintiff substantially performed its contractual obligations and was ready, willing, and able to perform its remaining obligations, that the defendant was able to convey the property, and that there was no adequate remedy at law (<i>see</i> <i>Kugel v Reynolds</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2024/2024_03173.htm" aria-label="Official Citation 228 AD3d 743">228 AD3d 743</a>, 748; <i>Treasure Is. of Asbury Park Self-Storage, LLC v MBAR Realty, LLC</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2023/2023_02906.htm" aria-label="Official Citation 216 AD3d 1200">216 AD3d 1200</a>, 1203; <i>Rha v Blangiardo</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2020/2020_07412.htm" aria-label="Official Citation 189 AD3d 1098">189 AD3d 1098</a>, 1099). A party seeking specific performance of a contract for the sale of real property is required to establish not only that it was ready, willing, and able to close on the scheduled closing date, but also that the other party was in default (<i>see</i> <i>Treasure Is. of Asbury Park Self-Storage, LLC v MBAR Realty, LLC</i>, 216 AD3d at 1203; <i>141 Park Ave. Realties, Inc. v 141 Park Ave. Holdings, LLC</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2023/2023_02631.htm" aria-label="Official Citation 216 AD3d 881">216 AD3d 881</a>, 883; <i>Rha v Blangiardo</i>, 189 AD3d at 1099). The decision <span class="page" aria-label="slip opinion page 2" >[*2]</span>whether to grant or deny the remedy of specific performance lies within the sound discretion of the court (<i>see</i> <i>Rha v Blangiardo</i>, 189 AD3d at 1099; <i>Cho v 401-403 57th St. Realty Corp.</i>, 300 AD2d 174, 175).</p>
+<p>When a contract for the sale of real property contains a provision that time is of the essence, the parties are obligated to comply strictly with its terms (<i>see</i> <i>Bank of Am. v Petit</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2011/2011_07787.htm" aria-label="Official Citation 89 AD3d 652">89 AD3d 652</a>, 653), and the parties bound by that clause must tender performance on the law day unless the time for performance has been extended by mutual agreement (<i>see</i> <i>184 Joralemon, LLC v Brklyn Hts Condos, LLC</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2014/2014_03245.htm" aria-label="Official Citation 117 AD3d 699">117 AD3d 699</a>, 702). Where time is of the essence, performance on the specific date is a material element of the contract, and failure to perform on that date constitutes a material breach of the contract (<i>see</i> <i>id.</i>; <i>Bank of Am. v Petit</i>, 89 AD3d at 653; <i>Kaiser-Haidri v Battery Place Green, LLC</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2011/2011_05022.htm" aria-label="Official Citation 85 AD3d 730">85 AD3d 730</a>, 733).</p>
+<p>Here, the Supreme Court properly dismissed the complaint insofar as asserted against Auberge. At trial, the plaintiff failed to establish that it was entitled to specific performance of the terms of sale for the property. Pursuant to the terms of sale, time was made of the essence as to the plaintiff. After four adjournments at the plaintiff's request, the plaintiff and Auberge entered into a written stipulation dated May 5, 2014, under which they agreed that the closing would be adjourned to May 29, 2014, with time being of the essence as to the plaintiff. The evidence at trial demonstrated that the plaintiff did not substantially perform its contractual obligations and was not ready, willing, and able to perform its remaining obligations, as the plaintiff did not appear at the May 29, 2014 closing and did not have the necessary financing in place at that time. Because time was made of the essence in the terms of sale, no separate notice of an intent to declare a default was necessary (<i>cf</i>. <i>Nehmadi v Davis</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2009/2009_05524.htm" aria-label="Official Citation 63 AD3d 1125">63 AD3d 1125</a>; <i>Guippone v Gaias</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2004/2004_09039.htm" aria-label="Official Citation 13 AD3d 339">13 AD3d 339</a>). Moreover, the plaintiff was collaterally estopped from relitigating the issue of its default in closing, as that issue was raised in an action brought by Wing Fung Chau, on behalf of the plaintiff, and was decided against the plaintiff after a full and fair opportunity to contest that issue in that action (<i>see</i> <i>Simmons v Trans Express Inc.</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2021/2021_03484.htm" aria-label="Official Citation 37 NY3d 107">37 NY3d 107</a>, 112; <i>Buechel v Bain</i>, 97 NY2d 295, 303; <i>Caminero v Michael Flynn, Esq., PLLC.</i>, <a href="https://www.nycourts.gov/reporter/3dseries/2025/2025_03701.htm" aria-label="Official Citation 239 AD3d 818">239 AD3d 818</a>). In addition, the plaintiff failed to demonstrate that Auberge was in default under the terms of sale.</p>
+<p>Accordingly, the Supreme Court properly dismissed the complaint insofar as asserted against Auberge.</p>
+<p class="left">CHRISTOPHER, J.P., FORD, WARHIT and VOUTSINAS, JJ., concur.</p>
+<p class="quote">ENTER:</p>
+<p class="left">Darrell M. Joseph</p>
+<p class="left">Clerk of the Court</p>
+</div>
+
+		</main>
+		<!-- Footer -->
+<div class="footer-container">
+    <footer class="footer flex">
+        <div>
+            <p>Court Decisions</p>
+            <a href="/reporter/Decisions.shtml">All Court Decisions</a>
+            <a href="https://govt.westlaw.com/nyofficial/Index?__lrTS=20160610194954496">Official Reports Service</a>
+            <a href="/reporter/bound-volumes.shtml">Bound Volumes</a>
+            <a class="advsearch" href="https://iapps.courts.state.ny.us/lawReporting/Search">Decision Search <!--&#128269;--></a>
+        </div>
+        <div class="footer-resources">
+            <p>Resources</p>
+            <a href="/reporter/RSS.shtml">RSS Feeds</a>
+            <a href="/reporter/Styman_Menu.shtml">Style Manual</a>
+            <a href="/reporter/Citator_Menu.shtml">Citation Tools</a>
+            <a href="/reporter/Format.shtml">Opinion Formatting &amp; Privacy Guidelines</a>
+            <a href="/reporter/Selection.shtml">Opinion Selection Criteria</a>
+            <a href="/reporter/research.shtml">Legal Research Portal</a>
+            <a href="/reporter/Contents.shtml">Site Index</a>
+        </div>
+        <div>
+            <p>About</p>
+            <a href="/reporter/About.shtml">About the Law Reporting Bureau</a>
+            <a href="/reporter/Operations.shtml">About our Operations</a>
+            <a href="/reporter/contact.shtml">Contact Us</a>
+            <a href="https://twitter.com/NYOfficialRpts?lang=en">Twitter</a>
+        </div>
+        <div class="footer-contact">
+            <p>Quick Contact Info</p>
+            <p>17 Lodge Street</p>
+            <p>Albany, NY 12207</p>
+            <p>Phone: (518) 453-6900</p>
+            <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2934.460049708907!2d-73.75836204509163!3d42.65160549705156!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x89de0a26824aa943%3A0xd1ca515da334b041!2s17%20Lodge%20St%2C%20Albany%2C%20NY%2012207!5e0!3m2!1sen!2sus!4v1731102245878!5m2!1sen!2sus" title="Law Reporting Bureau address" width="200" height="150" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+        </div>
+    </footer>
+</div> <!-- End Footer -->
+
+<div>
+    <p class="disclaimer">Links to or from other sites do not signify endorsement or relationship with them.</p>
+</div>
+
+<script type="text/javascript">
+    var adblock = true;
+</script>
+<script type="text/javascript" src="/reporter/js/ad1.js">
+    // This file will allow us to check if adblock is present. If adblock is present, this file will be blocked and adblock will be "true" and our banner will appear. 
+</script>
+<script type="text/javascript">
+    if (adblock === true) {
+        var ab = document.getElementById("ab");
+        ab.style.display = "block";
+    }
+</script>
+<script src="/reporter/js/script-min.js"></script>
+
+	</body>
+</html>

--- a/tests/examples/opinions/cleanup_content/ny_permanent_format.compare.html
+++ b/tests/examples/opinions/cleanup_content/ny_permanent_format.compare.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html><html><body><div>People v Seymore (2026 NY Slip Op 00028)
+
+
+
+<table align="center">
+<tbody><tr>
+<td align="center"><b>People v Seymore</b></td>
+</tr>
+<tr>
+<td align="center">2026 NY Slip Op 00028 [245 AD3d 423]</td>
+</tr>
+<tr>
+<td align="center">January 6, 2026</td>
+</tr>
+<tr>
+<td align="center">Appellate Division, First Department</td>
+</tr>
+<tr>
+<td align="center">Published by New York State Law Reporting Bureau
+pursuant to Judiciary Law § 431.</td>
+</tr>
+<tr><td><center>As corrected through Thursday, May 7, 2026</center></td></tr>
+</tbody></table>
+<br><br>
+
+
+[*1]
+
+<table align="center"><tbody><tr align="center"><td><b> The People of the State of New York,
+Respondent,<br>v<br>Teon Seymore, Appellant.</b></td></tr></tbody></table><p>
+
+
+</p><p>Jenay Nurse Guilford, Center for Appellate Litigation, New York (David J. Klem of
+counsel), for appellant.</p>
+<p>Alvin L. Bragg, Jr., District Attorney, New York (Nathan Morgante of counsel), for
+respondent.</p>
+
+
+<div><br><b>HEADNOTES</b><br><br><br></div>
+
+<p><b>Crimes
+ - Sentence
+ - Probation
+ - Conditions<br></b>
+</p><p>Judgment, Supreme Court, New York County (Michael Gaffey, J.), rendered September 26,
+2023, convicting defendant, upon his plea of guilty, of criminal possession of a controlled
+substance in the fifth degree, and sentencing him, as a second felony drug offender, to three years
+of probation, unanimously modified, on the law, to the extent of striking the condition of
+probation prohibiting defendant "from wearing or displaying gang paraphernalia" or "having any
+association with a gang or members of a gang if directed by the Department of Probation," and
+otherwise affirmed.</p>
+<p>Defendant validly waived his right to appeal (<i>see People v Thomas</i>, 34 NY3d 545, 559 [2019], <i>cert
+denied</i> 589 US 1302 [2020]), which forecloses review of his excessive
+sentence claim (<i>see People v Nunez</i>,
+220 AD3d 597, 597 [1st Dept 2023], <i>lv denied</i> 41 NY3d 1004 [2024]). In any event,
+we perceive no basis for reducing the sentence.</p>
+<p>Defendant's challenges to certain conditions of probation under Penal Law
+§ 65.10 (1) survive his valid waiver of his right to appeal and do not require
+preservation (<i>see People v Berkley</i>,
+241 AD3d 1167 [1st Dept 2025]). Regarding the condition of probation requiring him to
+"[a]void injurious or vicious habits; refrain from frequenting unlawful or disreputable places; and
+. . . not consort with disreputable people," the court providently deemed this
+condition "reasonably necessary to [e]nsure that the defendant will lead a law-abiding life or to
+assist him to do so," given that defendant was convicted for a second felony drug offense (Penal
+Law § 65.10 [1], [2]; <i>see People v Berkley</i>, 241 AD3d at 1168; <i>People v Lombard</i>, 241 AD3d
+1126, 1126 [1st Dept 2025]). However, the probation condition requiring defendant to
+"[r]efrain from wearing or displaying gang paraphernalia and having any association with a gang
+or members of a gang if directed by the Department of Probation" must be stricken because there
+is no evidence that defendant's actions were connected to gang activity or that he had a history of
+gang membership, rendering this condition neither reasonably related to his rehabilitation nor
+necessary to ensure that he leads a law-abiding life (<i>see People v Vasquetelles</i>, 241 AD3d 1208, 1209 [1st Dept 2025];
+Penal Law § 65.10 [1]).</p>
+<p>Defendant's valid waiver of his right to appeal forecloses review of his constitutional
+challenges to the probation conditions under the First Amendment and the vagueness doctrine of
+due process under the Fifth and Fourteenth Amendments (<i>see People v Lowndes</i>, 239 AD3d 574, 575 [1st Dept 2025]). In any
+event, the claims are unpreserved (<i>see
+People v Cabrera</i>, 41 NY3d 35, 42-51 [2023]), and we decline to review them in the
+interest of justice. Concur—Webber, J.P., Friedman, Mendez, Shulman, Hagler, JJ.</p>
+
+
+
+
+
+</div></body></html>

--- a/tests/examples/opinions/cleanup_content/ny_permanent_format.html
+++ b/tests/examples/opinions/cleanup_content/ny_permanent_format.html
@@ -1,0 +1,105 @@
+<HTML>
+<HEAD>
+<TITLE>People v Seymore (2026 NY Slip Op 00028)</TITLE>
+<STYLE>
+BODY {
+font-family : "Times New Roman", Times, serif;
+font-size : larger;
+}
+
+P {
+line-height: 150%;
+text-indent: 2em
+}
+.nomargin > P {
+margin: 0;
+}
+</STYLE>
+</HEAD>
+<BODY bgcolor=#ffffff>
+<table width="80%" border="1" cellspacing="2" cellpadding="5" align="center"
+bgcolor="#FFFF80">
+<tr>
+<td align="center"><B>People v Seymore</B></td>
+</tr>
+<tr>
+<td align="center">2026 NY Slip Op 00028 [245 AD3d 423]</td>
+</tr>
+<tr>
+<td align="center">January 6, 2026</td>
+</tr>
+<tr>
+<td align="center">Appellate Division, First Department</td>
+</tr>
+<tr>
+<td align="center"><font color="#FF0000">Published by <a
+href="https://www.courts.state.ny.us/reporter/">New York State Law Reporting Bureau</a>
+pursuant to Judiciary Law &sect; 431.</font></td>
+</tr>
+<tr><td><center>As corrected through Thursday, May 7, 2026</center></td></tr>
+</table>
+<BR><BR>
+
+
+<font color="FF0000">[*1]</font>
+
+<table width="80%" border="1" cellpadding="4" align="center" bgcolor="#99cccc"><tr
+align="center"><td><B>&emsp;The People of the State of New York,
+Respondent,<br>v<br>Teon Seymore, Appellant.</B></td></tr></table><p>
+
+
+<p>Jenay Nurse Guilford, Center for Appellate Litigation, New York (David J. Klem of
+counsel), for appellant.</p>
+<p>Alvin L. Bragg, Jr., District Attorney, New York (Nathan Morgante of counsel), for
+respondent.</p>
+
+<HeadnoteBlock type="boxed">
+<div align="center"><br><b>HEADNOTES</b><br><br><br></div>
+
+<p><b>Crimes
+ - Sentence
+ - Probation
+ - Conditions<br></b>
+<p>Judgment, Supreme Court, New York County (Michael Gaffey, J.), rendered September 26,
+2023, convicting defendant, upon his plea of guilty, of criminal possession of a controlled
+substance in the fifth degree, and sentencing him, as a second felony drug offender, to three years
+of probation, unanimously modified, on the law, to the extent of striking the condition of
+probation prohibiting defendant "from wearing or displaying gang paraphernalia" or "having any
+association with a gang or members of a gang if directed by the Department of Probation," and
+otherwise affirmed.</p>
+<p>Defendant validly waived his right to appeal (<a href="../2019/2019_08545.htm"
+target="_blank"><i>see People v Thomas</i>, 34 NY3d 545</a>, 559 [2019], <i>cert
+denied</i> 589 US 1302 [2020]), which forecloses review of his excessive
+sentence claim (<a href="../2023/2023_05449.htm" target="_blank"><i>see People v Nunez</i>,
+220 AD3d 597</a>, 597 [1st Dept 2023], <i>lv denied</i> 41 NY3d 1004 [2024]). In any event,
+we perceive no basis for reducing the sentence.</p>
+<p>Defendant's challenges to certain conditions of probation under Penal Law
+&sect;&thinsp;65.10 (1) survive his valid waiver of his right to appeal and do not require
+preservation (<a href="../2025/2025_05162.htm" target="_blank"><i>see People v Berkley</i>,
+241 AD3d 1167</a> [1st Dept 2025]). Regarding the condition of probation requiring him to
+"[a]void injurious or vicious habits; refrain from frequenting unlawful or disreputable places; and
+.&ensp;.&ensp;. not consort with disreputable people," the court providently deemed this
+condition "reasonably necessary to [e]nsure that the defendant will lead a law-abiding life or to
+assist him to do so," given that defendant was convicted for a second felony drug offense (Penal
+Law &sect;&thinsp;65.10 [1], [2]; <i>see People v Berkley</i>, 241 AD3d at 1168; <a
+href="../2025/2025_05044.htm" target="_blank"><i>People v Lombard</i>, 241 AD3d
+1126</a>, 1126 [1st Dept 2025]). However, the probation condition requiring defendant to
+"[r]efrain from wearing or displaying gang paraphernalia and having any association with a gang
+or members of a gang if directed by the Department of Probation" must be stricken because there
+is no evidence that defendant's actions were connected to gang activity or that he had a history of
+gang membership, rendering this condition neither reasonably related to his rehabilitation nor
+necessary to ensure that he leads a law-abiding life (<a href="../2025/2025_05198.htm"
+target="_blank"><i>see People v Vasquetelles</i>, 241 AD3d 1208</a>, 1209 [1st Dept 2025];
+Penal Law &sect;&thinsp;65.10 [1]).</p>
+<p>Defendant's valid waiver of his right to appeal forecloses review of his constitutional
+challenges to the probation conditions under the First Amendment and the vagueness doctrine of
+due process under the Fifth and Fourteenth Amendments (<a href="../2025/2025_03868.htm"
+target="_blank"><i>see People v Lowndes</i>, 239 AD3d 574</a>, 575 [1st Dept 2025]). In any
+event, the claims are unpreserved (<a href="../2023/2023_05968.htm" target="_blank"><i>see
+People v Cabrera</i>, 41 NY3d 35</a>, 42-51 [2023]), and we decline to review them in the
+interest of justice. Concur&mdash;Webber, J.P., Friedman, Mendez, Shulman, Hagler, JJ.</p>
+
+
+<script defer src="https://static.cloudflareinsights.com/beacon.min.js/v4513226cdae34746b4dedf0b4dfa099e1781791509496" integrity="sha512-ZE9pZaUXND66v380QUtch/5sE9tPFh2zg45pR2PB0CVkCtOREv2AJKkSidISWkysEuQ0EH8faUU5du78bx87UQ==" data-cf-beacon='{"version":"2024.11.0","token":"c4f679615d524c938a4d9038ad0d97f9","server_timing":{"name":{"cfCacheStatus":true,"cfEdge":true,"cfExtPri":true,"cfL4":true,"cfOrigin":true,"cfSpeedBrain":true},"location_startswith":null}}' crossorigin="anonymous"></script>
+</BODY>
+</HTML>

--- a/tests/local/test_ScraperCleanupContentTest.py
+++ b/tests/local/test_ScraperCleanupContentTest.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+
+import glob
+import os
+import unittest
+
+from juriscraper.lib.importer import build_module_list
+from juriscraper.lib.string_utils import CaseNameTweaker
+from juriscraper.lib.test_utils import warn_generated_compare_file
+
+FIXTURE_DIR = os.path.join("tests", "examples", "opinions", "cleanup_content")
+COMPARE_EXTENSION = ".compare.html"
+
+
+class ScraperCleanupContentTest(unittest.TestCase):
+    """Test Site.cleanup_content against real downloaded documents
+
+    Fixtures live in tests/examples/opinions/cleanup_content/ and are named
+    `<module_name>_<label>.html`, holding a document exactly as downloaded
+    from the source. Each is run through the matching scraper's
+    `cleanup_content` and compared against `<module_name>_<label>.compare.html`.
+
+    Like ScraperExampleTest's compare.json files, a missing compare file is
+    generated from the actual output and the test run fails; review it and
+    run again.
+    """
+
+    def test_cleanup_content_fixtures(self):
+        module_strings = build_module_list("juriscraper.opinions")
+        modules_by_name = {
+            module_string.rsplit(".", 1)[1]: module_string
+            for module_string in module_strings
+            if "backscraper" not in module_string
+        }
+        paths = sorted(
+            path
+            for path in glob.glob(os.path.join(FIXTURE_DIR, "*.html"))
+            if not path.endswith(COMPARE_EXTENSION)
+        )
+        self.assertTrue(paths, f"No fixture files found in {FIXTURE_DIR}")
+
+        compare_files_generated = []
+        for path in paths:
+            fixture_name = os.path.basename(path).rsplit(".", 1)[0]
+            # A module name may itself contain underscores (nyappdiv_1st),
+            # so match the longest module name prefixing the fixture name
+            matches = [
+                name
+                for name in modules_by_name
+                if fixture_name.startswith(f"{name}_")
+            ]
+            self.assertTrue(
+                matches, f"No scraper module matches fixture '{path}'"
+            )
+            module_string = modules_by_name[max(matches, key=len)]
+            package, module = module_string.rsplit(".", 1)
+            mod = __import__(
+                f"{package}.{module}", globals(), locals(), [module]
+            )
+            site = mod.Site(cnt=CaseNameTweaker())
+
+            with open(path, "rb") as fixture_file:
+                content = fixture_file.read()
+            cleaned = site.cleanup_content(content)
+            if isinstance(cleaned, str):
+                cleaned = cleaned.encode()
+
+            compare_path = f"{path.rsplit('.', 1)[0]}{COMPARE_EXTENSION}"
+            if os.path.isfile(compare_path):
+                with (
+                    open(compare_path, "rb") as compare_file,
+                    self.subTest(
+                        "Testing cleanup_content fixtures",
+                        fixture=path,
+                        module_string=module_string,
+                    ),
+                ):
+                    self.assertEqual(compare_file.read(), cleaned)
+            else:
+                warn_generated_compare_file(compare_path)
+                compare_files_generated.append(compare_path)
+                with open(compare_path, "wb") as compare_file:
+                    compare_file.write(cleaned)
+
+        if compare_files_generated:
+            self.fail(
+                "Generated compare file(s) during test, please review before "
+                "proceeding. If the data looks good, run tests again, then be "
+                "sure to include the new compare file(s) in your commit: "
+                f"{', '.join(compare_files_generated)}"
+            )


### PR DESCRIPTION
Fixes #2058

## What

Since ~April 2026, the NY Law Reporting Bureau serves "current" slip opinion pages wrapped in site chrome: a skip link, a static "disable Adblock" banner (always present in the HTML, hidden client-side by CSS/JS), header menus, breadcrumbs, and a footer. `ny.Site.cleanup_content` nh3-cleaned the entire document, keeping the text of every div, so all that chrome landed in opinion content for ~2,834 opinions (details and root-cause analysis in #2058).

## How

- `ny.Site.cleanup_content` now parses the raw HTML before `nh3.clean` (nh3 strips the `id` attributes needed to locate the container) and, when the new template's `<main id="main">` container is present, keeps only that subtree. Pages without the container (permanent-format pages, verified chrome-free from 2020 through today against real archived documents) fall through to the existing whole-document cleaning unchanged.
- Covers all NY scrapers: `nyappdiv_*`/`nyappterm_*` inherit from `ny.Site`, and `nytrial.Site.cleanup_content` delegates to it (also fixed its `str` type annotations, the input is `bytes`).
- New court-agnostic test harness `tests/local/test_ScraperCleanupContentTest.py`: globs `tests/examples/opinions/cleanup_content/<module>_<label>.html` fixtures, runs each through the matching scraper's `cleanup_content`, and compares against `<module>_<label>.compare.html`. Missing compare files are auto-generated and fail the run, same convention as the `compare.json` files. Any court can be covered later by dropping in fixtures; NY is the only one populated for now.
- Fixtures are real documents: the new-template page (April 2026 Wayback snapshot) and a permanent-format page.

## Testing

- `uv run python -m unittest tests.local.test_ScraperCleanupContentTest` — new-template output contains only the opinion (case-info block, `[*1]` page markers, counsel preserved; no Adblock text, header menus, or footer); permanent-format output unchanged in substance.
- `uv run python -m unittest tests.local.test_ScraperExampleTest.ScraperExampleTest.test_scrape_opinion_state_example_files` — 197 scrapers pass, no regressions.
- Validated against real archived documents from storage.courtlistener.com (one per year, 2020–2026) and against raw pages for the three template variants (`nyappdiv`, `ny`, misc-series): see https://github.com/freelawproject/juriscraper/issues/2058#issuecomment-5124379179 for the full validation matrix and the remediation plan for already-ingested opinions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)