### PR TITLE
feat(ci): add mypy integration to CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,3 +13,16 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
       - uses: pre-commit/action@v3.0.1
+
+  static-type-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+      - name: mypy Static Type Checker
+        run: |
+          uv run mypy --pretty .

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,12 @@ pre-commit run ruff
 
 You can also [integrate Ruff into your editor](https://docs.astral.sh/ruff/editors/setup/) for automatic formatting and diagnostics.
 
-It is a goal of this project to get mypy type checking as part of our list of pre-commit hooks. It will take us a bit of work to get there, but we ask that until that time if you touch a file, fix any type errors in it that you can. You can verify your changes against mypy with `uv run mypy path/to/my/code.py`.
+Comprehensive static analysis of the project is a development goal. The current `mypy` analyzer runs with many useful checks disabled, but with work, the strictness of the configuration can increase. We ask that if you touch a file, fix any type errors in it that you can, regardless of whether or not the current configuration enforces them.
+
+You can verify your using mypy with the following command:
+```
+uv run mypy --pretty .
+```
 
 ### Formatting Guidelines
 

--- a/juriscraper/state/RequestManager.py
+++ b/juriscraper/state/RequestManager.py
@@ -367,7 +367,7 @@ class RequestManager(AsyncClient):
             asyncio.create_task(h.listen(self, request)) for h in self.handlers
         }
         logger.debug("Handlers listening: %s", request.url)
-        _ = await self.enqueue_request(request)
+        await self.enqueue_request(request)
 
         logger.debug(
             "Request %s queued. Waiting for listen handlers to finish.",

--- a/mypy.ini
+++ b/mypy.ini
@@ -44,6 +44,5 @@ disable_error_code =
     typeddict-unknown-key,
     no-redef,
     import-not-found,
-    func-returns-value,
     call-arg,
     unused-ignore,

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,49 @@
+[mypy]
+strict = True
+disallow_any_unimported = True
+disallow_any_expr = False
+disallow_any_explicit = False
+disallow_any_generics = True
+disallow_subclassing_any = True
+disallow_untyped_defs = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+warn_no_return = True
+warn_return_any = True
+warn_unreachable = True
+# This merely reflects behavior prior to the introduction of mypy. This should be shortened with urgency, then applied
+# on a per-module basis, and then eliminated.
+disable_error_code =
+    no-untyped-call,
+    no-untyped-def,
+    union-attr,
+    attr-defined,
+    type-arg,
+    index,
+    arg-type,
+    no-any-return,
+    assignment,
+    typeddict-item,
+    override,
+    var-annotated,
+    return-value,
+    misc,
+    import-untyped,
+    operator,
+    unreachable,
+    has-type,
+    call-overload,
+    return,
+    dict-item,
+    valid-type,
+    comparison-overlap,
+    unused-coroutine,
+    type-var,
+    str-bytes-safe,
+    name-defined,
+    typeddict-unknown-key,
+    no-redef,
+    import-not-found,
+    func-returns-value,
+    call-arg,
+    unused-ignore,


### PR DESCRIPTION
Following up on #2116, this is an initial patch that gets `mypy` up, running, and enforced. The `mypy.ini` configuration accepts the project as it is. Subsequent development can increase the strictness.

The first patch introduces `mypy` and the second patch makes a trivial change addressing one of the permitted errors and enforces violations going forward.