### PR TITLE
fix(appellate docket report): address conflicting implementations for `_get_pacer_doc_id`

### DIFF
--- a/juriscraper/pacer/appellate_docket.py
+++ b/juriscraper/pacer/appellate_docket.py
@@ -649,10 +649,6 @@ class AppellateDocketReport(BaseDocketReport, BaseReport):
         return file_size
 
     @staticmethod
-    def _get_pacer_doc_id(row: html.HtmlElement) -> str:
-        return row.xpath(".//a/@data-pacer-doc-id")
-
-    @staticmethod
     def _get_pacer_seq_no_from_tr(row: html.HtmlElement) -> str | None:
         """Take a row of the attachment table, and return the sequence number
         from the name attribute.


### PR DESCRIPTION
Static analysis yields the following `no-redef` error:
```
juriscraper/pacer/appellate_docket.py:779: error: Name "_get_pacer_doc_id" already defined on line 652  [no-redef]
```

The static function, `AppellateDocketReport._get_pacer_doc_id()`, is defined twice! The two implementations are as follows:

```
# ba7ff43e9 ttys0dev (Thu Oct 12 19:26:31 2023 -0600): Parse appellate docket attachments
@staticmethod
def _get_pacer_doc_id(row: html.HtmlElement) -> str:
    return row.xpath(".//a/@data-pacer-doc-id")
```

```
# 64fb8a0d8 Michael Lissner (Mon May 21 21:48:23 2018 -0700): feat(appellate parsers): Adds docket entry table parsing.
@staticmethod
def _get_pacer_doc_id(cell):
    urls = cell.xpath(".//a")
    if not urls:
        # Entry exists but lacks a URL. Probably a minute order or similar.
        return None
    else:
        doc1_url = urls[0].xpath("./@href")[0]
        return get_pacer_doc_id_from_doc1_url(doc1_url)
```

The nature of Python is such that the later defined function will win. In this case, that is the 2018 vintage (from 64fb8a0d8). Inspection confirms this:

```
inspect.getsource(AppellateDocketReport._get_pacer_doc_id)
```

Troublingly, but not unexpectedly, these functions have different behaviors. The 2023 vintage uses the `data-pacer-doc-id` HTML attribute, while the 2018 vintage extracts the result from the `href` attribute.

I cannot judge which is best, but I do know which one has been used in production for the last three years, and that is the 2018 vintange. This change uncritically ratifies this behavior.

A later change, adopting the more modern `data-pacer-doc-id` attribute may be a good idea.