### PR TITLE
fix(ca9): order oral arguments by upload time, not hearing date

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Changes:
 -
 
 Fixes:
--
+- `ca9` oral arguments: query and order the `media` table by the court's upload timestamp instead of the hearing date, so arguments uploaded late in the day, or long after the hearing, are no longer hidden behind items already in CourtListener. #2111
 
 ## 3.0.35 - 2026-08-06
 

--- a/juriscraper/oral_args/united_states/federal_appellate/ca9.py
+++ b/juriscraper/oral_args/united_states/federal_appellate/ca9.py
@@ -193,7 +193,7 @@ class Site(OralArgumentSiteLinear):
             self.cases.append(
                 {
                     "date": date_str,
-                    "docket": record["case_num"]["S"],
+                    "docket": docket,
                     "judge": record["case_panel"]["S"],
                     "name": record["case_name"]["S"],
                     "url": urljoin(self.base_url, audio),

--- a/juriscraper/oral_args/united_states/federal_appellate/ca9.py
+++ b/juriscraper/oral_args/united_states/federal_appellate/ca9.py
@@ -18,7 +18,11 @@ from juriscraper.OralArgumentSiteLinear import OralArgumentSiteLinear
 
 class Site(OralArgumentSiteLinear):
     query_url = "https://dynamodb.us-west-2.amazonaws.com/"
-    days_interval = 30
+    # Lookback for the regular scrape, in `created_date` terms. The cron runs
+    # hourly, so this only needs to cover a scraper outage. Widening it is
+    # free: DynamoDB applies a FilterExpression after the scan, so the same
+    # pages are read either way. #2111
+    upload_window_days = 7
     first_opinion_date = datetime(2000, 10, 16)
 
     def __init__(self, *args, **kwargs):
@@ -46,27 +50,55 @@ class Site(OralArgumentSiteLinear):
         }
 
         self.end_date = datetime.now()
-        self.start_date = self.end_date - timedelta(days=self.days_interval)
+        self.start_date = self.end_date - timedelta(
+            days=self.upload_window_days
+        )
         self.build_payload()
 
         self.url = "https://cognito-identity.us-west-2.amazonaws.com/"
         self.make_backscrape_iterable(kwargs)
 
-    def build_payload(self):
-        """Build the DynamoDB query for the current start_date/end_date
+    def build_payload(self, backscrape: bool = False) -> None:
+        """Build the DynamoDB scan for the current start_date/end_date
 
+        The regular scrape filters on `created_date`, the timestamp the court
+        wrote the row, because ordering the crawl by upload time is what keeps
+        us from missing arguments; see `_process_html`. Backscrapes filter on
+        `publish`, the hearing date, because the court only started recording
+        `created_date` in mid 2021 and historical rows would otherwise be
+        invisible. #2111
+
+        :param backscrape: filter by hearing date instead of upload time
         :return: None
         """
+        if backscrape:
+            # `publish` is a number, e.g. 20260605
+            column = "publish"
+            expression = "#COLUMN >= :from_date AND #COLUMN <= :to_date"
+            values = {
+                ":from_date": {"N": self.start_date.strftime("%Y%m%d")},
+                ":to_date": {"N": self.end_date.strftime("%Y%m%d")},
+            }
+        else:
+            # `created_date` is a court-local "%Y-%m-%d %H:%M:%S" string.
+            # Truncating to the day absorbs the offset against our own clock,
+            # and there is deliberately no upper bound, so that clock skew can
+            # never hide the court's newest uploads
+            column = "created_date"
+            expression = "#COLUMN >= :from_date"
+            values = {
+                ":from_date": {
+                    "S": self.start_date.strftime("%Y-%m-%d 00:00:00")
+                }
+            }
+
         self.payload = json.dumps(
             {
                 "TableName": self.table,
                 "ReturnConsumedCapacity": "TOTAL",
-                "FilterExpression": "#PUBLISH >= :from_date AND #PUBLISH <= :to_date",
-                "ExpressionAttributeNames": {"#PUBLISH": "publish"},
-                "ExpressionAttributeValues": {
-                    ":from_date": {"N": self.start_date.strftime("%Y%m%d")},
-                    ":to_date": {"N": self.end_date.strftime("%Y%m%d")},
-                },
+                "FilterExpression": expression,
+                "ExpressionAttributeNames": {"#COLUMN": column},
+                "ExpressionAttributeValues": values,
             }
         )
 
@@ -137,17 +169,25 @@ class Site(OralArgumentSiteLinear):
 
         for record in self.html:
             date_str = record.get("hearing_date", {}).get("S")
+            docket = record.get("case_num", {}).get("S")
             try:
                 # validate ISO date
                 datetime.strptime(date_str, "%Y-%m-%d")
             except Exception:
-                logger.debug(f"Skipping row with bad hearing_date: {date_str}")
+                logger.warning(
+                    "ca9: skipping row with bad hearing_date %s for docket %s",
+                    date_str,
+                    docket,
+                )
                 continue
 
             try:
                 audio = record["audio_file_name"]["S"]
             except KeyError:
-                logger.debug("Skipping row with no audio_file_name")
+                logger.warning(
+                    "ca9: skipping row with no audio_file_name for docket %s",
+                    docket,
+                )
                 continue
 
             self.cases.append(
@@ -157,8 +197,38 @@ class Site(OralArgumentSiteLinear):
                     "judge": record["case_panel"]["S"],
                     "name": record["case_name"]["S"],
                     "url": urljoin(self.base_url, audio),
+                    # Only used for ordering below; it has no getter, so it
+                    # never reaches the scraped output
+                    "created_date": record.get("created_date", {}).get(
+                        "S", ""
+                    ),
                 }
             )
+
+        # CourtListener walks these cases top down and stops at the first
+        # duplicate, so the newest uploads have to come first: that guarantees
+        # every new row is seen before the first row we already have. Ordering
+        # by hearing date instead left arguments the court uploaded later in the
+        # day sitting behind rows already in CL, where nothing ever reached
+        # them again. Rows older than mid 2021 have no `created_date` and fall
+        # back to hearing date order. #2111
+        self.cases.sort(
+            key=lambda case: (
+                case["created_date"],
+                case["date"],
+                case["docket"],
+            ),
+            reverse=True,
+        )
+
+    def _date_sort(self) -> None:
+        """Preserve the upload time ordering applied by `_process_html`
+
+        `AbstractSite._date_sort` would reorder the cases by hearing date, which
+        is the ordering that made us miss arguments. #2111
+
+        :return: None
+        """
 
     async def _download_backwards(self, dates: tuple[str, str]) -> None:
         """Download backwards
@@ -181,7 +251,7 @@ class Site(OralArgumentSiteLinear):
             self.end_date = datetime.now()
 
         # Rebuild payload for this slice
-        self.build_payload()
+        self.build_payload(backscrape=True)
         self.html = await self._download()
         self._process_html()
 
@@ -189,6 +259,11 @@ class Site(OralArgumentSiteLinear):
         """
         Prepare a single (start, end) tuple, defaulting to __init__’s range
         or overridden via backscrape_start / backscrape_end in kwargs.
+
+        A single tuple on purpose: each DynamoDB scan reads the whole table
+        regardless of the FilterExpression, so splitting a backscrape into
+        `days_interval` chunks would multiply the cost by the number of chunks
+        and return nothing extra.
         """
         start = kwargs.get("backscrape_start", self.start_date)
         end = kwargs.get("backscrape_end", self.end_date)

--- a/tests/examples/oral_args/united_states/ca9_example_2.compare.json
+++ b/tests/examples/oral_args/united_states/ca9_example_2.compare.json
@@ -1,0 +1,146 @@
+[
+  {
+    "case_dates": "2026-08-06",
+    "case_names": "City of Calimesa v. Everest Reinsurance Company",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/06/25-7356.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-7356",
+    "judges": "GRABER, KOH, THOMAS",
+    "case_name_shorts": ""
+  },
+  {
+    "case_dates": "2026-08-06",
+    "case_names": "E.V. v. City of Covina",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/06/25-7151.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-7151",
+    "judges": "GRABER, KOH, THOMAS",
+    "case_name_shorts": "E.V."
+  },
+  {
+    "case_dates": "2026-08-06",
+    "case_names": "Bandy v. Move, Inc.",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/06/25-2095.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-2095",
+    "judges": "GRABER, KOH, THOMAS",
+    "case_name_shorts": "Bandy"
+  },
+  {
+    "case_dates": "2026-08-06",
+    "case_names": "NW Energy Coalition v. Bonneville Power Administration",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/06/25-4278.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-4278",
+    "judges": "McKEOWN, SMITH, CHRISTEN",
+    "case_name_shorts": ""
+  },
+  {
+    "case_dates": "2026-08-06",
+    "case_names": "Vaughn, Jr. v. Klamath County Fire District1",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/06/25-4210.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-4210",
+    "judges": "McKEOWN, SMITH, CHRISTEN",
+    "case_name_shorts": ""
+  },
+  {
+    "case_dates": "2026-08-06",
+    "case_names": "McGuffin v. Karcher",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/06/25-2548.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-2548",
+    "judges": "McKEOWN, SMITH, CHRISTEN",
+    "case_name_shorts": "McGuffin"
+  },
+  {
+    "case_dates": "2026-08-05",
+    "case_names": "Rohani v. Rubio",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/05/25-4628.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-4628",
+    "judges": "HAWKINS, McKEOWN, CHRISTEN",
+    "case_name_shorts": "Rohani"
+  },
+  {
+    "case_dates": "2026-08-05",
+    "case_names": "Stewart v. City of Tacoma",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/05/25-4271.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-4271",
+    "judges": "HAWKINS, McKEOWN, CHRISTEN",
+    "case_name_shorts": "Stewart"
+  },
+  {
+    "case_dates": "2026-08-05",
+    "case_names": "Calderon v. Blanche",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/05/25-6153.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-6153",
+    "judges": "GRABER, KOH, THOMAS",
+    "case_name_shorts": "Calderon"
+  },
+  {
+    "case_dates": "2026-08-04",
+    "case_names": "Collard v. Bisignano",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/04/25-6334.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-6334",
+    "judges": "HAWKINS, McKEOWN, CHRISTEN",
+    "case_name_shorts": "Collard"
+  },
+  {
+    "case_dates": "2026-08-04",
+    "case_names": "T.W. v. Echtenkamp",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/04/25-5777.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-5777",
+    "judges": "HAWKINS, McKEOWN, CHRISTEN",
+    "case_name_shorts": "T.W."
+  },
+  {
+    "case_dates": "2026-08-04",
+    "case_names": "Quilbillies, LLC v. First American Title Insurance Company",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/04/25-501.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-501",
+    "judges": "HAWKINS, McKEOWN, CHRISTEN",
+    "case_name_shorts": ""
+  },
+  {
+    "case_dates": "2026-08-04",
+    "case_names": "Neaman v. Washington Department of Corrections",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/04/25-3254.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-3254",
+    "judges": "HAWKINS, McKEOWN, CHRISTEN",
+    "case_name_shorts": "Neaman"
+  },
+  {
+    "case_dates": "2026-08-04",
+    "case_names": "Colestock v. DeJoy",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/04/25-2941.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "25-2941",
+    "judges": "HAWKINS, McKEOWN, CHRISTEN",
+    "case_name_shorts": "Colestock"
+  },
+  {
+    "case_dates": "2026-08-03",
+    "case_names": "Rayford v. Keeling",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/03/26-2279.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "26-2279",
+    "judges": "HAWKINS, SMITH, CHRISTEN",
+    "case_name_shorts": "Rayford"
+  },
+  {
+    "case_dates": "2026-08-03",
+    "case_names": "United States v. Pigida",
+    "download_urls": "https://cdn.ca9.uscourts.gov/datastore/media/2026/08/03/24-3223.mp3",
+    "blocked_statuses": false,
+    "docket_numbers": "24-3223",
+    "judges": "HAWKINS, SMITH, CHRISTEN",
+    "case_name_shorts": "Pigida"
+  }
+]

--- a/tests/examples/oral_args/united_states/ca9_example_2.json
+++ b/tests/examples/oral_args/united_states/ca9_example_2.json
@@ -1,0 +1,898 @@
+[
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/03/26-2279.mp3"
+    },
+    "case_name": {
+      "S": "Rayford, et al. v. Keeling, et al."
+    },
+    "case_name_lc": {
+      "S": "rayford, et al. v. keeling, et al."
+    },
+    "case_num": {
+      "S": "26-2279"
+    },
+    "case_panel": {
+      "S": "HAWKINS, SMITH, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "hawkins, smith, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-03 12:55:09"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-03"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260803"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "HRNEIJ6texY"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/04/25-501.mp3"
+    },
+    "case_name": {
+      "S": "Quilbillies, LLC, et al. v. First American Title Insurance Company"
+    },
+    "case_name_lc": {
+      "S": "quilbillies, llc, et al. v. first american title insurance company"
+    },
+    "case_num": {
+      "S": "25-501"
+    },
+    "case_panel": {
+      "S": "HAWKINS, McKEOWN, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "hawkins, mckeown, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-04 12:52:26"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-04"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260804"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "E45xcTRgR2g"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/06/25-7356.mp3"
+    },
+    "case_name": {
+      "S": "City of Calimesa v. Everest Reinsurance Company"
+    },
+    "case_name_lc": {
+      "S": "city of calimesa v. everest reinsurance company"
+    },
+    "case_num": {
+      "S": "25-7356"
+    },
+    "case_panel": {
+      "S": "GRABER, KOH, THOMAS"
+    },
+    "case_panel_lc": {
+      "S": "graber, koh, thomas"
+    },
+    "cr_display": {
+      "S": "Courtroom 1"
+    },
+    "created_date": {
+      "S": "2026-08-06 13:44:02"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-06"
+    },
+    "hearing_location": {
+      "S": "Pasadena, CA"
+    },
+    "hearing_location_code": {
+      "S": "PAS"
+    },
+    "hearing_location_lc": {
+      "S": "pasadena, ca"
+    },
+    "publish": {
+      "N": "20260806"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "7Gvl9ymW-Hw"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/05/25-6153.mp3"
+    },
+    "case_name": {
+      "S": "Calderon v. Blanche"
+    },
+    "case_name_lc": {
+      "S": "calderon v. blanche"
+    },
+    "case_num": {
+      "S": "25-6153"
+    },
+    "case_panel": {
+      "S": "GRABER, KOH, THOMAS"
+    },
+    "case_panel_lc": {
+      "S": "graber, koh, thomas"
+    },
+    "cr_display": {
+      "S": "Courtroom 1"
+    },
+    "created_date": {
+      "S": "2026-08-05 11:51:50"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-05"
+    },
+    "hearing_location": {
+      "S": "Pasadena, CA"
+    },
+    "hearing_location_code": {
+      "S": "PAS"
+    },
+    "hearing_location_lc": {
+      "S": "pasadena, ca"
+    },
+    "publish": {
+      "N": "20260805"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "mLDHyzexrbA"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/06/25-4210.mp3"
+    },
+    "case_name": {
+      "S": "Vaughn, Jr., et al. v. Klamath County Fire District1, et al."
+    },
+    "case_name_lc": {
+      "S": "vaughn, jr., et al. v. klamath county fire district1, et al."
+    },
+    "case_num": {
+      "S": "25-4210"
+    },
+    "case_panel": {
+      "S": "McKEOWN, SMITH, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "mckeown, smith, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-06 13:07:57"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-06"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260806"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "8r3mRorxBM4"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/04/25-5777.mp3"
+    },
+    "case_name": {
+      "S": "T.W. v. Echtenkamp, et al."
+    },
+    "case_name_lc": {
+      "S": "t.w. v. echtenkamp, et al."
+    },
+    "case_num": {
+      "S": "25-5777"
+    },
+    "case_panel": {
+      "S": "HAWKINS, McKEOWN, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "hawkins, mckeown, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-04 12:53:24"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-04"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260804"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "b-muY2thTWE"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/04/25-6334.mp3"
+    },
+    "case_name": {
+      "S": "Collard v. Bisignano"
+    },
+    "case_name_lc": {
+      "S": "collard v. bisignano"
+    },
+    "case_num": {
+      "S": "25-6334"
+    },
+    "case_panel": {
+      "S": "HAWKINS, McKEOWN, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "hawkins, mckeown, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-04 12:54:26"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-04"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260804"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "et2_ZzUAcOQ"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/06/25-2095.mp3"
+    },
+    "case_name": {
+      "S": "Bandy, et al. v. Move, Inc., et al."
+    },
+    "case_name_lc": {
+      "S": "bandy, et al. v. move, inc., et al."
+    },
+    "case_num": {
+      "S": "25-2095"
+    },
+    "case_panel": {
+      "S": "GRABER, KOH, THOMAS"
+    },
+    "case_panel_lc": {
+      "S": "graber, koh, thomas"
+    },
+    "cr_display": {
+      "S": "Courtroom 1"
+    },
+    "created_date": {
+      "S": "2026-08-06 13:43:52"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-06"
+    },
+    "hearing_location": {
+      "S": "Pasadena, CA"
+    },
+    "hearing_location_code": {
+      "S": "PAS"
+    },
+    "hearing_location_lc": {
+      "S": "pasadena, ca"
+    },
+    "publish": {
+      "N": "20260806"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "UHv3qqV1xjY"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/04/25-3254.mp3"
+    },
+    "case_name": {
+      "S": "Neaman v. Washington Department of Corrections, et al."
+    },
+    "case_name_lc": {
+      "S": "neaman v. washington department of corrections, et al."
+    },
+    "case_num": {
+      "S": "25-3254"
+    },
+    "case_panel": {
+      "S": "HAWKINS, McKEOWN, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "hawkins, mckeown, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-04 12:51:33"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-04"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260804"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "Xn95zHc-gGc"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/05/25-4271.mp3"
+    },
+    "case_name": {
+      "S": "Stewart, et al. v. City of Tacoma, et al."
+    },
+    "case_name_lc": {
+      "S": "stewart, et al. v. city of tacoma, et al."
+    },
+    "case_num": {
+      "S": "25-4271"
+    },
+    "case_panel": {
+      "S": "HAWKINS, McKEOWN, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "hawkins, mckeown, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-05 13:48:31"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-05"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260805"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "j5VQhsP8TLg"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/04/25-2941.mp3"
+    },
+    "case_name": {
+      "S": "Colestock v. DeJoy"
+    },
+    "case_name_lc": {
+      "S": "colestock v. dejoy"
+    },
+    "case_num": {
+      "S": "25-2941"
+    },
+    "case_panel": {
+      "S": "HAWKINS, McKEOWN, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "hawkins, mckeown, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-04 12:50:48"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-04"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260804"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "CBgjbVrUe1I"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/06/25-2548.mp3"
+    },
+    "case_name": {
+      "S": "McGuffin, et al. v. Karcher, et al."
+    },
+    "case_name_lc": {
+      "S": "mcguffin, et al. v. karcher, et al."
+    },
+    "case_num": {
+      "S": "25-2548"
+    },
+    "case_panel": {
+      "S": "McKEOWN, SMITH, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "mckeown, smith, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-06 13:06:20"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-06"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260806"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "sT4xyyJxQU0"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/06/25-4278.mp3"
+    },
+    "case_name": {
+      "S": "NW Energy Coalition, et al. v. Bonneville Power Administration"
+    },
+    "case_name_lc": {
+      "S": "nw energy coalition, et al. v. bonneville power administration"
+    },
+    "case_num": {
+      "S": "25-4278"
+    },
+    "case_panel": {
+      "S": "McKEOWN, SMITH, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "mckeown, smith, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-06 13:08:54"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-06"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260806"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "RCkhxd9h33A"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/05/25-4628.mp3"
+    },
+    "case_name": {
+      "S": "Rohani, et al. v. Rubio, et al."
+    },
+    "case_name_lc": {
+      "S": "rohani, et al. v. rubio, et al."
+    },
+    "case_num": {
+      "S": "25-4628"
+    },
+    "case_panel": {
+      "S": "HAWKINS, McKEOWN, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "hawkins, mckeown, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-05 13:49:22"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-05"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260805"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "FUh3qgyJhjU"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/03/24-3223.mp3"
+    },
+    "case_name": {
+      "S": "USA v. Pigida"
+    },
+    "case_name_lc": {
+      "S": "usa v. pigida"
+    },
+    "case_num": {
+      "S": "24-3223"
+    },
+    "case_panel": {
+      "S": "HAWKINS, SMITH, CHRISTEN"
+    },
+    "case_panel_lc": {
+      "S": "hawkins, smith, christen"
+    },
+    "cr_display": {
+      "S": "7th Floor Courtroom 2"
+    },
+    "created_date": {
+      "S": "2026-08-03 12:54:08"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-03"
+    },
+    "hearing_location": {
+      "S": "Seattle, WA"
+    },
+    "hearing_location_code": {
+      "S": "SE"
+    },
+    "hearing_location_lc": {
+      "S": "seattle, wa"
+    },
+    "publish": {
+      "N": "20260803"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "SnN-SRNfWI8"
+    }
+  },
+  {
+    "active": {
+      "S": "1"
+    },
+    "associated_cases": {
+      "S": ""
+    },
+    "audio_file_name": {
+      "S": "2026/08/06/25-7151.mp3"
+    },
+    "case_name": {
+      "S": "E.V., et al. v. City of Covina, et al."
+    },
+    "case_name_lc": {
+      "S": "e.v., et al. v. city of covina, et al."
+    },
+    "case_num": {
+      "S": "25-7151"
+    },
+    "case_panel": {
+      "S": "GRABER, KOH, THOMAS"
+    },
+    "case_panel_lc": {
+      "S": "graber, koh, thomas"
+    },
+    "cr_display": {
+      "S": "Courtroom 1"
+    },
+    "created_date": {
+      "S": "2026-08-06 13:43:56"
+    },
+    "description": {
+      "S": ""
+    },
+    "hearing_date": {
+      "S": "2026-08-06"
+    },
+    "hearing_location": {
+      "S": "Pasadena, CA"
+    },
+    "hearing_location_code": {
+      "S": "PAS"
+    },
+    "hearing_location_lc": {
+      "S": "pasadena, ca"
+    },
+    "publish": {
+      "N": "20260806"
+    },
+    "record_type": {
+      "S": "ora"
+    },
+    "youtube_code": {
+      "S": "Gif8-slblC8"
+    }
+  }
+]


### PR DESCRIPTION
Fixes #2111

CA9 posts oral arguments in batches through the day. Because the scraper handed CourtListener rows ordered by hearing date (then case name), a row written at 13:51 landed at an arbitrary alphabetical position among rows CL already had, `DupChecker` hit its 5-consecutive-duplicate abort, and everything below was never reached — on that run or any later one, since the ordering is deterministic.

The `media` table has a `created_date` upload timestamp we weren't using. Filtering and sorting by it puts every genuinely new row above every row we already have, so the abort can only fire once the new rows are in.

## Changes

- Filter the `media` table by `created_date` (7d window) instead of `publish` (30d)
- Sort cases by `created_date` desc so new rows precede ones already in CL, and no-op `_date_sort`, which would otherwise re-sort by hearing date
- Keep backscrapes on `publish`: `created_date` only exists from mid-2021
- Log skipped rows at warning instead of debug; drop unused `days_interval`
- Add `ca9_example_2` fixture from a live response

## Verification

Replaying CourtListener's real `press_on` rules hour by hour over the actual 188 rows in 2026-04-01..2026-06-05:

| ordering | ingested | of the 14 rows prod missed |
|---|---|---|
| current (hearing date, 30d `publish`) | 181/188 | 7 recovered |
| this PR (`created_date`, 7d window) | **188/188** | **14 recovered** |

The 14 were identified from their CourtListener `date_created` (the batch a backscrape added on 2026-08-06). Every row the model predicts as lost under the current ordering is in that set, i.e. no false positives; it under-predicts 7 vs 14 because it assumes every hourly run completes cleanly.

Two things worth noting from the sweep:

- The current ordering fails *because* the scraper runs often — 181/188 hourly, 183/188 every 6h, 188/188 daily. More frequent runs put more duplicates ahead of each new batch.
- The window has to exceed the longest run gap. At a 7-day gap a 3-day window drops to 69/188 while 7 days holds at 188/188, which is why the window is 7 and not 3.

Also confirmed against `23-293 Perez Diaz v Bondi` (argued 2025-08-22, uploaded 341 days later): a run on the upload day sees it first in its window, whereas the 30-day hearing-date window could never reach it.

Backscrape unchanged, still returns 188 items for that range. Local suite passes (145 tests).

## Follow-ups

- A backscrape is needed after this merges to recover the existing backlog — already-missed rows have old `created_date` values and sit below any rolling window.
- 4 of the 14 recovered rows are the Bankruptcy Appellate Panel records from #2113; this makes that leak consistent rather than intermittent.
- `ca9_p` / `ca9_u` have the same defect with the same fix available via `last_updated`; worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)