### PR TITLE
fix(ca7): preserve filing dates and feed order

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Changes:
 -
 
 Fixes:
--
+- `ca7` opinions: use filing dates from opinion links and retain feed timestamp ordering. #2123
 
 ## 3.0.36 - 2026-08-07
 

--- a/juriscraper/opinions/united_states/federal_appellate/ca7.py
+++ b/juriscraper/opinions/united_states/federal_appellate/ca7.py
@@ -11,6 +11,10 @@ from juriscraper.OpinionSiteLinear import OpinionSiteLinear
 
 
 class Site(OpinionSiteLinear):
+    filing_date_re = re.compile(
+        r"Path=Y(?P<year>\d{4})/D(?P<month>\d{2})-(?P<day>\d{2})"
+    )
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.url = "https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Time=month&startDate=&endDate=&Author=any&AuthorName=&Case=any&CaseYear=&CaseNum=&Rubmit=RssRecent&RssJudgeName=Sykes&OpsOnly=yes"
@@ -29,7 +33,11 @@ class Site(OpinionSiteLinear):
             docket = parts[parts.index("case#") + 1]
             name = item["summary"].split(docket)[1].split("(")[0]
             author = item["summary"].split("{")[1].split("}")[0]
-            date = item["published"]
+            date_match = self.filing_date_re.search(item["link"])
+            if date_match is None:
+                logger.warning("Skipping item with no filing date in link")
+                continue
+            date = "-".join(date_match.group("year", "month", "day"))
             per_curiam = False
             if "curiam" in author.lower():
                 per_curiam = True
@@ -45,8 +53,16 @@ class Site(OpinionSiteLinear):
                     "judge": author,
                     "author": author,
                     "per_curiam": per_curiam,
+                    "feed_timestamp": item["published_parsed"],
                 }
             )
+
+        self.cases.sort(key=lambda case: case["feed_timestamp"], reverse=True)
+        for case in self.cases:
+            del case["feed_timestamp"]
+
+    def _date_sort(self) -> None:
+        """Preserve the feed timestamp order applied by `_process_html`."""
 
     def extract_from_text(self, scraped_text: str) -> dict:
         """Extract lower court from the scraped text.

--- a/tests/examples/opinions/united_states/ca7_example.compare.json
+++ b/tests/examples/opinions/united_states/ca7_example.compare.json
@@ -40,19 +40,6 @@
   },
   {
     "case_dates": "2023-01-11",
-    "case_names": "Randall Behning v. Kevin Johnson",
-    "download_urls": "https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&Path=Y2023/D01-11/C:21-1840:J:PerCuriam:aut:T:fnOp:N:2985862:S:0",
-    "precedential_statuses": "Published",
-    "blocked_statuses": false,
-    "date_filed_is_approximate": false,
-    "docket_numbers": "21-1840",
-    "judges": "",
-    "case_name_shorts": "",
-    "authors": "",
-    "per_curiam": true
-  },
-  {
-    "case_dates": "2023-01-11",
     "case_names": "Jacob Daneshrad v. Trean Group, LLC",
     "download_urls": "https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&Path=Y2023/D01-11/C:22-1421:J:Easterbrook:aut:T:fnOp:N:2986385:S:0",
     "precedential_statuses": "Published",
@@ -63,5 +50,18 @@
     "case_name_shorts": "",
     "authors": "Easterbrook",
     "per_curiam": false
+  },
+  {
+    "case_dates": "2023-01-11",
+    "case_names": "Randall Behning v. Kevin Johnson",
+    "download_urls": "https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&Path=Y2023/D01-11/C:21-1840:J:PerCuriam:aut:T:fnOp:N:2985862:S:0",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "21-1840",
+    "judges": "",
+    "case_name_shorts": "",
+    "authors": "",
+    "per_curiam": true
   }
 ]

--- a/tests/examples/opinions/united_states/ca7_example_2.compare.json
+++ b/tests/examples/opinions/united_states/ca7_example_2.compare.json
@@ -1,0 +1,54 @@
+[
+  {
+    "case_dates": "2026-07-31",
+    "case_names": "Breah Bedford v. Brandon Dewitt",
+    "download_urls": "https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&Path=Y2026/D07-31/C:24-2205:J:Kolar:aut:T:fnOp:N:3583973:S:0",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "24-2205",
+    "judges": "Kolar",
+    "case_name_shorts": "",
+    "authors": "Kolar",
+    "per_curiam": false
+  },
+  {
+    "case_dates": "2026-07-20",
+    "case_names": "Isabelle Arana v. Board of Regents of the University of Wisconsin",
+    "download_urls": "https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&Path=Y2026/D07-20/C:22-2454:J:Kirsch:aut:T:fnOp:N:3576025:S:0",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "22-2454",
+    "judges": "Kirsch",
+    "case_name_shorts": "",
+    "authors": "Kirsch",
+    "per_curiam": false
+  },
+  {
+    "case_dates": "2026-07-20",
+    "case_names": "Nancy Lyon Havlik v. University of Chicago",
+    "download_urls": "https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&Path=Y2026/D07-20/C:25-2821:J:Hamilton:aut:T:fnOp:N:3576017:S:0",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "25-2821",
+    "judges": "Hamilton",
+    "case_name_shorts": "",
+    "authors": "Hamilton",
+    "per_curiam": false
+  },
+  {
+    "case_dates": "2026-07-09",
+    "case_names": "Caleb Barnett v. Kwame Raoul",
+    "download_urls": "https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&Path=Y2026/D07-09/C:24-3060:J:St__Eve:aut:T:fnOp:N:3571193:S:0",
+    "precedential_statuses": "Published",
+    "blocked_statuses": false,
+    "date_filed_is_approximate": false,
+    "docket_numbers": "24-3060",
+    "judges": "St.Eve",
+    "case_name_shorts": "",
+    "authors": "St.Eve",
+    "per_curiam": false
+  }
+]

--- a/tests/examples/opinions/united_states/ca7_example_2.html
+++ b/tests/examples/opinions/united_states/ca7_example_2.html
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+<channel>
+<title>US 7th Judicial Circuit: New Opinions</title>
+<description>The latest opinions released by the US 7th Circuit Court of Appeals</description>
+
+<item>
+  <title>FinalOpinion in case# 24-2205</title>
+  <link>https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&amp;Path=Y2026/D07-31/C:24-2205:J:Kolar:aut:T:fnOp:N:3583973:S:0</link>
+  <description>FinalOpinion in case# 24-2205 Breah Bedford v Brandon Dewitt (cv) {Kolar} [uploaded: 07/31/2026]</description>
+  <guid isPermaLink="false">/opinionTest.html#{07/31/2026 Fri,31_Jul_2026_15:45:02}</guid>
+  <pubDate>Fri, 31 Jul 2026 15:45:02 CDT</pubDate>
+</item>
+
+<item>
+  <title>FinalOpinion in case# 25-2821</title>
+  <link>https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&amp;Path=Y2026/D07-20/C:25-2821:J:Hamilton:aut:T:fnOp:N:3576017:S:0</link>
+  <description>FinalOpinion in case# 25-2821 Nancy Lyon Havlik v University of Chicago (cv) {Hamilton} [uploaded: 07/20/2026]</description>
+  <guid isPermaLink="false">/opinionTest.html#{07/20/2026 Mon,20_Jul_2026_12:30:02}</guid>
+  <pubDate>Mon, 20 Jul 2026 12:30:02 CDT</pubDate>
+</item>
+
+<item>
+  <title>FinalOpinion in case# 22-2454</title>
+  <link>https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&amp;Path=Y2026/D07-20/C:22-2454:J:Kirsch:aut:T:fnOp:N:3576025:S:0</link>
+  <description>FinalOpinion in case# 22-2454 Isabelle Arana v Board of Regents of the University of Wisconsin (cv) {Kirsch} [uploaded: 07/20/2026]</description>
+  <guid isPermaLink="false">/opinionTest.html#{07/20/2026 Mon,20_Jul_2026_12:45:02}</guid>
+  <pubDate>Mon, 20 Jul 2026 12:45:02 CDT</pubDate>
+</item>
+
+<item>
+  <title>FinalOpinion in case# 24-3060</title>
+  <link>https://media.ca7.uscourts.gov/cgi-bin/OpinionsWeb/processWebInputExternal.pl?Submit=Display&amp;Path=Y2026/D07-09/C:24-3060:J:St__Eve:aut:T:fnOp:N:3571193:S:0</link>
+  <description>FinalOpinion in case# 24-3060 Caleb Barnett v Kwame Raoul (cv) {St.Eve} [uploaded: 07/09/2026]</description>
+  <guid isPermaLink="false">/opinionTest.html#{07/09/2026 Mon,20_Jul_2026_11:35:17}</guid>
+  <pubDate>Mon, 20 Jul 2026 11:35:17 CDT</pubDate>
+</item>
+
+</channel>
+</rss>


### PR DESCRIPTION
Fixes #2123

CA7's RSS `pubDate` is the feed timestamp, not the filing date. Parse filing dates from the opinion link and keep full feed timestamp order so new entries are not buried behind duplicates.

Tests:
- federal appellate scraper examples (22 scrapers, 28 fixtures)
- pre-commit