### PR TITLE
fix(florida): Add sort parameters to paginated case detail endpoints

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,7 @@ Fixes:
   bug. Affected example fixtures regenerated. Fixes #2048.
 - Fix `pa` backscraper: fixed a missing `await` that made them return zero results. #1860
 - Fix `sd` backscraper: fixed a missing `await` that made pagination recurse until `RecursionError`. #1860
+- Add sorting to FL paginated case detail endpoints (matching the values on the ACIS site) to prevent unstable results.
 -
 
 ## 3.0.36 - 2026-08-07

--- a/juriscraper/state/florida/scraper.py
+++ b/juriscraper/state/florida/scraper.py
@@ -536,6 +536,7 @@ class FloridaScraper:
         ) = await self._flatten_enumerate_pages(
             parties_parser.endpoint.format(court=court_uuid, case=case_uuid),
             parties_parser,
+            params={"sort": "partyNumber,asc"},
         )
         (
             output_case.entries,
@@ -543,6 +544,7 @@ class FloridaScraper:
         ) = await self._flatten_enumerate_pages(
             de_parser.endpoint.format(court=court_uuid, case=case_uuid),
             de_parser,
+            params={"sort": "docketEntryHeader.filedDate,desc"},
         )
         (
             output_case.arguments,
@@ -550,6 +552,7 @@ class FloridaScraper:
         ) = await self._flatten_enumerate_pages(
             arguments_parser.endpoint.format(court=court_uuid, case=case_uuid),
             arguments_parser,
+            params={"sort": "startDate,asc"},
         )
 
         da_parser = FloridaDocumentAccessParser(court_id=court_id)

--- a/juriscraper/state/florida/scraper.py
+++ b/juriscraper/state/florida/scraper.py
@@ -544,7 +544,9 @@ class FloridaScraper:
         ) = await self._flatten_enumerate_pages(
             de_parser.endpoint.format(court=court_uuid, case=case_uuid),
             de_parser,
-            params={"sort": "docketEntryHeader.filedDate,desc"},
+            params={
+                "sort": "docketEntryHeader.filedDate,desc,docketEntryHeader.docketEntryUUID,asc"
+            },
         )
         (
             output_case.arguments,


### PR DESCRIPTION
Add sort parameters to FL paginated case detail endpoints to ensure results are stable across pagination.

This should be deployed before we start running the polling command in CL.