### PR TITLE
fix(miss): update user agent blocked by the source's WAF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,7 @@ Changes:
 -
 
 Fixes:
--
+- Fix `miss` and `missctapp`, blocked by the source's WAF (#2129)
 
 ## 3.0.37 - 2026-08-13
 

--- a/juriscraper/opinions/united_states/state/miss.py
+++ b/juriscraper/opinions/united_states/state/miss.py
@@ -28,9 +28,14 @@ class Site(OpinionSiteLinear):
             "court": self.court_parameter,
             "year": str(datetime.date.today().year),
         }
+        # The site's WAF answers 500 with a "Website Maintenance" page to
+        # user agents on its bot list, which includes "Juriscraper" and
+        # outdated browser versions. The Chrome 120 string we used to send
+        # became stale and started getting blocked, so this needs to be
+        # bumped whenever the court starts failing again. See #2129
         self.request["headers"]["User-Agent"] = (
             "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
-            " (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            " (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36"
         )
 
         self.status = "Published"


### PR DESCRIPTION
Fixes #2129

## Root cause

Not a site change — `courts.ms.gov` deployed a WAF that returns **HTTP 500 with a "Website Maintenance" page** to user agents on its bot list. Our hardcoded `Chrome/120.0.0.0` string is on it: Chrome 120 shipped in December 2023, and "outdated browser version" is a standard bot heuristic.

Probing the rule with otherwise identical requests:

| User-Agent | Result |
| --- | --- |
| `...Chrome/120.0.0.0 Safari/537.36` (what we sent) | **500** |
| `...Chrome/128` / `131` / `139` / `140` / `151` | 200 |
| `Juriscraper` (the `AbstractSite` default) | **500** |
| `curl/7.81.0`, `Python-urllib/3.10` | **500** |
| `CourtListener`, `FreeLawProject`, `Mozilla/5.0` | 200 |

The block is site-wide: `getHanddown.php`, the `/Images/HDList/*.html` opinion lists, **and the opinion PDFs** all returned 500. Since this scraper sets `needs_special_headers = True`, CL was sending the same blocked user agent when downloading the documents themselves, so this broke document retrieval too, not just the scrape.

The endpoint itself was never broken — `getHanddown.php` returns correct current data as soon as the user agent passes, so no parsing changes were needed.

## Fix

Bump the user agent to `Chrome/151.0.0.0`, and add a comment recording that this string goes stale and is the first thing to check if the court starts failing again.

## Testing

Run against the live site:

- `miss` → 13 items (SCT hand downs 07-30, 08-06, 08-13)
- `missctapp` → 10 items (COA hand downs 08-04, 08-11)
- `miss --backscrape --backscrape-start 2026/03/01 --backscrape-end 2026/04/15` → 18 items across 6 hand-down dates
- Opinion PDF fetch → 200, 205KB
- `python -m unittest tests.local.test_ScraperExampleTest juriscraper.opinions` → 21 scrapers against 21 example files, no failures and no compare-file drift

## Follow-ups (not in this PR)

- `vt.py` (Chrome/128, 2024) and `nh_p.py` (Chrome/135, 2025) carry the same stale-string risk if their sources adopt a similar rule. Eight scrapers each hardcode their own version; a shared constant would let one bump cover all of them.
- The WAF blocks the literal string `Juriscraper`, the `AbstractSite` default. Any court behind this same vendor would fail identically, and the 500-plus-maintenance-page response reads as a site outage rather than a block.
