### PR TITLE
refactor(AbstractSite): single source for the browser User-Agent

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Features:
 -
 
 Changes:
--
+- Add `AbstractSite.chrome_user_agent` / `chrome_sec_ch_ua`, built from a single `chrome_version` attribute, and use them in every scraper that spoofs a browser User-Agent, so stale-version blocks are a one-line fix. #2132
 
 Fixes:
 -

--- a/juriscraper/AbstractSite.py
+++ b/juriscraper/AbstractSite.py
@@ -56,6 +56,22 @@ class AbstractSite:
     # Useful for sites that block httpx via TLS fingerprinting.
     use_urllib = False
 
+    # Some courts' bot management blocks the "Juriscraper" User-Agent, and
+    # some also block browser User-Agents that have gone stale. Scrapers that
+    # need to look like a browser should use `self.chrome_user_agent` instead
+    # of hardcoding a string, so a single bump here updates all of them.
+    # Keep in sync with the current stable Chrome release.
+    chrome_version = "151"
+    chrome_user_agent = (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        f"(KHTML, like Gecko) Chrome/{chrome_version}.0.0.0 Safari/537.36"
+    )
+    # Client hints matching `chrome_user_agent`, for sites that check them
+    chrome_sec_ch_ua = (
+        f'"Google Chrome";v="{chrome_version}", '
+        f'"Chromium";v="{chrome_version}", "Not)A;Brand";v="24"'
+    )
+
     def __init__(self, cnt=None, user_agent="Juriscraper", **kwargs):
         super().__init__()
 

--- a/juriscraper/opinions/united_states/administrative_agency/asbca.py
+++ b/juriscraper/opinions/united_states/administrative_agency/asbca.py
@@ -30,7 +30,7 @@ class Site(OpinionSiteLinear):
             "accept-encoding": "gzip, deflate, br, zstd",
             "accept-language": "en-US,en;q=0.9",
             "priority": "u=0, i",
-            "sec-ch-ua": '"Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24"',
+            "sec-ch-ua": self.chrome_sec_ch_ua,
             "sec-ch-ua-mobile": "?0",
             "sec-ch-ua-platform": '"Linux"',
             "sec-fetch-dest": "document",
@@ -38,7 +38,7 @@ class Site(OpinionSiteLinear):
             "sec-fetch-user": "?1",
             "sec-fetch-site": "cross-site",
             "upgrade-insecure-requests": "1",
-            "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
+            "user-agent": self.chrome_user_agent,
         }
         self.needs_special_headers = True
 

--- a/juriscraper/opinions/united_states/federal_appellate/cafc.py
+++ b/juriscraper/opinions/united_states/federal_appellate/cafc.py
@@ -28,9 +28,7 @@ class Site(OpinionSiteLinear):
         self.needs_special_headers = True
         self.request.update(
             {
-                "headers": {
-                    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
-                },
+                "headers": {"User-Agent": self.chrome_user_agent},
             }
         )
         self.should_have_results = True

--- a/juriscraper/opinions/united_states/federal_special/uscgcoca.py
+++ b/juriscraper/opinions/united_states/federal_special/uscgcoca.py
@@ -30,7 +30,7 @@ class Site(OpinionSiteLinear):
             "accept-encoding": "gzip, deflate, br, zstd",
             "accept-language": "en-US,en;q=0.9",
             "priority": "u=0, i",
-            "sec-ch-ua": '"Google Chrome";v="149", "Chromium";v="149", "Not)A;Brand";v="24"',
+            "sec-ch-ua": self.chrome_sec_ch_ua,
             "sec-ch-ua-mobile": "?0",
             "sec-ch-ua-platform": '"Linux"',
             "sec-fetch-dest": "document",
@@ -38,7 +38,7 @@ class Site(OpinionSiteLinear):
             "sec-fetch-site": "cross-site",
             "sec-fetch-user": "?1",
             "upgrade-insecure-requests": "1",
-            "user-agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0.0.0 Safari/537.36",
+            "user-agent": self.chrome_user_agent,
         }
         self.needs_special_headers = True
         self.should_have_results = True

--- a/juriscraper/opinions/united_states/state/alaska.py
+++ b/juriscraper/opinions/united_states/state/alaska.py
@@ -116,10 +116,7 @@ class Site(OpinionSiteLinear):
         self.end_date = date.today()
         self.start_date = self.end_date - timedelta(days=self.days_interval)
         # A browser User-Agent is required to pass the site's bot management
-        self.request["headers"]["User-Agent"] = (
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-        )
+        self.request["headers"]["User-Agent"] = self.chrome_user_agent
         # Tell the caller (CourtListener) to download opinions with the same
         # browser headers, otherwise the per-document fetch goes out as
         # "CourtListener" and trips the bot management we just bypassed

--- a/juriscraper/opinions/united_states/state/dc.py
+++ b/juriscraper/opinions/united_states/state/dc.py
@@ -27,10 +27,7 @@ class Site(OpinionSiteLinear):
         self.status = "Published"
 
         self.needs_special_headers = True
-        self.request["headers"]["User-Agent"] = (
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-        )
+        self.request["headers"]["User-Agent"] = self.chrome_user_agent
 
     def _process_html(self):
         """Process the html and extract out the opinions

--- a/juriscraper/opinions/united_states/state/la.py
+++ b/juriscraper/opinions/united_states/state/la.py
@@ -58,10 +58,7 @@ class Site(OpinionSiteLinear):
         self.rendered_pages: list[tuple[str, str]] = []
         # lasc.org sits behind Cloudflare and serves the default httpx
         # User-Agent the 521/empty shell more often; a browser UA is stabler.
-        self.request["headers"]["User-Agent"] = (
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-            "(KHTML, like Gecko) Chrome/120.0 Safari/537.36"
-        )
+        self.request["headers"]["User-Agent"] = self.chrome_user_agent
 
     async def _download(self, request_dict=None):
         if self.test_mode_enabled():

--- a/juriscraper/opinions/united_states/state/minn.py
+++ b/juriscraper/opinions/united_states/state/minn.py
@@ -51,6 +51,10 @@ class Site(OpinionSiteLinear):
             "Accept-Language": "en-US,en;q=0.9",
             "Sec-Fetch-Mode": "navigate",
             "Host": "mn.gov",
+            # Radware Bot Manager blocks a bare Chrome User-Agent here:
+            # httpx's TLS/HTTP2 fingerprint does not match the browser the
+            # UA claims to be. A non-Chrome UA passes, so this scraper must
+            # NOT use `self.chrome_user_agent`
             "User-Agent": "Juriscraper/3.0 Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.1 Safari/605.1.15",
             "Referer": "https://mn.gov/law-library/search/?v%3Asources=mn-law-library-opinions&query=+%28url%3A%2Farchive%2Fsupct%29+&citation=&qt=&sortby=&docket=&case=&v=&p=&start-date=&end-date=",
             "Connection": "keep-alive",

--- a/juriscraper/opinions/united_states/state/miss.py
+++ b/juriscraper/opinions/united_states/state/miss.py
@@ -30,13 +30,9 @@ class Site(OpinionSiteLinear):
         }
         # The site's WAF answers 500 with a "Website Maintenance" page to
         # user agents on its bot list, which includes "Juriscraper" and
-        # outdated browser versions. The Chrome 120 string we used to send
-        # became stale and started getting blocked, so this needs to be
-        # bumped whenever the court starts failing again. See #2129
-        self.request["headers"]["User-Agent"] = (
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"
-            " (KHTML, like Gecko) Chrome/151.0.0.0 Safari/537.36"
-        )
+        # outdated browser versions, so `AbstractSite.chrome_version` needs
+        # to be bumped when the court starts failing again. See #2129
+        self.request["headers"]["User-Agent"] = self.chrome_user_agent
 
         self.status = "Published"
         self.pages = {}

--- a/juriscraper/opinions/united_states/state/ncbizct.py
+++ b/juriscraper/opinions/united_states/state/ncbizct.py
@@ -26,9 +26,7 @@ class Site(OpinionSiteLinear):
         self.make_backscrape_iterable(kwargs)
         self.should_have_results = True
         self.needs_special_headers = True
-        self.request["headers"] = {
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
-        }
+        self.request["headers"] = {"User-Agent": self.chrome_user_agent}
 
     def _process_html(self):
         for row in self.html.xpath(

--- a/juriscraper/opinions/united_states/state/nh_p.py
+++ b/juriscraper/opinions/united_states/state/nh_p.py
@@ -176,7 +176,7 @@ class Site(OpinionSiteLinear):
         }
         self.url = f"{self.base_url}?{urlencode(params)}"
         self.request["headers"] = {
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36",
+            "User-Agent": self.chrome_user_agent,
             "Accept": "application/json, text/plain, */*",
             "Accept-Language": "en-US,en;q=0.9",
             "Accept-Encoding": "gzip, deflate, br",

--- a/juriscraper/opinions/united_states/state/nj.py
+++ b/juriscraper/opinions/united_states/state/nj.py
@@ -23,10 +23,7 @@ class Site(OpinionSiteLinear):
         # Imperva WAF blocks the default UA on both the index pages and the
         # opinion PDFs, so the override must also apply to content downloads.
         self.needs_special_headers = True
-        self.request["headers"]["User-Agent"] = (
-            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-            "(KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
-        )
+        self.request["headers"]["User-Agent"] = self.chrome_user_agent
 
     def _process_html(self) -> None:
         """Process the html and extract out the opinions

--- a/juriscraper/opinions/united_states/state/vt.py
+++ b/juriscraper/opinions/united_states/state/vt.py
@@ -37,9 +37,7 @@ class Site(OpinionSiteLinear):
         self.set_url()
         self.make_backscrape_iterable(kwargs)
         self.needs_special_headers = True
-        self.request["headers"] = {
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36"
-        }
+        self.request["headers"] = {"User-Agent": self.chrome_user_agent}
 
     def _process_html(self) -> None:
         """Process HTML into case dictionaries

--- a/juriscraper/oral_args/united_states/federal_appellate/cafc.py
+++ b/juriscraper/oral_args/united_states/federal_appellate/cafc.py
@@ -31,9 +31,7 @@ class Site(OralArgumentSiteLinear):
         self.needs_special_headers = True
         self.request.update(
             {
-                "headers": {
-                    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/135.0.0.0 Safari/537.36"
-                },
+                "headers": {"User-Agent": self.chrome_user_agent},
             }
         )
 


### PR DESCRIPTION
Fixes #2132

13 scraper groups each hardcoded their own Chrome User-Agent, pinned to whatever version was current the day they were written — Chrome 120 through 149, against a current stable of 151. WAFs blocklist stale browser versions, so they break one at a time, months later, looking like site changes until you dig in (#2129 being the latest).

This adds `chrome_version`, `chrome_user_agent` and `chrome_sec_ch_ua` to `AbstractSite` and points every one of them at it, so a refresh is a one-line change. Parameterizing only the major version is safe: Chrome's User-Agent Reduction froze the rest of the string, and the `"Not)A;Brand"` entry in `sec-ch-ua` is GREASE, which servers must ignore.

**`minn` is deliberately excluded.** Its Radware Bot Manager compares the claimed browser against the client's TLS/HTTP-2 fingerprint, and httpx doesn't look like Chrome. Tested live:

| User-Agent sent | Result |
|---|---|
| `… Chrome/151.0.0.0 Safari/537.36` | **blocked** — Radware captcha |
| `Juriscraper` | **blocked** — Radware captcha |
| `… Version/17.1 Safari/605.1.15` (current) | OK, 10 items |
| `Juriscraper/3.0 ` + the same Chrome 151 string | OK, 10 items |

It keeps its own string, with a comment saying it must not use `chrome_user_agent`.

### Testing

Every affected scraper was run live with `sample_caller`, since the point of the change is behaviour against real WAFs:

| Scraper | Items | Scraper | Items |
|---|---|---|---|
| `asbca` | 147 | `miss` | 13 |
| `uscgcoca` | 15 | `ncbizct` | 20 |
| `cafc` (opinions) | 100 | `nh_p` | 25 |
| `alaska` | 16 | `nj` | 20 |
| `dc` | 6 | `vt` | 25 |
| `la` | 14 | `minn` (unchanged) | 10 |

Subclasses were checked too — `alaskactapp`, `missctapp`, `miss_beginningofyear`, `missctapp_beginningofyear`, `nh_u`, `njtaxct_p`, `njsuperctappdiv_u`, `vtsuperct_civil`, `vt_criminal` all inherit the new UA; `minnctapp_p` / `minnctapp_u` correctly keep the Safari one.

`dc` is worth a look: it was the only Windows UA and works fine on the shared Linux one.

`cafc` oral args returns 0 items on its default 30-day window, but that is not a regression — it returns 0 under the old Chrome 135 string too, and 62 items for a May 2026 backscrape range under both. Empty window (August recess).

`tests.local.test_ScraperExampleTest`: 8 tests, OK — 254 scrapers against 296 example files.

### Notes

The `ca5` backscraper also had a hardcoded UA, but it was deleted on `main` in f3fb9846 while this was in progress, so it's dropped from this change.

Keeping the value current is #2133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
