### PR TITLE
fix(olc, bia): correct override of `download_content()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Changes:
 
 Fixes:
 - Fix `miss` and `missctapp`, blocked by the source's WAF (#2129)
+- Fix `bia` and `olc` implementations of `download_content()`
 
 ## 3.0.37 - 2026-08-13
 

--- a/juriscraper/opinions/united_states/administrative_agency/bia.py
+++ b/juriscraper/opinions/united_states/administrative_agency/bia.py
@@ -14,6 +14,8 @@ import re
 from datetime import datetime, timedelta
 from typing import Any
 
+from typing_extensions import override
+
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.auth_utils import get_justice_dot_gov_auth_cookies
 from juriscraper.lib.exceptions import UnexpectedContentTypeError
@@ -105,20 +107,24 @@ class Site(OpinionSiteLinear):
         }
         return metadata
 
-    def download_content(
-        self, download_url, doctor_is_available=True, media_root=""
-    ):
+    @override
+    async def download_content(
+        self,
+        download_url: str,
+        doctor_is_available: bool = True,
+        media_root: str = "",
+    ) -> str | bytes:
         """Overrides regular download_content to handle the
         "I am not a robot challenge". See #1724
         """
         try:
-            return super().download_content(
+            return await super().download_content(
                 download_url, doctor_is_available, media_root
             )
         except UnexpectedContentTypeError as exc:
             # access HTML with JS variables to populate cookies
             html_text = exc.data["response"].text
             self.cookies = get_justice_dot_gov_auth_cookies(html_text)
-            return super().download_content(
+            return await super().download_content(
                 download_url, doctor_is_available, media_root
             )

--- a/juriscraper/opinions/united_states/administrative_agency/olc.py
+++ b/juriscraper/opinions/united_states/administrative_agency/olc.py
@@ -11,6 +11,8 @@ History:
 from datetime import date, datetime
 from urllib.parse import urlencode
 
+from typing_extensions import override
+
 from juriscraper.AbstractSite import logger
 from juriscraper.lib.auth_utils import get_justice_dot_gov_auth_cookies
 from juriscraper.lib.exceptions import UnexpectedContentTypeError
@@ -67,20 +69,24 @@ class Site(OpinionSiteLinear):
         self.html = await self._download()
         self._process_html()
 
-    def download_content(
-        self, download_url, doctor_is_available=True, media_root=""
-    ):
+    @override
+    async def download_content(
+        self,
+        download_url: str,
+        doctor_is_available: bool = True,
+        media_root: str = "",
+    ) -> str | bytes:
         """Overrides regular download_content to handle the
         "I am not a robot challenge". See #1724
         """
         try:
-            return super().download_content(
+            return await super().download_content(
                 download_url, doctor_is_available, media_root
             )
         except UnexpectedContentTypeError as exc:
             # access HTML with JS variables to populate cookies
             html_text = exc.data["response"].text
             self.cookies = get_justice_dot_gov_auth_cookies(html_text)
-            return super().download_content(
+            return await super().download_content(
                 download_url, doctor_is_available, media_root
             )


### PR DESCRIPTION

## Fixes
This fixes `bia` and `olc` implementations of `download_content()`

## Summary
Analysis of the large `AbstractSite` heirarchy for mistaken overrides revealed these errors, which were masked by the fact that the functions were unannotated:

```
juriscraper/opinions/united_states/administrative_agency/bia.py:108: error: Return type "str | bytes" of "download_content" incompatible with return type "Coroutine[Any, Any, str | bytes]" in supertype "juriscraper.AbstractSite.AbstractSite"  [override]
juriscraper/opinions/united_states/administrative_agency/bia.py:118: error: Incompatible return value type (got "Coroutine[Any, Any, str | bytes]", expected "str | bytes")  [return-value]
juriscraper/opinions/united_states/administrative_agency/bia.py:118: note: Maybe you forgot to use "await"?
juriscraper/opinions/united_states/administrative_agency/bia.py:123: error: Value of type "dict[Any, Any] | None" is not indexable  [index]
juriscraper/opinions/united_states/administrative_agency/bia.py:125: error: Incompatible return value type (got "Coroutine[Any, Any, str | bytes]", expected "str | bytes")  [return-value]
juriscraper/opinions/united_states/administrative_agency/bia.py:125: note: Maybe you forgot to use "await"?
juriscraper/opinions/united_states/administrative_agency/olc.py:70: error: Return type "str | bytes" of "download_content" incompatible with return type "Coroutine[Any, Any, str | bytes]" in supertype "juriscraper.AbstractSite.AbstractSite"  [override]
juriscraper/opinions/united_states/administrative_agency/olc.py:80: error: Incompatible return value type (got "Coroutine[Any, Any, str | bytes]", expected "str | bytes")  [return-value]
juriscraper/opinions/united_states/administrative_agency/olc.py:80: note: Maybe you forgot to use "await"?
juriscraper/opinions/united_states/administrative_agency/olc.py:85: error: Value of type "dict[Any, Any] | None" is not indexable  [index]
juriscraper/opinions/united_states/administrative_agency/olc.py:87: error: Incompatible return value type (got "Coroutine[Any, Any, str | bytes]", expected "str | bytes")  [return-value]
juriscraper/opinions/united_states/administrative_agency/olc.py:87: note: Maybe you forgot to use "await"?
```

In 0a12116 (#1843), `download_content()` of `AbstactSite` was made `async`. This method was overridden by two subclasses and neither were updated to reflect the shift to `async`. This is all but certain to have been an accident.

It would not be surprising if this is the cause of an unrecognized bug breaking integration with the the `bia` and `olc` scrapers. This is unexplored, but an investigation into "why wasn't this recognized?" would be merited.

The issue is resolved by copying over the method signature from `AbstractSite` to its subclasses. The `@override` decorator, which could have caught and prevented this regression is also introduced, for good measure.

## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
