### PR TITLE
fix(alaska): correct override of `cleanup_content`

### DIFF
--- a/juriscraper/opinions/united_states/state/alaska.py
+++ b/juriscraper/opinions/united_states/state/alaska.py
@@ -229,7 +229,8 @@ class Site(OpinionSiteLinear):
                 }
             )
 
-    def cleanup_content(self, content: bytes) -> str:
+    @staticmethod
+    def cleanup_content(content: bytes) -> str:
         """Isolate the opinion from the surrounding Westlaw site chrome.
 
         Also deletes hash-altering per-request tokens.
@@ -244,14 +245,14 @@ class Site(OpinionSiteLinear):
         nodes = tree.xpath("//*[@id='co_document']")
         if not nodes:
             raise InvalidDocumentError(
-                f"{self.court_id}: opinion container '#co_document' missing; "
+                "alaska: opinion container '#co_document' missing; "
                 "the document request was likely blocked"
             )
         cleaned = html.tostring(nodes[0], encoding="unicode")
 
         # Strip per-request tokens from embedded image/link URLs so the
         # content hash is stable across downloads (CL dedupes on hash) #2009
-        return self.volatile_token_regex.sub("", cleaned)
+        return Site.volatile_token_regex.sub("", cleaned)
 
     async def _download_backwards(self, dates: tuple[date, date]) -> None:
         """Configure the date window for a historical range and download.


### PR DESCRIPTION

## Fixes
This fixes a mismatched method signature in `alaska.Site`

## Summary
Analysis of the large `AbstractSite` heirarchy for mistaken overrides revealed this error:

```
juriscraper/opinions/united_states/state/alaska.py:232: error: Signature of "cleanup_content" incompatible with supertype "juriscraper.AbstractSite.AbstractSite"  [override]
juriscraper/opinions/united_states/state/alaska.py:232: note:      Superclass:
juriscraper/opinions/united_states/state/alaska.py:232: note:          @staticmethod
juriscraper/opinions/united_states/state/alaska.py:232: note:          def cleanup_content(content: Any) -> Any
juriscraper/opinions/united_states/state/alaska.py:232: note:      Subclass:
juriscraper/opinions/united_states/state/alaska.py:232: note:          def cleanup_content(self, content: bytes) -> str
```

While this mismatch does not produce an error in practical usage (surprisingly, the arguments work themselves out), the implementation that `alaska` uses is out of step with all other implementations of the method. This introduces unhelpful confusion that amounts to a bug.

In order to use `@staticmethod`, there are two instances of `self` that needed to be addressed. `volatile_token_regex` is referred to using the class `Site` (harmless) and `court_id` is replaced with literal (precedent for this in `masssuperct`).

## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
