### PR TITLE
fix(async): correct signature of `__aexit__`

### DIFF
--- a/juriscraper/OpinionSiteLinearWebDriven.py
+++ b/juriscraper/OpinionSiteLinearWebDriven.py
@@ -7,7 +7,7 @@ class OpinionSiteLinearWebDriven(OpinionSiteLinear, WebDriven):
         super().__init__(*args, **kwargs)
         WebDriven.__init__(self, args, kwargs)
 
-    async def __aexit__(self):
+    async def __aexit__(self, exc_type, exc_value, traceback):
         await self.close_session()
 
     def __del__(self):

--- a/juriscraper/OpinionSiteWebDriven.py
+++ b/juriscraper/OpinionSiteWebDriven.py
@@ -7,7 +7,7 @@ class OpinionSiteWebDriven(OpinionSite, WebDriven):
         super().__init__(*args, **kwargs)
         WebDriven.__init__(self, args, kwargs)
 
-    async def __aexit__(self):
+    async def __aexit__(self, exc_type, exc_value, traceback):
         await self.close_session()
 
     def __del__(self):

--- a/juriscraper/OralArgumentSiteLinearWebDriven.py
+++ b/juriscraper/OralArgumentSiteLinearWebDriven.py
@@ -7,7 +7,7 @@ class OralArgumentSiteLinearWebDriven(OralArgumentSiteLinear, WebDriven):
         super().__init__(*args, **kwargs)
         WebDriven.__init__(self, args, kwargs)
 
-    async def __aexit__(self):
+    async def __aexit__(self, exc_type, exc_value, traceback):
         await self.close_session()
 
     def __del__(self):


### PR DESCRIPTION

## Fixes
This fixes a lurking `TypeError` for usage of `OpinionSiteWebDriven`, `OpinionSiteLinearWebDriven`, and `OralArgumentSiteLinearWebDriven` in connection with `async with`.

## Summary
Analysis of the large `AbstractSite` heirarchy for mistaken overrides revealed bad overrides of `__aexit__()`:

```
juriscraper/OpinionSiteWebDriven.py:10: error: Signature of "__aexit__" incompatible with supertype "juriscraper.AbstractSite.AbstractSite"  [override]
juriscraper/OpinionSiteWebDriven.py:10: note:      Superclass:
juriscraper/OpinionSiteWebDriven.py:10: note:          def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any
juriscraper/OpinionSiteWebDriven.py:10: note:      Subclass:
juriscraper/OpinionSiteWebDriven.py:10: note:          def __aexit__(self) -> Any
juriscraper/OralArgumentSiteLinearWebDriven.py:10: error: Signature of "__aexit__" incompatible with supertype "juriscraper.AbstractSite.AbstractSite"  [override]
juriscraper/OralArgumentSiteLinearWebDriven.py:10: note:      Superclass:
juriscraper/OralArgumentSiteLinearWebDriven.py:10: note:          def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any
juriscraper/OralArgumentSiteLinearWebDriven.py:10: note:      Subclass:
juriscraper/OralArgumentSiteLinearWebDriven.py:10: note:          def __aexit__(self) -> Any
juriscraper/OpinionSiteLinearWebDriven.py:10: error: Signature of "__aexit__" incompatible with supertype "juriscraper.AbstractSite.AbstractSite"  [override]
juriscraper/OpinionSiteLinearWebDriven.py:10: note:      Superclass:
juriscraper/OpinionSiteLinearWebDriven.py:10: note:          def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any
juriscraper/OpinionSiteLinearWebDriven.py:10: note:      Subclass:
juriscraper/OpinionSiteLinearWebDriven.py:10: note:          def __aexit__(self) -> Any
```

As written `__aexit__()` is unary - this is common with many "dunders", but not this one; it is invoked by the runtime with 4 arguments. As is, use of these objects by `with` will raise a `TypeError`:

```
class ImplementationN_ary:
    async def __aenter__(self):
        print("(n-ary) -> Entering")
        return self

    async def __aexit__(self, *_exc_info: object):
        print("(n-ary) -> Exiting (Cleanup)")
        return False

class ImplementationUnary:
    async def __aenter__(self):
        print("(unary) -> Entering")
        return self

    async def __aexit__(self):
        print("(unary) -> Exiting (Cleanup)")
        return False

async def main():
    async with ImplementationN_ary():
        print("(n-ary)   Inside block")
    async with ImplementationUnary():
        print("(unary)   Inside block")

asyncio.run(main())
# TypeError: ImplementationUnary.__aexit__() takes 1 positional argument but 4 were given

```

These were introduced in 0a12116 (#1843), all indications are that it was accidental. This signature (untyped) is copied uncritically from the definition given by `AbstractSite`. Better typing and `@override` would be nice, but that can be left as a exercise for later.

## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
