### PR TITLE
fix(bap1, mich, michctapp): correct missing await for `download()`, etc.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,7 +21,8 @@ Changes:
 -
 
 Fixes:
--
+- Fix `bap1` backscraper: fixed a missing `await` that made it return zero results. #2136
+- Fix `mich` backscraper: fixed a missing `await` that made it return zero results. #2136
 
 ## 3.0.40 - 2026-08-19
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -23,6 +23,7 @@ Changes:
 Fixes:
 - Fix `bap1` backscraper: fixed a missing `await` that made it return zero results. #2136
 - Fix `mich` backscraper: fixed a missing `await` that made it return zero results. #2136
+- Fix `michctapp` backscraper: fixed a missing `await` that would lead to cases getting the title "Placeholder name".
 
 ## 3.0.40 - 2026-08-19
 

--- a/juriscraper/opinions/united_states/federal_bankruptcy/bap1.py
+++ b/juriscraper/opinions/united_states/federal_bankruptcy/bap1.py
@@ -72,7 +72,7 @@ class Site(OpinionSiteLinear):
         }
 
         self.url = f"{self.url}?{urlencode(params)}"
-        self.html = self._download()
+        self.html = await self._download()
         self._process_html()
 
     def _process_html(self) -> None:

--- a/juriscraper/opinions/united_states/state/mich.py
+++ b/juriscraper/opinions/united_states/state/mich.py
@@ -46,15 +46,15 @@ class Site(OpinionSiteLinear):
         self.request["headers"] = {"User-Agent": ""}
         self.make_backscrape_iterable(kwargs)
 
-    def _process_html(self) -> None:
+    async def _process_html(self) -> None:
         """Process the html and extract out the opinions
 
         :return: None
         """
         for item in self.html["searchItems"]:
-            self.cases.append(self._extract_case_data_from_item(item))
+            self.cases.append(await self._extract_case_data_from_item(item))
 
-    def _extract_case_data_from_item(self, item: dict) -> dict:
+    async def _extract_case_data_from_item(self, item: dict) -> dict:
         """Extract the case data from the item
 
         :param item: The item from the API
@@ -64,7 +64,7 @@ class Site(OpinionSiteLinear):
             docket = match.group("docket")
             name = self.cleanup_case_name(match.group("name"))
         else:
-            name, docket = self.get_missing_name_and_docket(item)
+            name, docket = await self.get_missing_name_and_docket(item)
 
         disposition = self.get_disposition(item)
 
@@ -107,7 +107,7 @@ class Site(OpinionSiteLinear):
         lower_courts = re.sub(r"\s+", " ", ", ".join(courts).lstrip(", "))
         return titlecase(lower_courts)
 
-    def get_missing_name_and_docket(self, item: dict) -> tuple[str, str]:
+    async def get_missing_name_and_docket(self, item: dict) -> tuple[str, str]:
         """
         Return 2 placeholders. We can get the values via `extract_from_text`
         To be overriden in `michctapp`
@@ -147,7 +147,7 @@ class Site(OpinionSiteLinear):
         logger.info("Backscraping for range %s %s", *dates)
         self.url = self._build_backscrape_url(dates)
         self.html = await self._download()
-        self._process_html()
+        await self._process_html()
 
     def extract_from_text(self, scraped_text: str) -> dict:
         """Extracts case names and docket numbers from the document's text

--- a/juriscraper/opinions/united_states/state/mich.py
+++ b/juriscraper/opinions/united_states/state/mich.py
@@ -138,7 +138,7 @@ class Site(OpinionSiteLinear):
         )
         return f"https://www.courts.michigan.gov/api/CaseSearch/SearchCaseOpinions?{urlencode(params)}"
 
-    def _download_backwards(self, dates: tuple[date, date]) -> None:
+    async def _download_backwards(self, dates: tuple[date, date]) -> None:
         """Download opinions for a specific date range.
 
         :param dates: (start_date, end_date) tuple from make_backscrape_iterable
@@ -146,7 +146,7 @@ class Site(OpinionSiteLinear):
         """
         logger.info("Backscraping for range %s %s", *dates)
         self.url = self._build_backscrape_url(dates)
-        self.html = self._download()
+        self.html = await self._download()
         self._process_html()
 
     def extract_from_text(self, scraped_text: str) -> dict:

--- a/juriscraper/opinions/united_states/state/michctapp.py
+++ b/juriscraper/opinions/united_states/state/michctapp.py
@@ -32,13 +32,13 @@ class Site(ClusterSite, mich.Site):
         params = self.filters + (("aAppellateCourt", self.court),)
         self.url = f"https://www.courts.michigan.gov/api/CaseSearch/SearchCaseOpinions?{urlencode(params)}"
 
-    def _process_html(self) -> None:
+    async def _process_html(self) -> None:
         """Process the html and extract out the opinions
 
         :return: None
         """
         for item in self.html["searchItems"]:
-            case_dict = self._extract_case_data_from_item(item)
+            case_dict = await self._extract_case_data_from_item(item)
 
             # Use URL suffix to get the type. Other prefixes not used here
             # "o.opn.pdf": "On Remand" opinions
@@ -61,7 +61,7 @@ class Site(ClusterSite, mich.Site):
             if not self.cluster_opinions(case_dict, self.cases):
                 self.cases.append(case_dict)
 
-    def get_missing_name_and_docket(self, item: dict) -> tuple[str, str]:
+    async def get_missing_name_and_docket(self, item: dict) -> tuple[str, str]:
         """Try to get the case name using a secondary request
 
         Example of the content in the URL
@@ -86,7 +86,7 @@ class Site(ClusterSite, mich.Site):
             return "Placeholder name", "Placeholder docket"
 
         url = f"https://www.courts.michigan.gov/api/CaseSearch/SearchCaseSearchContent?searchQuery={docket_number}"
-        self._request_url_get(url)
+        await self._request_url_get(url)
         response = self.request["response"].json()
         search_items = response.get("caseDetailResults", {}).get(
             "searchItems", []


### PR DESCRIPTION
## Fixes
This fixes bugs affecting backscraping for `mich`, `bap1` and `michctapp`.

## Summary
Analysis of the large `AbstractSite` heirarchy for mistaken overrides revealed misuse of `_download()`, which was masked by the fact that `_download()` returns `Any` and the type of `html` is unspecified. Futher scrutiny of `async` methods revealed that a call of the async `_request_url_get()` for `michctapp` was called without `await`.

In 0a12116 (#1843), `download()` of `AbstactSite` was made `async`. For reasons unknown, the `bap1` usage of `download()` didn't get updated (while its neighbors did), and `mich` didn't get updates for either the `download()` usage or its `_download_backwards()` override. This is all but certain to have been an accident.

It would not be surprising if this is the cause of an unrecognized bug breaking backscraping for both `bap1` and `mich`. This is unexplored, but an investigation into "why wasn't this recognized?" would be merited.


## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
