### PR TITLE
docs: align contributor and install docs with current tooling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Features:
 -
 
 Changes:
--
+- Correct contributor and install docs that were out of date with the repo: required Python is 3.10+, scraper templates live on `main`, the sample caller example now points at `ca1`, and the leftover nosetests debugger instructions are replaced with tox/pytest. #749
 
 Fixes:
 - Fix `bap1` backscraper: fixed a missing `await` that made it return zero results. #2136

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,8 @@ Reach out to us so we can find a scraper that you can work on and that nobody el
 
 Templates for scrapers:
 
-- [Opinion scraper template](https://github.com/freelawproject/juriscraper/blob/master/juriscraper/opinions/opinion_template.py)
-- [Oral argument scraper template](https://github.com/freelawproject/juriscraper/blob/master/juriscraper/oral_args/oral_argument_template.py)
+- [Opinion scraper template](https://github.com/freelawproject/juriscraper/blob/main/juriscraper/opinions/opinion_template.py)
+- [Oral argument scraper template](https://github.com/freelawproject/juriscraper/blob/main/juriscraper/oral_args/oral_argument_template.py)
 
 ### Contributing Workflow
 
@@ -81,7 +81,7 @@ Before we can accept your contribution, you must sign the Contributor License Ag
 
 ### Requirements
 
-- Python 3.9+
+- Python 3.10+
 - [`uv`](https://github.com/astral-sh/uv): modern Python package manager
 - Git
 - (Optional) Docker for running Selenium tests
@@ -140,7 +140,7 @@ Run tests for a single Python version, such as for Python 3.13:
 tox -e py313
 ```
 
-Add extra args to `pytest`, add them after a ``--`` separator,:
+Add extra args to `pytest` after a ``--`` separator:
 
 ```bash
 tox -e py313 -- --pdb
@@ -175,7 +175,7 @@ uv run sample_caller.py
 For example, to test `ca1`, run:
 
 ```bash
-uv run sample_caller.py -c juriscraper.opinions.united_states.state.kan_p
+uv run sample_caller.py -c juriscraper.opinions.united_states.federal_appellate.ca1
 ```
 
 ---
@@ -287,18 +287,18 @@ Individual tests can be run with:
 tox -e py -- tests/local/test_DateTest.py::DateTest::test_date_range_creation
 ```
 
-To run and drop to the Python debugger if it fails, but you must install `nost` to have `nosetests`:
+To drop into the Python debugger if a test fails, pass `--pdb` through tox to pytest:
 
 ```bash
-uv run nosetests -v --pdb tests/local/test_DateTest.py:DateTest.test_date_range_creation
+tox -e py313 -- --pdb tests/local/test_DateTest.py::DateTest::test_date_range_creation
 ```
 
 ---
 
 ## Future Goals
 -  Support for additional PACER pages and utilities
--  Support opinions from for all courts of U.S. territories (Guam, American Samoa, etc.)
--  Support opinions from for all federal district courts with non-PACER opinion listings
+-  Support opinions from all courts of U.S. territories (Guam, American Samoa, etc.)
+-  Support opinions from all federal district courts with non-PACER opinion listings
 -  For every court above where a backscraper is possible, it is implemented.
 -  Support video, additional oral argument audio, and transcripts everywhere available
 

--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ Some of the design goals for this project are:
 Installation & Dependencies
 ===========================
 
-First step: Install Python 3.9+, then:
+First step: Install Python 3.10+, then:
 
 Install the dependencies
 ------------------------


### PR DESCRIPTION
## Fixes
Fixes: #749

## Summary
The install and contributor docs were out of date with the repo.

- Python 3.9+ is no longer accurate (`requires-python = ">=3.10"`).
- Scraper template links pointed at the retired `master` branch.
- The sample caller example said `ca1` but invoked `kan_p`.
- The debugger instructions still told people to install `nost`/`nosetests`; tests run through tox/pytest.
- Two Future Goals bullets had a stray "from for".

This is docs-only. It does not add a per-court test filter (raised in #749 comments); that would be a separate change.

## AI Disclosure
- [x] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.