### PR TITLE
feat(state): improve typing of `Deserializable`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Features:
 -
 
 Changes:
--
+- Improve type of `Deserializable.deserialize()` to conserve the subject type.
 
 Fixes:
 - Fix `bap1` backscraper: fixed a missing `await` that made it return zero results. #2136

--- a/juriscraper/state/docket.py
+++ b/juriscraper/state/docket.py
@@ -10,13 +10,17 @@ from typing import Generic, TypeVar
 
 from pydantic import BaseModel
 
+_DeserializableT = TypeVar("_DeserializableT", bound="Deserializable")
+
 
 class Deserializable(BaseModel):
     """Indicates a Pydantic model which can be deserialized from the output of
     a `model_dump` method."""
 
     @classmethod
-    def deserialize(cls, text: str) -> "Deserializable":
+    def deserialize(
+        cls: type[_DeserializableT], text: str
+    ) -> _DeserializableT:
         """Deserialize a JSON string into an instance of this model."""
         return cls.model_validate_json(
             text,


### PR DESCRIPTION
## Summary

Usage of `Deserializable` in CourtListener leads to the following issues are found by the type checker:

```
ERROR cl/corpus_importer/tasks.py:5095:39-60: Argument `type[FloridaCase]` is not assignable to parameter `cls` with type `Deserializable` in function `juriscraper.state.docket.Deserializable.deserialize` [bad-argument-type]
ERROR cl/corpus_importer/tasks.py:5105:9-27: Object of class `Deserializable` has no attribute `docket_number` [missing-attribute]
ERROR cl/corpus_importer/tasks.py:5109:20-32: Object of class `Deserializable` has no attribute `entries` [missing-attribute]
ERROR cl/corpus_importer/tasks.py:5110:54-66: Object of class `Deserializable` has no attribute `entries` [missing-attribute]
ERROR cl/corpus_importer/tasks.py:5114:13-31: Object of class `Deserializable` has no attribute `docket_number` [missing-attribute]
ERROR cl/corpus_importer/tasks.py:5118:41-45: Argument `Deserializable` is not assignable to parameter `scrape` with type `FloridaCase` in function `cl.corpus_importer.state.merger.Merger.__init__` [bad-argument-type]
ERROR cl/corpus_importer/tasks.py:5123:13-31: Object of class `Deserializable` has no attribute `docket_number` [missing-attribute]
```

These can be addressed with a little more usage of the type system. By using a `TypeVar`, we can communicate the `deserialize()` will return an instance of the subject class.

## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
