### PR TITLE
fix(lib): fix handling of meta refresh HTML

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,6 +24,7 @@ Fixes:
 - Fix `bap1` backscraper: fixed a missing `await` that made it return zero results. #2136
 - Fix `mich` backscraper: fixed a missing `await` that made it return zero results. #2136
 - Fix `michctapp` backscraper: fixed a missing `await` that would lead to cases getting the title "Placeholder name".
+- Fix handling of meta redirects with url-relative destinations
 
 ## 3.0.40 - 2026-08-19
 

--- a/juriscraper/lib/microservices_utils.py
+++ b/juriscraper/lib/microservices_utils.py
@@ -52,7 +52,7 @@ async def test_for_meta_redirections(
             url = text[4:]
             if not url.startswith("http"):
                 # Relative URL, adapt
-                url = urljoin(r.url, url)
+                url = urljoin(str(r.url), url)
             return True, url
     except IndexError:
         return False, None


### PR DESCRIPTION

## Fixes
The handling of relative meta redirect destinations _always_ raises an exception. This patch address the problem, while leaving larger issues related to the approach untouched.

## Summary
An analysis of the project for type errors surfaced the following error:
```
ERROR juriscraper/lib/microservices_utils.py:55:30-42: `URL` is not assignable to any of constraints `str`, `bytes` of type variable `AnyStr` [bad-specialization]
```

There are no tests, but a manual test verified that a `URL` is sent as an argument to a parameter that needs to be a `str | bytes`. While the intent is clear, it is unlikely the the code ever worked as intended: meta redirects that use relative destinations will not be followed and will raise the following error and interrupt scraping:

```
raise TypeError("Cannot mix str and non-str arguments")
```

While `follow_redirections()` and associated code has lots of room for improvement, a simple `URL -> str` conversion will fix things.


## AI Disclosure
<!-- Please check the one box that applies. -->
- [x] No AI tools were used to create the content of this PR.
- [ ] Parts of this PR were created with the help of an AI tool, and I have carefully reviewed all of its content and take full responsibility for it.

<!-- Thank you for contributing and filling out this form! -->
